### PR TITLE
fix: native build and test (gvm23)

### DIFF
--- a/build/Manual.java
+++ b/build/Manual.java
@@ -15,6 +15,11 @@ import java.util.Map;
 public class Manual {
 
     public static void main(String[] args) throws IOException {
+        var javaHomeEnv = System.getenv("JAVA_HOME");
+        if (javaHomeEnv == null) {
+            throw new IllegalStateException("JAVA_HOME environment variable is not set; please set it to compile Java");
+        }
+        System.setProperty("java.home", javaHomeEnv);
         MavenRepository mavenRepository = new MavenDefaultRepository();
         Map<String, Repository> repositories = Map.of("maven", mavenRepository);
         Map<String, Resolver> resolvers = Map.of("maven", new MavenPomResolver());

--- a/config/reachability-metadata.json
+++ b/config/reachability-metadata.json
@@ -1,0 +1,19 @@
+{
+  "includes": [
+    { "pattern": ".*" }
+  ],
+  "bundles": [
+    {
+      "name": "com.sun.tools.javac.resources.compiler",
+      "locales": ["en"]
+    },
+    {
+      "name": "sun.tools.jar.resources.jar",
+      "locales": ["en"]
+    },
+    {
+      "name": "com.sun.tools.javac.resources.javac",
+      "locales": ["en"]
+    }
+  ]
+}

--- a/sources/build/buildbuddy/BuildExecutor.java
+++ b/sources/build/buildbuddy/BuildExecutor.java
@@ -358,7 +358,7 @@ public class BuildExecutor {
     }
 
     public SequencedMap<String, Path> execute() {
-        try (ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor()) {
+        try (ExecutorService executorService = Executors.newCachedThreadPool()) {
             return execute(executorService).toCompletableFuture().join();
         }
     }

--- a/sources/build/buildbuddy/step/Java.java
+++ b/sources/build/buildbuddy/step/Java.java
@@ -1,8 +1,5 @@
 package build.buildbuddy.step;
 
-import build.buildbuddy.BuildStepArgument;
-import build.buildbuddy.BuildStepContext;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -20,6 +17,9 @@ import java.util.function.Function;
 import java.util.jar.JarFile;
 import java.util.stream.Stream;
 import java.util.zip.ZipFile;
+
+import build.buildbuddy.BuildStepArgument;
+import build.buildbuddy.BuildStepContext;
 
 public abstract class Java extends ProcessBuildStep {
 
@@ -122,6 +122,7 @@ public abstract class Java extends ProcessBuildStep {
             }
         }
         List<String> prefixes = new ArrayList<>();
+        prefixes.add("--enable-preview");
         if (!classPath.isEmpty()) {
             prefixes.add("-classpath");
             prefixes.add(String.join(File.pathSeparator, classPath));

--- a/sources/build/buildbuddy/step/Javac.java
+++ b/sources/build/buildbuddy/step/Javac.java
@@ -1,8 +1,5 @@
 package build.buildbuddy.step;
 
-import build.buildbuddy.BuildStepArgument;
-import build.buildbuddy.BuildStepContext;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -17,6 +14,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
+
+import build.buildbuddy.BuildStepArgument;
+import build.buildbuddy.BuildStepContext;
 
 public class Javac extends ProcessBuildStep {
 
@@ -39,6 +39,7 @@ public class Javac extends ProcessBuildStep {
             throws IOException {
         Path target = Files.createDirectory(context.next().resolve(CLASSES));
         List<String> files = new ArrayList<>(), path = new ArrayList<>(), commands = new ArrayList<>(List.of(
+                "--enable-preview",
                 "--release", Integer.toString(Runtime.version().version().getFirst()),
                 "-d", target.toString()));
         for (BuildStepArgument argument : arguments.values()) {

--- a/sources/build/buildbuddy/step/Tests.java
+++ b/sources/build/buildbuddy/step/Tests.java
@@ -1,8 +1,5 @@
 package build.buildbuddy.step;
 
-import build.buildbuddy.BuildStepArgument;
-import build.buildbuddy.BuildStepContext;
-
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -19,6 +16,9 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+
+import build.buildbuddy.BuildStepArgument;
+import build.buildbuddy.BuildStepContext;
 
 public class Tests extends Java {
 
@@ -63,6 +63,7 @@ public class Tests extends Java {
                 .of(() -> arguments.values().stream().map(BuildStepArgument::folder).iterator())
                 .orElseThrow(() -> new IllegalArgumentException("No test engine found")) : this.engine;
         List<String> commands = new ArrayList<>();
+        commands.add("--enable-preview");
         if (modular && engine.module != null) {
             commands.add("--add-modules");
             commands.add("ALL-MODULE-PATH");


### PR DESCRIPTION
One of two mutually exclusive PRs: fixes an issue building under `native-image` and using `javac`. This version applies changes to work under GraalVM 23.

GVM 24 equivalent: #2

fix: set `java.home` property to value in `JAVA_HOME` env if available
fix: fail if no `JAVA_HOME` env var is set (needed to jartool/compiler)
fix: add `--enable-preview` flags to `java` and `javac` calls as needed
fix: switch to cached threadpool because of a bug with system properties
fix: add metadata for resources used by java compiler/jar tool

This PR targets stable GraalVM, which is JDK 23. Because of a bug in the current GVM 23 release, execution is switched to using a cached thread- pool.

GraalVM issue: https://github.com/oracle/graal/issues/9939
Fixes and closes: https://github.com/oracle/graal/issues/10679

Tested against GraalVM 23 with:
```
javac build/Manual.java;
native-image build.Manual \
    -H:ResourceConfigurationFiles=./config/reachability-metadata.json;
./build.manual;
```