### PR TITLE
Dependency tree reporting via a resolver edge-listener (jenesis.project.tree)

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,19 +435,23 @@ file makes watch a project's default.
 
 ### Printing the dependency tree
 
-Set `-Djenesis.project.tree=true` to print the resolved dependency tree after the build, the way
-`mvn dependency:tree` / `gradle dependencies` do:
+Set `-Djenesis.project.tree=true` to print each module's dependency tree as it is resolved, verbose-style,
+the way `mvn dependency:tree` / `gradle dependencies` do:
 
     java -Djenesis.project.tree=true build/jenesis/Project.java
 
 Unlike a separate "resolve" goal, this captures the **actual** resolution the build performs. It works by
-passing an optional `ResolutionListener` into the resolver (`Resolver.dependencies(..., listener)`, a no-op
-default overload otherwise, so nothing changes when the flag is off): the resolver reports each discovered
-parent -> child edge - with the property-file key, the resolved version and scope, and a `followed` flag that
-is `false` on a dedup re-encounter. A `DependencyTreeReport` (wired in through `DependenciesModule`, which forces
-its `Resolve` step to re-run so the tree always prints) collects those edges and prints a **deduplicated** tree
-(each dependency once, under the first parent) with box-drawing. Each node shows its key (e.g.
-`maven/org.apache.commons/commons-lang3/3.14.0` or `module/org.slf4j/2.0.16`) and, for Maven, its scope. The
+passing an optional `ResolutionListener` into the resolver (`Resolver.dependencies(..., listener)`, which
+defaults to `null`, so nothing changes and nothing is allocated when the flag is off): the resolver reports
+each discovered parent -> child edge - with the property-file key, the discovered version and scope, and a
+`followed` flag that is `false` on a dedup re-encounter - and announces each negotiated version through
+`onResolution`. A `DependencyTreeReport` implements `ResolutionListener` directly; the flag wires a fresh one
+per resolve (through `DependenciesModule` -> `Resolve`, which forces a re-run so the tree always prints), and on
+the completion callback (`onResolved`) it renders and prints that resolve's tree to a `PrintStream` (defaulting
+to `System.out`) - the printing happens on the callback, not as a build step. Each node shows the version each
+parent requested, the negotiated version inline when it differs (`[1,2] -> 2`), the Maven scope, and any module
+metadata; not-followed duplicates are dimmed and marked `(*)`, and a per-declared-dependency colour gradient
+tints the tree connectors. A `Resolved dependencies` list of negotiated versions follows each tree. The
 resolution tree itself is never persisted or hashed - only the flat closure remains the build's product - and the
 report never reads or downloads anything the build did not already fetch. For `MODULAR_TO_MAVEN`, each module's
 resolved Maven coordinate is what the tree shows (e.g. the `org.slf4j` module resolves to
@@ -1388,7 +1392,7 @@ The following system properties and environment variables tune the build at laun
 | `jenesis.project.target`        | system property | Overrides the per-build output folder passed to `BuildExecutor.of(...)` (default `target`). Safe to delete to force a clean build. |
 | `jenesis.project.cache`         | system property | Overrides the cross-build cache folder (default `.jenesis/cache`) under which the `MODULAR` layout stores `<encoded-coordinate>.jar` for each downloaded module jar (see *The `.jenesis/cache/` folder*). Effectively ignored by `MAVEN` and `MODULAR_TO_MAVEN` since they cache through `~/.m2/repository` instead. |
 | `jenesis.project.watch`         | system property | When `true`, `Project.doMain(...)` does not return after one build: it registers a `java.nio` `WatchService` over the project root (via `ProjectWatch`) and re-runs the requested target on every file change, excluding the output folders (`target/`, the configured cache) and dot-directories so the build's own writes do not re-trigger. Each rebuild reuses the incremental cache, so only changed steps re-execute; module selectors are honored. See *Watching for changes*. Default `false` (single build). |
-| `jenesis.project.tree`          | system property | When `true`, `Project.doMain(...)` runs the build with a `ResolutionListener` threaded into every resolver (through `DependenciesModule` -> `Resolve`, which forces a re-run so it always fires), then prints the **deduplicated** dependency tree it observed via `DependencyTreeReport`. The listener argument has a no-op default overload, so a normal build is byte-identical and unaffected; the tree is never persisted or hashed and the report reads/downloads nothing extra. Each node shows the property-file key, resolved version, and (Maven) scope; `MODULAR_TO_MAVEN` shows each module's resolved Maven coordinate. See *Printing the dependency tree*. Default `false`. |
+| `jenesis.project.tree`          | system property | When `true`, `Project.doMain(...)` runs the build with a fresh `DependencyTreeReport` (which implements `ResolutionListener`) per resolve, threaded in through `DependenciesModule` -> `Resolve` (forced to re-run so it always fires). Each report prints its tree to `System.out` on its `onResolved` callback as the module is resolved - printing happens on the callback, not as a build step. The listener argument defaults to `null`, so a normal build is byte-identical and allocates nothing extra; the tree is never persisted or hashed and the report reads/downloads nothing extra. Each node shows the property-file key, the requested version (with the negotiated version inline when it differs), and (Maven) scope; `MODULAR_TO_MAVEN` shows each module's resolved Maven coordinate. See *Printing the dependency tree*. Default `false`. |
 | `jenesis.project.sources`       | system property | When `true` (bare flag accepted), resolves the project-level `source` flag to `true`, so `JavaMultiProjectAssembler` also assembles a per-module sources jar. |
 | `jenesis.project.documentation` | system property | When `true` (bare flag accepted), resolves the project-level `documentation` flag to `true`, so `JavaMultiProjectAssembler` also assembles a per-module javadoc jar. |
 | `jenesis.project.metadata`      | system property | Path to a project-level metadata override file (conventionally `project.properties`) whose entries are merged into every module's `metadata.properties` between the framework defaults and `jenesis.project.version`. |

--- a/README.md
+++ b/README.md
@@ -1607,7 +1607,8 @@ build.
 
 `Resolver` is a `Serializable @FunctionalInterface` whose method takes the root coordinates, the
 `Map<String, Repository>` to fetch from, a `versions` pin map (with optional space-separated `<algorithm>/<hex>`
-checksum suffix), and a `compile`/`runtime` flag, and returns the resolved closure as a
+checksum suffix), a `DependencyScope` (`COMPILE` or `RUNTIME`), and an optional `ResolutionListener`, and
+returns the resolved closure as a
 `SequencedMap<String, String>`. The value carries the chosen version and/or checksum that the downstream
 `Download` step validates against. The default method `resolver.translated(targetPrefix, translator)`
 rewrites both coordinates and the prefix before delegating, which is useful when a generic translation

--- a/README.md
+++ b/README.md
@@ -433,6 +433,27 @@ selectors still apply, so `-Djenesis.project.watch=true build/jenesis/Project.ja
 just that module's subgraph. Press Ctrl+C to stop. Setting `jenesis.project.watch=true` in a `jenesis.properties`
 file makes watch a project's default.
 
+### Printing the dependency tree
+
+Set `-Djenesis.project.tree=true` to print the resolved dependency tree after the build, the way
+`mvn dependency:tree` / `gradle dependencies` do:
+
+    java -Djenesis.project.tree=true build/jenesis/Project.java
+
+Unlike a separate "resolve" goal, this captures the **actual** resolution the build performs. It works by
+passing an optional `ResolutionListener` into the resolver (`Resolver.dependencies(..., listener)`, a no-op
+default overload otherwise, so nothing changes when the flag is off): the resolver reports each discovered
+parent -> child edge - with the property-file key, the resolved version and scope, and a `followed` flag that
+is `false` on a dedup re-encounter. A `DependencyTreeReport` (wired in through `DependenciesModule`, which forces
+its `Resolve` step to re-run so the tree always prints) collects those edges and prints a **deduplicated** tree
+(each dependency once, under the first parent) with box-drawing. Each node shows its key (e.g.
+`maven/org.apache.commons/commons-lang3/3.14.0` or `module/org.slf4j/2.0.16`) and, for Maven, its scope. The
+resolution tree itself is never persisted or hashed - only the flat closure remains the build's product - and the
+report never reads or downloads anything the build did not already fetch. For `MODULAR_TO_MAVEN`, each module's
+resolved Maven coordinate is what the tree shows (e.g. the `org.slf4j` module resolves to
+`maven/org.slf4j/slf4j-api/2.0.16`). The listener is reusable, so the same hook can later report trees for other
+resolution (e.g. plugins).
+
 ### Running inside Docker
 
 Set `-Djenesis.project.docker=true` to run the entire build inside a throwaway container instead of directly on
@@ -1367,6 +1388,7 @@ The following system properties and environment variables tune the build at laun
 | `jenesis.project.target`        | system property | Overrides the per-build output folder passed to `BuildExecutor.of(...)` (default `target`). Safe to delete to force a clean build. |
 | `jenesis.project.cache`         | system property | Overrides the cross-build cache folder (default `.jenesis/cache`) under which the `MODULAR` layout stores `<encoded-coordinate>.jar` for each downloaded module jar (see *The `.jenesis/cache/` folder*). Effectively ignored by `MAVEN` and `MODULAR_TO_MAVEN` since they cache through `~/.m2/repository` instead. |
 | `jenesis.project.watch`         | system property | When `true`, `Project.doMain(...)` does not return after one build: it registers a `java.nio` `WatchService` over the project root (via `ProjectWatch`) and re-runs the requested target on every file change, excluding the output folders (`target/`, the configured cache) and dot-directories so the build's own writes do not re-trigger. Each rebuild reuses the incremental cache, so only changed steps re-execute; module selectors are honored. See *Watching for changes*. Default `false` (single build). |
+| `jenesis.project.tree`          | system property | When `true`, `Project.doMain(...)` runs the build with a `ResolutionListener` threaded into every resolver (through `DependenciesModule` -> `Resolve`, which forces a re-run so it always fires), then prints the **deduplicated** dependency tree it observed via `DependencyTreeReport`. The listener argument has a no-op default overload, so a normal build is byte-identical and unaffected; the tree is never persisted or hashed and the report reads/downloads nothing extra. Each node shows the property-file key, resolved version, and (Maven) scope; `MODULAR_TO_MAVEN` shows each module's resolved Maven coordinate. See *Printing the dependency tree*. Default `false`. |
 | `jenesis.project.sources`       | system property | When `true` (bare flag accepted), resolves the project-level `source` flag to `true`, so `JavaMultiProjectAssembler` also assembles a per-module sources jar. |
 | `jenesis.project.documentation` | system property | When `true` (bare flag accepted), resolves the project-level `documentation` flag to `true`, so `JavaMultiProjectAssembler` also assembles a per-module javadoc jar. |
 | `jenesis.project.metadata`      | system property | Path to a project-level metadata override file (conventionally `project.properties`) whose entries are merged into every module's `metadata.properties` between the framework defaults and `jenesis.project.version`. |

--- a/demo/demo-01-java-pom/README.md
+++ b/demo/demo-01-java-pom/README.md
@@ -6,6 +6,21 @@ one real Maven dependency. It shows Jenesis driving plain `javac` through the
 default `JavaMultiProjectAssembler`, resolving and downloading the declared
 dependency, and pinning it. Its modular counterpart is `../demo-02-java-modular`.
 
+Printing the dependency tree
+----------------------------
+
+`-Djenesis.project.tree=true` prints the resolved dependency tree as the module
+resolves (a verbose toggle, not a build step):
+
+    java -Djenesis.project.tree=true build/jenesis/Project.java
+
+    Dependency tree:
+    maven/org.apache.commons/commons-lang3 3.14.0 [compile]
+
+Each node shows the property-file key, the requested version (with the negotiated
+version inline when it differs), and the Maven scope; transitive dependencies nest
+underneath and duplicates are dimmed and marked `(*)`.
+
 Layout
 ------
 

--- a/demo/demo-02-java-modular/README.md
+++ b/demo/demo-02-java-modular/README.md
@@ -8,6 +8,22 @@ Jenesis module repository, and emits a modular jar alongside a generated POM. It
 POM-based counterpart is `../demo-01-java-pom`, and its multi-module counterpart is
 `../demo-04-java-modular-multi`.
 
+Printing the dependency tree
+----------------------------
+
+`-Djenesis.project.tree=true` prints the resolved dependency tree as the module
+resolves (a verbose toggle, not a build step):
+
+    java -Djenesis.project.tree=true build/jenesis/Project.java
+
+    Dependency tree:
+    maven/org.slf4j/slf4j-api 2.0.16 [compile]
+
+Because this is the default MODULAR_TO_MAVEN layout, `requires org.slf4j` is shown
+as the Maven coordinate it resolves to, with a Maven scope. Under the pure MODULAR
+layout the same dependency shows as a Java module name (`module/org.slf4j`) instead
+- see `../demo-12-module-layout`, which contrasts the two.
+
 Layout
 ------
 

--- a/demo/demo-03-java-pom-multi/README.md
+++ b/demo/demo-03-java-pom-multi/README.md
@@ -7,6 +7,28 @@ dependency, so the demo shows intra-project and external resolution side by
 side. The `greeter` module also carries a JUnit test, so the demo doubles as a
 MAVEN-layout testing example. Its single-module counterpart is `../demo-01-java-pom`.
 
+Printing the dependency tree
+----------------------------
+
+`-Djenesis.project.tree=true` prints each module's resolved tree as it resolves
+(a verbose toggle, not a build step); a multi-module build prints one block per
+module and scope:
+
+    java -Djenesis.project.tree=true build/jenesis/Project.java
+
+    Dependency tree:
+    maven/org.junit.jupiter/junit-jupiter 5.11.3 [compile]
+    ├─ maven/org.junit.jupiter/junit-jupiter-api 5.11.3 [compile]
+    │  ├─ maven/org.opentest4j/opentest4j 1.3.0 [compile]
+    │  ├─ maven/org.junit.platform/junit-platform-commons 1.11.3 [compile]
+    │  │  └─ maven/org.apiguardian/apiguardian-api 1.1.2 [compile] (*)
+    │  └─ maven/org.apiguardian/apiguardian-api 1.1.2 [compile]
+    └─ maven/org.junit.jupiter/junit-jupiter-engine 5.11.3 [runtime]
+
+Each node shows the property-file key, version, and Maven scope; a dependency
+reached more than once is expanded under its first parent and dimmed with `(*)`
+everywhere else.
+
 Layout
 ------
 

--- a/demo/demo-04-java-modular-multi/README.md
+++ b/demo/demo-04-java-modular-multi/README.md
@@ -9,6 +9,26 @@ library, so the demo doubles as a MODULAR_TO_MAVEN testing example. Its
 single-module counterpart is `../demo-02-java-modular`, and its POM-based sibling is
 `../demo-03-java-pom-multi`.
 
+Printing the dependency tree
+----------------------------
+
+`-Djenesis.project.tree=true` prints each module's resolved tree as it resolves
+(a verbose toggle, not a build step), one block per module and scope:
+
+    java -Djenesis.project.tree=true build/jenesis/Project.java
+
+    Dependency tree:
+    maven/org.junit.jupiter/junit-jupiter 5.11.3 [compile]
+    ├─ maven/org.junit.jupiter/junit-jupiter-api 5.11.3 [compile]
+    │  └─ maven/org.junit.platform/junit-platform-commons 1.11.3 [compile]
+    └─ maven/org.junit.jupiter/junit-jupiter-engine 5.11.3 [runtime]
+
+Even though every descriptor here is a `module-info.java`, the default
+MODULAR_TO_MAVEN layout resolves each `requires` through Maven, so the tree shows
+Maven coordinates and their transitive Maven closure - the same shape as the
+POM-based `../demo-03-java-pom-multi`. The pure MODULAR layout
+(`../demo-12-module-layout`) shows the same dependencies as Java module names.
+
 Layout
 ------
 

--- a/demo/demo-12-module-layout/README.md
+++ b/demo/demo-12-module-layout/README.md
@@ -57,6 +57,32 @@ differ in how dependencies are resolved and what else is emitted:
   selects MODULAR for you. So picking this layout narrows what you can depend on to
   the subset of the ecosystem published as proper Java modules.
 
+Seeing the difference in the tree
+---------------------------------
+
+`-Djenesis.project.tree=true` prints each module's resolved dependency tree as it
+resolves (a verbose toggle, not a build step), and it makes the layout distinction
+concrete. The same `requires org.slf4j` shows up differently under each layout.
+
+Under **MODULAR** (this demo) the node is a Java module name resolved from the
+module repository - no Maven coordinate, no Maven scope:
+
+    java -Djenesis.project.tree=true build/Demo.java
+
+    Dependency tree:
+    module/org.slf4j 2.0.16
+
+Under **MODULAR_TO_MAVEN** (the same project in `../demo-02-java-modular`) the
+module is translated to its Maven coordinate and resolved through Maven, so the
+node is a Maven artifact carrying a Maven scope:
+
+    Dependency tree:
+    maven/org.slf4j/slf4j-api 2.0.16 [compile]
+
+In a project with transitive dependencies the Maven side expands the full
+nearest-wins closure (resolved versions, scopes, and duplicates dimmed and marked
+`(*)`), while the modular side stays a graph of named modules.
+
 Run it
 ------
 

--- a/sources/build/jenesis/DependencyScope.java
+++ b/sources/build/jenesis/DependencyScope.java
@@ -1,4 +1,4 @@
-package build.jenesis.project;
+package build.jenesis;
 
 import module java.base;
 

--- a/sources/build/jenesis/DependencyTreeReport.java
+++ b/sources/build/jenesis/DependencyTreeReport.java
@@ -2,81 +2,74 @@ package build.jenesis;
 
 import module java.base;
 
-public final class DependencyTreeReport {
+public final class DependencyTreeReport implements ResolutionListener {
 
     private static final int[] GRADIENT = {
             39, 44, 48, 83, 113, 148, 184, 214, 208, 203, 168, 134};
 
-    private final List<Tree> trees = Collections.synchronizedList(new ArrayList<>());
-    private final Set<Resolution> resolutions = Collections.synchronizedSet(new LinkedHashSet<>());
+    private final PrintStream out;
+    private final List<Edge> edges = new ArrayList<>();
+    private final Map<String, String> resolved = new HashMap<>();
 
-    public Supplier<ResolutionListener> supplier() {
-        return Collector::new;
+    public DependencyTreeReport() {
+        this(System.out);
     }
 
-    public void print(PrintStream out) {
-        List<Tree> snapshot;
-        synchronized (trees) {
-            snapshot = new ArrayList<>(trees);
+    public DependencyTreeReport(PrintStream out) {
+        this.out = out;
+    }
+
+    @Override
+    public void onDependency(String prefix,
+                             String parent,
+                             String coordinate,
+                             String version,
+                             String scope,
+                             boolean followed,
+                             Supplier<ResolutionContext> context) {
+        edges.add(new Edge(parent, coordinate, version, scope, followed, context));
+    }
+
+    @Override
+    public void onResolution(String prefix,
+                             String coordinate,
+                             String version) {
+        resolved.put(coordinate, version);
+    }
+
+    @Override
+    public void onResolved() {
+        if (edges.isEmpty()) {
+            return;
         }
-        List<Set<String>> signatures = new ArrayList<>();
-        for (Tree tree : snapshot) {
-            Set<String> signature = new HashSet<>();
-            for (Edge edge : tree.edges()) {
-                if (edge.followed()) {
-                    signature.add(edge.parent() + " -> " + edge.coordinate());
-                }
+        StringBuilder builder = new StringBuilder();
+        builder.append(System.lineSeparator())
+                .append(BuildExecutorCallback.YELLOW).append("Dependency tree:").append(BuildExecutorCallback.RESET)
+                .append(System.lineSeparator())
+                .append(render());
+        List<Resolution> resolutions = new ArrayList<>();
+        resolved.forEach((coordinate, version) -> resolutions.add(new Resolution(coordinate, version)));
+        resolutions.sort(Comparator.comparing(Resolution::coordinate).thenComparing(Resolution::version));
+        if (!resolutions.isEmpty()) {
+            builder.append(System.lineSeparator())
+                    .append(BuildExecutorCallback.YELLOW).append("Resolved dependencies:").append(BuildExecutorCallback.RESET)
+                    .append(System.lineSeparator());
+            for (Resolution resolution : resolutions) {
+                builder.append("  ")
+                        .append(resolution.coordinate())
+                        .append(paint(245, " -> " + resolution.version()))
+                        .append(System.lineSeparator());
             }
-            signatures.add(signature);
         }
-        List<Tree> surviving = new ArrayList<>();
-        for (int index = 0; index < snapshot.size(); index++) {
-            Set<String> signature = signatures.get(index);
-            if (!signature.isEmpty() && !subsumed(signature, index, signatures)) {
-                surviving.add(snapshot.get(index));
-            }
-        }
-        if (!surviving.isEmpty()) {
-            out.println();
-            out.println(BuildExecutorCallback.YELLOW + "Dependency tree:" + BuildExecutorCallback.RESET);
-            int[] color = {0};
-            for (Tree tree : surviving) {
-                out.println();
-                out.print(render(tree, color));
-            }
-        }
-        List<Resolution> resolved;
-        synchronized (resolutions) {
-            resolved = new ArrayList<>(resolutions);
-        }
-        resolved.sort(Comparator.comparing(Resolution::coordinate).thenComparing(Resolution::version));
-        if (!resolved.isEmpty()) {
-            out.println();
-            out.println(BuildExecutorCallback.YELLOW + "Resolved dependencies:" + BuildExecutorCallback.RESET);
-            for (Resolution resolution : resolved) {
-                out.println("  " + resolution.coordinate() + paint(245, " -> " + resolution.version()));
-            }
+        synchronized (out) {
+            out.print(builder);
         }
     }
 
-    private static boolean subsumed(Set<String> signature, int index, List<Set<String>> signatures) {
-        for (int other = 0; other < signatures.size(); other++) {
-            if (other == index) {
-                continue;
-            }
-            Set<String> candidate = signatures.get(other);
-            if (candidate.containsAll(signature)
-                    && (candidate.size() > signature.size() || other < index)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static String render(Tree tree, int[] colorIndex) {
+    private String render() {
         SequencedMap<String, List<Edge>> children = new LinkedHashMap<>();
         List<Edge> roots = new ArrayList<>();
-        for (Edge edge : tree.edges()) {
+        for (Edge edge : edges) {
             if (edge.parent() == null) {
                 if (edge.followed()) {
                     roots.add(edge);
@@ -85,37 +78,37 @@ public final class DependencyTreeReport {
                 children.computeIfAbsent(edge.parent(), _ -> new ArrayList<>()).add(edge);
             }
         }
-        StringBuilder out = new StringBuilder();
+        StringBuilder builder = new StringBuilder();
         Set<String> seen = new HashSet<>();
+        int[] colorIndex = {0};
         for (Edge root : roots) {
             int treeColor = GRADIENT[colorIndex[0]++ % GRADIENT.length];
-            out.append(label(root, tree.resolved(), treeColor, true)).append(System.lineSeparator());
-            children(out, root.coordinate(), children, "", seen, tree.resolved(), treeColor);
+            builder.append(label(root, treeColor, true)).append(System.lineSeparator());
+            children(builder, root.coordinate(), children, "", seen, treeColor);
         }
-        return out.toString();
+        return builder.toString();
     }
 
-    private static void children(StringBuilder out,
-                                 String coordinate,
-                                 SequencedMap<String, List<Edge>> children,
-                                 String indent,
-                                 Set<String> seen,
-                                 Map<String, String> resolved,
-                                 int treeColor) {
+    private void children(StringBuilder builder,
+                          String coordinate,
+                          SequencedMap<String, List<Edge>> children,
+                          String indent,
+                          Set<String> seen,
+                          int treeColor) {
         List<Edge> next = children.getOrDefault(coordinate, List.of());
         for (int index = 0; index < next.size(); index++) {
             boolean last = index == next.size() - 1;
             Edge edge = next.get(index);
-            out.append(paint(treeColor, indent + (last ? "└─ " : "├─ ")))
-                    .append(label(edge, resolved, treeColor, false))
+            builder.append(paint(treeColor, indent + (last ? "└─ " : "├─ ")))
+                    .append(label(edge, treeColor, false))
                     .append(System.lineSeparator());
             if (edge.followed() && seen.add(edge.coordinate())) {
-                children(out, edge.coordinate(), children, indent + (last ? "   " : "│  "), seen, resolved, treeColor);
+                children(builder, edge.coordinate(), children, indent + (last ? "   " : "│  "), seen, treeColor);
             }
         }
     }
 
-    private static String label(Edge edge, Map<String, String> resolved, int treeColor, boolean root) {
+    private String label(Edge edge, int treeColor, boolean root) {
         String coordinate = edge.coordinate(), version = edge.version(), key = coordinate, discovered = null;
         if (version != null && !version.isEmpty() && coordinate.endsWith("/" + version)) {
             key = coordinate.substring(0, coordinate.length() - version.length() - 1);
@@ -168,41 +161,6 @@ public final class DependencyTreeReport {
 
     private static String paint(int code, String text) {
         return "\033[38;5;" + code + "m" + text + BuildExecutorCallback.RESET;
-    }
-
-    private final class Collector implements ResolutionListener {
-
-        private final List<Edge> edges = new ArrayList<>();
-        private final Map<String, String> resolved = new HashMap<>();
-
-        @Override
-        public void onDependency(String prefix,
-                                 String parent,
-                                 String coordinate,
-                                 String version,
-                                 String scope,
-                                 boolean followed,
-                                 Supplier<ResolutionContext> context) {
-            edges.add(new Edge(parent, coordinate, version, scope, followed, context));
-        }
-
-        @Override
-        public void onResolution(String prefix,
-                                 String coordinate,
-                                 String version) {
-            resolved.put(coordinate, version);
-            resolutions.add(new Resolution(coordinate, version));
-        }
-
-        @Override
-        public void onResolved() {
-            if (!edges.isEmpty()) {
-                trees.add(new Tree(List.copyOf(edges), Map.copyOf(resolved)));
-            }
-        }
-    }
-
-    private record Tree(List<Edge> edges, Map<String, String> resolved) {
     }
 
     private record Edge(String parent,

--- a/sources/build/jenesis/DependencyTreeReport.java
+++ b/sources/build/jenesis/DependencyTreeReport.java
@@ -4,47 +4,58 @@ import module java.base;
 
 public final class DependencyTreeReport {
 
-    private final List<List<Edge>> trees = Collections.synchronizedList(new ArrayList<>());
+    private static final int[] GRADIENT = {
+            39, 44, 48, 83, 113, 148, 184, 214, 208, 203, 168, 134};
+
+    private final List<Tree> trees = Collections.synchronizedList(new ArrayList<>());
+    private final Set<Resolution> resolutions = Collections.synchronizedSet(new LinkedHashSet<>());
 
     public Supplier<ResolutionListener> supplier() {
         return Collector::new;
     }
 
     public void print(PrintStream out) {
-        List<List<Edge>> snapshot;
+        List<Tree> snapshot;
         synchronized (trees) {
             snapshot = new ArrayList<>(trees);
         }
         List<Set<String>> signatures = new ArrayList<>();
-        for (List<Edge> tree : snapshot) {
+        for (Tree tree : snapshot) {
             Set<String> signature = new HashSet<>();
-            for (Edge edge : tree) {
+            for (Edge edge : tree.edges()) {
                 if (edge.followed()) {
                     signature.add(edge.parent() + " -> " + edge.coordinate());
                 }
             }
             signatures.add(signature);
         }
-        Set<String> rendered = new LinkedHashSet<>();
-        List<String> blocks = new ArrayList<>();
+        List<Tree> surviving = new ArrayList<>();
         for (int index = 0; index < snapshot.size(); index++) {
             Set<String> signature = signatures.get(index);
-            if (signature.isEmpty() || subsumed(signature, index, signatures)) {
-                continue;
-            }
-            String block = render(snapshot.get(index));
-            if (!block.isEmpty() && rendered.add(block)) {
-                blocks.add(block);
+            if (!signature.isEmpty() && !subsumed(signature, index, signatures)) {
+                surviving.add(snapshot.get(index));
             }
         }
-        if (blocks.isEmpty()) {
-            return;
-        }
-        out.println();
-        out.println("Dependency tree:");
-        for (String block : blocks) {
+        if (!surviving.isEmpty()) {
             out.println();
-            out.print(block);
+            out.println(BuildExecutorCallback.YELLOW + "Dependency tree:" + BuildExecutorCallback.RESET);
+            int[] color = {0};
+            for (Tree tree : surviving) {
+                out.println();
+                out.print(render(tree, color));
+            }
+        }
+        List<Resolution> resolved;
+        synchronized (resolutions) {
+            resolved = new ArrayList<>(resolutions);
+        }
+        resolved.sort(Comparator.comparing(Resolution::coordinate).thenComparing(Resolution::version));
+        if (!resolved.isEmpty()) {
+            out.println();
+            out.println(BuildExecutorCallback.YELLOW + "Resolved dependencies:" + BuildExecutorCallback.RESET);
+            for (Resolution resolution : resolved) {
+                out.println("  " + resolution.coordinate() + paint(245, " -> " + resolution.version()));
+            }
         }
     }
 
@@ -62,15 +73,14 @@ public final class DependencyTreeReport {
         return false;
     }
 
-    private static String render(List<Edge> tree) {
+    private static String render(Tree tree, int[] colorIndex) {
         SequencedMap<String, List<Edge>> children = new LinkedHashMap<>();
         List<Edge> roots = new ArrayList<>();
-        for (Edge edge : tree) {
-            if (!edge.followed()) {
-                continue;
-            }
+        for (Edge edge : tree.edges()) {
             if (edge.parent() == null) {
-                roots.add(edge);
+                if (edge.followed()) {
+                    roots.add(edge);
+                }
             } else {
                 children.computeIfAbsent(edge.parent(), _ -> new ArrayList<>()).add(edge);
             }
@@ -78,8 +88,9 @@ public final class DependencyTreeReport {
         StringBuilder out = new StringBuilder();
         Set<String> seen = new HashSet<>();
         for (Edge root : roots) {
-            out.append(label(root)).append(System.lineSeparator());
-            children(out, root.coordinate(), children, "", seen);
+            int treeColor = GRADIENT[colorIndex[0]++ % GRADIENT.length];
+            out.append(label(root, tree.resolved(), treeColor, true)).append(System.lineSeparator());
+            children(out, root.coordinate(), children, "", seen, tree.resolved(), treeColor);
         }
         return out.toString();
     }
@@ -88,48 +99,81 @@ public final class DependencyTreeReport {
                                  String coordinate,
                                  SequencedMap<String, List<Edge>> children,
                                  String indent,
-                                 Set<String> seen) {
-        if (!seen.add(coordinate)) {
-            return;
-        }
+                                 Set<String> seen,
+                                 Map<String, String> resolved,
+                                 int treeColor) {
         List<Edge> next = children.getOrDefault(coordinate, List.of());
         for (int index = 0; index < next.size(); index++) {
             boolean last = index == next.size() - 1;
             Edge edge = next.get(index);
-            out.append(indent).append(last ? "└─ " : "├─ ").append(label(edge)).append(System.lineSeparator());
-            children(out, edge.coordinate(), children, indent + (last ? "   " : "│  "), seen);
+            out.append(paint(treeColor, indent + (last ? "└─ " : "├─ ")))
+                    .append(label(edge, resolved, treeColor, false))
+                    .append(System.lineSeparator());
+            if (edge.followed() && seen.add(edge.coordinate())) {
+                children(out, edge.coordinate(), children, indent + (last ? "   " : "│  "), seen, resolved, treeColor);
+            }
         }
     }
 
-    private static String label(Edge edge) {
-        StringBuilder line = new StringBuilder(edge.coordinate());
-        if (edge.scope() != null) {
-            line.append("  [").append(edge.scope()).append(']');
+    private static String label(Edge edge, Map<String, String> resolved, int treeColor, boolean root) {
+        String coordinate = edge.coordinate(), version = edge.version(), key = coordinate, discovered = null;
+        if (version != null && !version.isEmpty() && coordinate.endsWith("/" + version)) {
+            key = coordinate.substring(0, coordinate.length() - version.length() - 1);
+            discovered = version;
         }
-        ResolutionContext context = edge.context() == null ? null : edge.context().get();
+        StringBuilder line = new StringBuilder();
+        if (!edge.followed()) {
+            line.append(paint(240, key));
+        } else if (root) {
+            line.append("\033[1;38;5;").append(treeColor).append('m').append(key).append(BuildExecutorCallback.RESET);
+        } else {
+            line.append(key);
+        }
+        if (discovered != null) {
+            line.append(' ').append(paint(245, discovered));
+            String promoted = resolved.get(key);
+            if (edge.followed() && promoted != null && !promoted.equals(discovered)) {
+                line.append(paint(173, " -> " + promoted));
+            }
+        }
+        if (edge.scope() != null) {
+            line.append(' ').append(paint(67, "[" + edge.scope() + "]"));
+        }
+        ResolutionContext context = edge.followed() && edge.context() != null ? edge.context().get() : null;
         if (context != null) {
+            StringBuilder meta = new StringBuilder();
             if (context.moduleName() != null) {
-                line.append("  (module ").append(context.moduleName());
+                meta.append("module ").append(context.moduleName());
                 if (context.moduleVersion() != null) {
-                    line.append('@').append(context.moduleVersion());
+                    meta.append('@').append(context.moduleVersion());
                 }
                 if (Boolean.TRUE.equals(context.automaticModule())) {
-                    line.append(", automatic");
+                    meta.append(", automatic");
                 }
-                line.append(')');
             } else if (Boolean.TRUE.equals(context.automaticModule())) {
-                line.append("  (automatic module)");
+                meta.append("automatic module");
+            }
+            if (!meta.isEmpty()) {
+                line.append(' ').append(paint(109, "(" + meta + ")"));
             }
             if (context.resolvedCoordinate() != null) {
-                line.append("  -> ").append(context.resolvedCoordinate());
+                line.append(' ').append(paint(108, "=> " + context.resolvedCoordinate()));
             }
         }
+        if (!edge.followed()) {
+            line.append(' ').append(paint(240, "(*)"));
+        }
         return line.toString();
+    }
+
+    private static String paint(int code, String text) {
+        return "\033[38;5;" + code + "m" + text + BuildExecutorCallback.RESET;
     }
 
     private final class Collector implements ResolutionListener {
 
         private final List<Edge> edges = new ArrayList<>();
+        private final Map<String, String> resolved = new HashMap<>();
 
         @Override
         public void onDependency(String prefix,
@@ -139,21 +183,36 @@ public final class DependencyTreeReport {
                                  String scope,
                                  boolean followed,
                                  Supplier<ResolutionContext> context) {
-            edges.add(new Edge(parent, coordinate, scope, followed, context));
+            edges.add(new Edge(parent, coordinate, version, scope, followed, context));
+        }
+
+        @Override
+        public void onResolution(String prefix,
+                                 String coordinate,
+                                 String version) {
+            resolved.put(coordinate, version);
+            resolutions.add(new Resolution(coordinate, version));
         }
 
         @Override
         public void onResolved() {
             if (!edges.isEmpty()) {
-                trees.add(List.copyOf(edges));
+                trees.add(new Tree(List.copyOf(edges), Map.copyOf(resolved)));
             }
         }
     }
 
+    private record Tree(List<Edge> edges, Map<String, String> resolved) {
+    }
+
     private record Edge(String parent,
                         String coordinate,
+                        String version,
                         String scope,
                         boolean followed,
                         Supplier<ResolutionContext> context) {
+    }
+
+    private record Resolution(String coordinate, String version) {
     }
 }

--- a/sources/build/jenesis/DependencyTreeReport.java
+++ b/sources/build/jenesis/DependencyTreeReport.java
@@ -1,0 +1,131 @@
+package build.jenesis;
+
+import module java.base;
+
+public final class DependencyTreeReport {
+
+    private final List<List<Edge>> trees = Collections.synchronizedList(new ArrayList<>());
+
+    public Supplier<ResolutionListener> supplier() {
+        return Collector::new;
+    }
+
+    public void print(PrintStream out) {
+        List<List<Edge>> snapshot;
+        synchronized (trees) {
+            snapshot = new ArrayList<>(trees);
+        }
+        Set<String> rendered = new LinkedHashSet<>();
+        List<String> blocks = new ArrayList<>();
+        for (List<Edge> tree : snapshot) {
+            String block = render(tree);
+            if (!block.isEmpty() && rendered.add(block)) {
+                blocks.add(block);
+            }
+        }
+        if (blocks.isEmpty()) {
+            return;
+        }
+        out.println();
+        out.println("Dependency tree:");
+        for (String block : blocks) {
+            out.println();
+            out.print(block);
+        }
+    }
+
+    private static String render(List<Edge> tree) {
+        SequencedMap<String, List<Edge>> children = new LinkedHashMap<>();
+        List<Edge> roots = new ArrayList<>();
+        for (Edge edge : tree) {
+            if (!edge.followed()) {
+                continue;
+            }
+            if (edge.parent() == null) {
+                roots.add(edge);
+            } else {
+                children.computeIfAbsent(edge.parent(), _ -> new ArrayList<>()).add(edge);
+            }
+        }
+        StringBuilder out = new StringBuilder();
+        Set<String> seen = new HashSet<>();
+        for (Edge root : roots) {
+            out.append(label(root)).append(System.lineSeparator());
+            children(out, root.coordinate(), children, "", seen);
+        }
+        return out.toString();
+    }
+
+    private static void children(StringBuilder out,
+                                 String coordinate,
+                                 SequencedMap<String, List<Edge>> children,
+                                 String indent,
+                                 Set<String> seen) {
+        if (!seen.add(coordinate)) {
+            return;
+        }
+        List<Edge> next = children.getOrDefault(coordinate, List.of());
+        for (int index = 0; index < next.size(); index++) {
+            boolean last = index == next.size() - 1;
+            Edge edge = next.get(index);
+            out.append(indent).append(last ? "└─ " : "├─ ").append(label(edge)).append(System.lineSeparator());
+            children(out, edge.coordinate(), children, indent + (last ? "   " : "│  "), seen);
+        }
+    }
+
+    private static String label(Edge edge) {
+        StringBuilder line = new StringBuilder(edge.coordinate());
+        if (edge.scope() != null) {
+            line.append("  [").append(edge.scope()).append(']');
+        }
+        ResolutionContext context = edge.context() == null ? null : edge.context().get();
+        if (context != null) {
+            if (context.moduleName() != null) {
+                line.append("  (module ").append(context.moduleName());
+                if (context.moduleVersion() != null) {
+                    line.append('@').append(context.moduleVersion());
+                }
+                if (Boolean.TRUE.equals(context.automaticModule())) {
+                    line.append(", automatic");
+                }
+                line.append(')');
+            } else if (Boolean.TRUE.equals(context.automaticModule())) {
+                line.append("  (automatic module)");
+            }
+            if (context.resolvedCoordinate() != null) {
+                line.append("  -> ").append(context.resolvedCoordinate());
+            }
+        }
+        return line.toString();
+    }
+
+    private final class Collector implements ResolutionListener {
+
+        private final List<Edge> edges = new ArrayList<>();
+
+        @Override
+        public void onDependency(String prefix,
+                                 String parent,
+                                 String coordinate,
+                                 String version,
+                                 String scope,
+                                 boolean followed,
+                                 Supplier<ResolutionContext> context) {
+            edges.add(new Edge(parent, coordinate, scope, followed, context));
+        }
+
+        @Override
+        public void onResolved() {
+            if (!edges.isEmpty()) {
+                trees.add(List.copyOf(edges));
+            }
+        }
+    }
+
+    private record Edge(String parent,
+                        String coordinate,
+                        String scope,
+                        boolean followed,
+                        Supplier<ResolutionContext> context) {
+    }
+}

--- a/sources/build/jenesis/DependencyTreeReport.java
+++ b/sources/build/jenesis/DependencyTreeReport.java
@@ -15,10 +15,24 @@ public final class DependencyTreeReport {
         synchronized (trees) {
             snapshot = new ArrayList<>(trees);
         }
+        List<Set<String>> signatures = new ArrayList<>();
+        for (List<Edge> tree : snapshot) {
+            Set<String> signature = new HashSet<>();
+            for (Edge edge : tree) {
+                if (edge.followed()) {
+                    signature.add(edge.parent() + " -> " + edge.coordinate());
+                }
+            }
+            signatures.add(signature);
+        }
         Set<String> rendered = new LinkedHashSet<>();
         List<String> blocks = new ArrayList<>();
-        for (List<Edge> tree : snapshot) {
-            String block = render(tree);
+        for (int index = 0; index < snapshot.size(); index++) {
+            Set<String> signature = signatures.get(index);
+            if (signature.isEmpty() || subsumed(signature, index, signatures)) {
+                continue;
+            }
+            String block = render(snapshot.get(index));
             if (!block.isEmpty() && rendered.add(block)) {
                 blocks.add(block);
             }
@@ -32,6 +46,20 @@ public final class DependencyTreeReport {
             out.println();
             out.print(block);
         }
+    }
+
+    private static boolean subsumed(Set<String> signature, int index, List<Set<String>> signatures) {
+        for (int other = 0; other < signatures.size(); other++) {
+            if (other == index) {
+                continue;
+            }
+            Set<String> candidate = signatures.get(other);
+            if (candidate.containsAll(signature)
+                    && (candidate.size() > signature.size() || other < index)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String render(List<Edge> tree) {

--- a/sources/build/jenesis/Project.java
+++ b/sources/build/jenesis/Project.java
@@ -368,7 +368,7 @@ public record Project(
                       %{name}version%{reset}                          Project version
                       %{name}digest%{reset}                           Algorithm for pin and dependency checksums (default: SHA-256)
                       %{name}watch%{reset}                            Rebuild the selected target whenever a source file changes (Ctrl+C to stop)
-                      %{name}tree%{reset}                             Print the resolved dependency tree after the build (per module, deduplicated)
+                      %{name}tree%{reset}                             Print each module's dependency tree as it is resolved (verbose-style)
                       %{name}docker%{reset}[, %{name}docker.image%{reset}]           Wrap the build in a container
                       %{name}docker.mount%{reset} <h[:c],...>         Extra read-only container mounts (host or host:container)
                       %{name}docker.mountWritable%{reset} <h[:c],...> Extra writable container mounts
@@ -658,9 +658,9 @@ public record Project(
                       watch                       Rebuild the selected target
                                                   whenever a source file changes
                                                   (Ctrl+C to stop).
-                      tree                        Print the resolved dependency
-                                                  tree after the build, per module
-                                                  and deduplicated, with the
+                      tree                        Print each module's dependency
+                                                  tree as it is resolved
+                                                  (verbose-style), with the
                                                   property-file key and scope.
 
                     Pinning:
@@ -1409,10 +1409,7 @@ public record Project(
             }
         }
         if (Boolean.getBoolean("jenesis.project.tree")) {
-            DependencyTreeReport report = new DependencyTreeReport();
-            SequencedMap<String, Path> result = build(report.supplier(), selectors);
-            report.print(System.out);
-            return result;
+            return build(DependencyTreeReport::new, selectors);
         }
         return this.build(selectors);
     }

--- a/sources/build/jenesis/Project.java
+++ b/sources/build/jenesis/Project.java
@@ -368,6 +368,7 @@ public record Project(
                       %{name}version%{reset}                          Project version
                       %{name}digest%{reset}                           Algorithm for pin and dependency checksums (default: SHA-256)
                       %{name}watch%{reset}                            Rebuild the selected target whenever a source file changes (Ctrl+C to stop)
+                      %{name}tree%{reset}                             Print the resolved dependency tree after the build (per module, deduplicated)
                       %{name}docker%{reset}[, %{name}docker.image%{reset}]           Wrap the build in a container
                       %{name}docker.mount%{reset} <h[:c],...>         Extra read-only container mounts (host or host:container)
                       %{name}docker.mountWritable%{reset} <h[:c],...> Extra writable container mounts
@@ -657,6 +658,10 @@ public record Project(
                       watch                       Rebuild the selected target
                                                   whenever a source file changes
                                                   (Ctrl+C to stop).
+                      tree                        Print the resolved dependency
+                                                  tree after the build, per module
+                                                  and deduplicated, with the
+                                                  property-file key and scope.
 
                     Pinning:
                       -Dbuild.jenesis.pinning=strict|ignore  strict fails on

--- a/sources/build/jenesis/Project.java
+++ b/sources/build/jenesis/Project.java
@@ -58,9 +58,10 @@ public record Project(
 
         Function<String, String> apply(BuildExecutor executor,
                                        Project project,
-                                       MultiProjectAssembler<? super ProjectModuleDescriptor> assembler) throws IOException;
+                                       MultiProjectAssembler<? super ProjectModuleDescriptor> assembler,
+                                       Supplier<ResolutionListener> listener) throws IOException;
 
-        Layout MAVEN = (executor, project, assembler) -> {
+        Layout MAVEN = (executor, project, assembler, listener) -> {
             executor.addModule(HELP, new HelpModule("maven", assembler.getClass().getName()));
             executor.addModule(SKILL, new SkillModule(project.target()));
             executor.addModule(METADATA, MetadataModule.toMetadataModule(project));
@@ -82,6 +83,7 @@ public record Project(
                                 Collections.unmodifiableMap(resolvers),
                                 project.pinning(),
                                 project.hashFunction(),
+                                listener,
                                 (descriptor, mergedRepos, mergedResolvers) -> pomAware.apply(
                                         new ProjectModuleDescriptor(descriptor,
                                                 project.tests(),
@@ -112,7 +114,7 @@ public record Project(
             };
         };
 
-        Layout MODULAR = (executor, project, assembler) -> {
+        Layout MODULAR = (executor, project, assembler, listener) -> {
             executor.addModule(HELP, new HelpModule("modular", assembler.getClass().getName()));
             executor.addModule(SKILL, new SkillModule(project.target()));
             executor.addModule(METADATA, MetadataModule.toMetadataModule(project));
@@ -136,6 +138,7 @@ public record Project(
                         project.pinning(),
                         true,
                         project.hashFunction(),
+                        listener,
                         (descriptor, mergedRepos, mergedResolvers) -> assembler.apply(
                                 new ProjectModuleDescriptor(descriptor,
                                         project.tests(),
@@ -167,7 +170,7 @@ public record Project(
             };
         };
 
-        Layout MODULAR_TO_MAVEN = (executor, project, assembler) -> {
+        Layout MODULAR_TO_MAVEN = (executor, project, assembler, listener) -> {
             executor.addModule(HELP, new HelpModule("modular_to_maven", assembler.getClass().getName()));
             executor.addModule(SKILL, new SkillModule(project.target()));
             executor.addModule(METADATA, MetadataModule.toMetadataModule(project));
@@ -198,6 +201,7 @@ public record Project(
                                 project.pinning(),
                                 true,
                                 project.hashFunction(),
+                                listener,
                                 (descriptor, mergedRepos, mergedResolvers) -> pomAware.apply(
                                         new ProjectModuleDescriptor(descriptor,
                                                 project.tests(),
@@ -231,7 +235,7 @@ public record Project(
             };
         };
 
-        Layout AUTO = (executor, project, assembler) -> of(project.root()).apply(executor, project, assembler);
+        Layout AUTO = (executor, project, assembler, listener) -> of(project.root()).apply(executor, project, assembler, listener);
 
         static Layout of(Path root) throws IOException {
             if (Files.isRegularFile(root.resolve("pom.xml"))) {
@@ -1300,8 +1304,12 @@ public record Project(
     }
 
     public SequencedMap<String, Path> build(String... selectors) throws IOException {
+        return build((Supplier<ResolutionListener>) null, selectors);
+    }
+
+    public SequencedMap<String, Path> build(Supplier<ResolutionListener> listener, String... selectors) throws IOException {
         BuildExecutor executor = BuildExecutor.of(target);
-        Function<String, String> resolver = layout.apply(executor, this, assembler);
+        Function<String, String> resolver = layout.apply(executor, this, assembler, listener);
         return executor.execute(Arrays.stream(selectors.length == 0 ? defaultTarget.toArray(String[]::new) : selectors)
                 .map(selector -> selector.startsWith("+") ? resolver.apply(selector.substring(1)) : selector)
                 .toArray(String[]::new));
@@ -1394,6 +1402,12 @@ public record Project(
             if (code != 0) {
                 System.exit(code);
             }
+        }
+        if (Boolean.getBoolean("jenesis.project.tree")) {
+            DependencyTreeReport report = new DependencyTreeReport();
+            SequencedMap<String, Path> result = build(report.supplier(), selectors);
+            report.print(System.out);
+            return result;
         }
         return this.build(selectors);
     }

--- a/sources/build/jenesis/Project.java
+++ b/sources/build/jenesis/Project.java
@@ -1309,6 +1309,9 @@ public record Project(
     }
 
     public SequencedMap<String, Path> build(String... selectors) throws IOException {
+        if (Boolean.getBoolean("jenesis.project.tree")) {
+            return build(DependencyTreeReport::new, selectors);
+        }
         return build((Supplier<ResolutionListener>) null, selectors);
     }
 
@@ -1407,9 +1410,6 @@ public record Project(
             if (code != 0) {
                 System.exit(code);
             }
-        }
-        if (Boolean.getBoolean("jenesis.project.tree")) {
-            return build(DependencyTreeReport::new, selectors);
         }
         return this.build(selectors);
     }

--- a/sources/build/jenesis/ResolutionContext.java
+++ b/sources/build/jenesis/ResolutionContext.java
@@ -1,0 +1,7 @@
+package build.jenesis;
+
+public record ResolutionContext(String moduleName,
+                                String moduleVersion,
+                                Boolean automaticModule,
+                                String resolvedCoordinate) {
+}

--- a/sources/build/jenesis/ResolutionListener.java
+++ b/sources/build/jenesis/ResolutionListener.java
@@ -1,0 +1,18 @@
+package build.jenesis;
+
+import module java.base;
+
+@FunctionalInterface
+public interface ResolutionListener {
+
+    void onDependency(String prefix,
+                      String parent,
+                      String coordinate,
+                      String version,
+                      String scope,
+                      boolean followed,
+                      Supplier<ResolutionContext> context);
+
+    default void onResolved() {
+    }
+}

--- a/sources/build/jenesis/ResolutionListener.java
+++ b/sources/build/jenesis/ResolutionListener.java
@@ -13,6 +13,11 @@ public interface ResolutionListener {
                       boolean followed,
                       Supplier<ResolutionContext> context);
 
+    default void onResolution(String prefix,
+                              String coordinate,
+                              String version) {
+    }
+
     default void onResolved() {
     }
 }

--- a/sources/build/jenesis/Resolver.java
+++ b/sources/build/jenesis/Resolver.java
@@ -20,7 +20,7 @@ public interface Resolver extends Serializable {
                                                       SequencedMap<String, String> versions,
                                                       boolean compile) throws IOException {
         return dependencies(executor, prefix, repositories, coordinates, versions, compile,
-                (p, par, c, v, s, f, ctx) -> {});
+                (_, _, _, _, _, _, _) -> {});
     }
 
     default SequencedSet<String> managedPrefixes() {

--- a/sources/build/jenesis/Resolver.java
+++ b/sources/build/jenesis/Resolver.java
@@ -19,8 +19,7 @@ public interface Resolver extends Serializable {
                                                       SequencedMap<String, SequencedSet<String>> coordinates,
                                                       SequencedMap<String, String> versions,
                                                       boolean compile) throws IOException {
-        return dependencies(executor, prefix, repositories, coordinates, versions, compile,
-                (_, _, _, _, _, _, _) -> {});
+        return dependencies(executor, prefix, repositories, coordinates, versions, compile, null);
     }
 
     default SequencedSet<String> managedPrefixes() {

--- a/sources/build/jenesis/Resolver.java
+++ b/sources/build/jenesis/Resolver.java
@@ -10,14 +10,25 @@ public interface Resolver extends Serializable {
                                               Map<String, Repository> repositories,
                                               SequencedMap<String, SequencedSet<String>> coordinates,
                                               SequencedMap<String, String> versions,
-                                              boolean compile) throws IOException;
+                                              boolean compile,
+                                              ResolutionListener listener) throws IOException;
+
+    default SequencedMap<String, String> dependencies(Executor executor,
+                                                      String prefix,
+                                                      Map<String, Repository> repositories,
+                                                      SequencedMap<String, SequencedSet<String>> coordinates,
+                                                      SequencedMap<String, String> versions,
+                                                      boolean compile) throws IOException {
+        return dependencies(executor, prefix, repositories, coordinates, versions, compile,
+                (p, par, c, v, s, f, ctx) -> {});
+    }
 
     default SequencedSet<String> managedPrefixes() {
         return Collections.emptyNavigableSet();
     }
 
     default <F extends BiFunction<String, String, String> & Serializable> Resolver translated(String translated, F translator) {
-        return (executor, prefix, repositories, coordinates, versions, compile) -> {
+        return (executor, prefix, repositories, coordinates, versions, compile, listener) -> {
             SequencedMap<String, String> translatedVersions = new LinkedHashMap<>();
             versions.forEach((coordinate, version) -> translatedVersions.put(
                     pinVersion(translator.apply(prefix, coordinate), version),
@@ -31,7 +42,8 @@ public interface Resolver extends Serializable {
                     repositories,
                     translatedCoordinates,
                     translatedVersions,
-                    compile);
+                    compile,
+                    listener);
         };
     }
 
@@ -59,7 +71,7 @@ public interface Resolver extends Serializable {
     }
 
     static Resolver identity() {
-        return (_, prefix, _, coordinates, _, _) -> {
+        return (_, prefix, _, coordinates, _, _, _) -> {
             SequencedMap<String, String> resolved = new LinkedHashMap<>();
             coordinates.sequencedKeySet().forEach(coordinate -> resolved.put(prefix + "/" + coordinate, ""));
             return resolved;
@@ -67,7 +79,7 @@ public interface Resolver extends Serializable {
     }
 
     static <F extends Function<String, SequencedCollection<String>> & Serializable> Resolver of(F translator) {
-        return (_, prefix, _, coordinates, _, _) -> {
+        return (_, prefix, _, coordinates, _, _, _) -> {
             SequencedMap<String, String> resolved = new LinkedHashMap<>();
             coordinates.sequencedKeySet().stream()
                     .flatMap(coordinate -> translator.apply(coordinate).stream())

--- a/sources/build/jenesis/Resolver.java
+++ b/sources/build/jenesis/Resolver.java
@@ -10,7 +10,7 @@ public interface Resolver extends Serializable {
                                               Map<String, Repository> repositories,
                                               SequencedMap<String, SequencedSet<String>> coordinates,
                                               SequencedMap<String, String> versions,
-                                              boolean compile,
+                                              DependencyScope scope,
                                               ResolutionListener listener) throws IOException;
 
     default SequencedMap<String, String> dependencies(Executor executor,
@@ -18,8 +18,8 @@ public interface Resolver extends Serializable {
                                                       Map<String, Repository> repositories,
                                                       SequencedMap<String, SequencedSet<String>> coordinates,
                                                       SequencedMap<String, String> versions,
-                                                      boolean compile) throws IOException {
-        return dependencies(executor, prefix, repositories, coordinates, versions, compile, null);
+                                                      DependencyScope scope) throws IOException {
+        return dependencies(executor, prefix, repositories, coordinates, versions, scope, null);
     }
 
     default SequencedSet<String> managedPrefixes() {
@@ -27,7 +27,7 @@ public interface Resolver extends Serializable {
     }
 
     default <F extends BiFunction<String, String, String> & Serializable> Resolver translated(String translated, F translator) {
-        return (executor, prefix, repositories, coordinates, versions, compile, listener) -> {
+        return (executor, prefix, repositories, coordinates, versions, scope, listener) -> {
             SequencedMap<String, String> translatedVersions = new LinkedHashMap<>();
             versions.forEach((coordinate, version) -> translatedVersions.put(
                     pinVersion(translator.apply(prefix, coordinate), version),
@@ -41,7 +41,7 @@ public interface Resolver extends Serializable {
                     repositories,
                     translatedCoordinates,
                     translatedVersions,
-                    compile,
+                    scope,
                     listener);
         };
     }

--- a/sources/build/jenesis/maven/MavenModuleResolver.java
+++ b/sources/build/jenesis/maven/MavenModuleResolver.java
@@ -1,6 +1,7 @@
 package build.jenesis.maven;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import build.jenesis.Repository;
 import build.jenesis.RepositoryItem;
 import build.jenesis.ResolutionListener;
@@ -29,7 +30,7 @@ public class MavenModuleResolver implements Resolver {
                                                      Map<String, Repository> repositories,
                                                      SequencedMap<String, SequencedSet<String>> coordinates,
                                                      SequencedMap<String, String> versions,
-                                                     boolean compile,
+                                                     DependencyScope scope,
                                                      ResolutionListener listener) throws IOException {
         coordinates.forEach((coordinate, exclusions) -> {
             if (!exclusions.isEmpty()) {

--- a/sources/build/jenesis/maven/MavenModuleResolver.java
+++ b/sources/build/jenesis/maven/MavenModuleResolver.java
@@ -56,7 +56,7 @@ public class MavenModuleResolver implements Resolver {
         }
         MavenRepository mavenRepo = MavenRepository.of(repositories.getOrDefault(mavenPrefix, Repository.empty()));
         SequencedMap<String, String> result = new LinkedHashMap<>();
-        delegate.dependencies(executor, mavenRepo, rootPoms, managedPoms, MavenDependencyScope.COMPILE)
+        delegate.dependencies(executor, mavenRepo, rootPoms, managedPoms, MavenDependencyScope.COMPILE, mavenPrefix, listener)
                 .forEach((key, value) -> {
                     String checksum = value.checksum();
                     if (checksum == null) {

--- a/sources/build/jenesis/maven/MavenModuleResolver.java
+++ b/sources/build/jenesis/maven/MavenModuleResolver.java
@@ -3,6 +3,7 @@ package build.jenesis.maven;
 import module java.base;
 import build.jenesis.Repository;
 import build.jenesis.RepositoryItem;
+import build.jenesis.ResolutionListener;
 import build.jenesis.Resolver;
 
 public class MavenModuleResolver implements Resolver {
@@ -28,7 +29,8 @@ public class MavenModuleResolver implements Resolver {
                                                      Map<String, Repository> repositories,
                                                      SequencedMap<String, SequencedSet<String>> coordinates,
                                                      SequencedMap<String, String> versions,
-                                                     boolean compile) throws IOException {
+                                                     boolean compile,
+                                                     ResolutionListener listener) throws IOException {
         coordinates.forEach((coordinate, exclusions) -> {
             if (!exclusions.isEmpty()) {
                 throw new IllegalArgumentException(

--- a/sources/build/jenesis/maven/MavenPomResolver.java
+++ b/sources/build/jenesis/maven/MavenPomResolver.java
@@ -95,7 +95,11 @@ public class MavenPomResolver implements MavenResolver {
                         true,
                         null,
                         Set.of(),
-                        null), new HashMap<>(), new HashMap<>(), null, (p, par, c, v, s, f, ctx) -> {});
+                        null),
+                new HashMap<>(),
+                new HashMap<>(),
+                null,
+                (_, _, _, _, _, _, _) -> {});
     }
 
     @Override
@@ -161,13 +165,19 @@ public class MavenPomResolver implements MavenResolver {
             throws IOException {
         Map<DependencyCoordinate, UnresolvedPom> unresolved = new HashMap<>();
         Map<DependencyCoordinate, ResolvedPom> resolved = new HashMap<>();
-        return dependencies(executor, repository, new ContextualPom(resolveOrCached(executor,
+        return dependencies(executor,
                 repository,
-                groupId,
-                artifactId,
-                version,
+                new ContextualPom(resolveOrCached(executor,
+                        repository,
+                        groupId,
+                        artifactId,
+                        version,
+                        resolved,
+                        unresolved), true, scope, Set.of(), null),
+                unresolved,
                 resolved,
-                unresolved), true, scope, Set.of(), null), unresolved, resolved, null, (p, par, c, v, s, f, ctx) -> {});
+                null,
+                (_, _, _, _, _, _, _) -> {});
     }
 
     private SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies(

--- a/sources/build/jenesis/maven/MavenPomResolver.java
+++ b/sources/build/jenesis/maven/MavenPomResolver.java
@@ -4,6 +4,8 @@ import module java.base;
 import module java.xml;
 import build.jenesis.Repository;
 import build.jenesis.RepositoryItem;
+import build.jenesis.ResolutionContext;
+import build.jenesis.ResolutionListener;
 import build.jenesis.Resolver;
 
 public class MavenPomResolver implements MavenResolver {
@@ -30,7 +32,8 @@ public class MavenPomResolver implements MavenResolver {
                                                      Map<String, Repository> repositories,
                                                      SequencedMap<String, SequencedSet<String>> coordinates,
                                                      SequencedMap<String, String> versions,
-                                                     boolean compile) throws IOException {
+                                                     boolean compile,
+                                                     ResolutionListener listener) throws IOException {
         Map<MavenDependencyKey, MavenDependencyValue> managedDependencies = new LinkedHashMap<>();
         versions.forEach((coordinate, value) -> {
             MavenDependencyKey key = MavenDependencyKey.parseKey(coordinate);
@@ -71,8 +74,11 @@ public class MavenPomResolver implements MavenResolver {
         SequencedMap<String, String> resolved = new LinkedHashMap<>();
         dependencies(executor,
                 MavenRepository.of(repositories.getOrDefault(Resolver.base(prefix), Repository.empty())),
-                managedDependencies,
-                dependencies).forEach((key, value) -> resolved.put(
+                new ContextualPom(new ResolvedPom(managedDependencies, dependencies), true, null, Set.of(), null),
+                new HashMap<>(),
+                new HashMap<>(),
+                prefix,
+                listener).forEach((key, value) -> resolved.put(
                         key.coordinate(prefix, value.version()),
                         value.checksum() == null ? "" : value.checksum()));
         return resolved;
@@ -88,7 +94,8 @@ public class MavenPomResolver implements MavenResolver {
                 new ContextualPom(new ResolvedPom(managedDependencies, dependencies),
                         true,
                         null,
-                        Set.of()), new HashMap<>(), new HashMap<>());
+                        Set.of(),
+                        null), new HashMap<>(), new HashMap<>(), null, (p, par, c, v, s, f, ctx) -> {});
     }
 
     @Override
@@ -139,8 +146,8 @@ public class MavenPomResolver implements MavenResolver {
                     new MavenDependencyValue(version, scope, null, null, null, rootPom.checksum()));
         }
         return dependencies(executor, repository,
-                new ContextualPom(new ResolvedPom(managedDependencies, dependencies), true, scope, Set.of()),
-                unresolved, resolved);
+                new ContextualPom(new ResolvedPom(managedDependencies, dependencies), true, scope, Set.of(), null),
+                unresolved, resolved, null, (p, par, c, v, s, f, ctx) -> {});
     }
 
     public SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies(Executor executor,
@@ -158,7 +165,7 @@ public class MavenPomResolver implements MavenResolver {
                 artifactId,
                 version,
                 resolved,
-                unresolved), true, scope, Set.of()), unresolved, resolved);
+                unresolved), true, scope, Set.of(), null), unresolved, resolved, null, (p, par, c, v, s, f, ctx) -> {});
     }
 
     private SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies(
@@ -166,12 +173,16 @@ public class MavenPomResolver implements MavenResolver {
             MavenRepository repository,
             ContextualPom initial,
             Map<DependencyCoordinate, UnresolvedPom> unresolved,
-            Map<DependencyCoordinate, ResolvedPom> resolved) throws IOException {
+            Map<DependencyCoordinate, ResolvedPom> resolved,
+            String prefix,
+            ResolutionListener listener) throws IOException {
         Map<MavenDependencyKey, DependencyResolution> resolutions = new HashMap<>();
         SequencedSet<MavenDependencyKey> dependencies = new LinkedHashSet<>(), conflicts;
+        List<Edge> edges = new ArrayList<>();
         MavenVersionNegotiator negotiator = negotiatorSupplier.get();
         do {
             dependencies.clear();
+            edges.clear();
             conflicts = traverse(executor,
                     repository,
                     negotiator,
@@ -180,7 +191,8 @@ public class MavenPomResolver implements MavenResolver {
                     resolutions,
                     initial.pom().managedDependencies(),
                     dependencies,
-                    initial);
+                    initial,
+                    edges);
             Iterator<MavenDependencyKey> it = conflicts.iterator();
             while (it.hasNext()) {
                 MavenDependencyKey key = it.next();
@@ -219,6 +231,18 @@ public class MavenPomResolver implements MavenResolver {
                     resolution.optional,
                     resolution.checksum));
         });
+        for (Edge edge : edges) {
+            DependencyResolution parent = edge.parent() == null ? null : resolutions.get(edge.parent());
+            listener.onDependency(prefix,
+                    edge.parent() == null
+                            ? null
+                            : edge.parent().coordinate(prefix, parent == null ? null : parent.currentVersion),
+                    edge.child().coordinate(prefix, edge.version()),
+                    edge.version(),
+                    edge.scope() == null ? null : edge.scope().name().toLowerCase(Locale.ROOT),
+                    edge.followed(),
+                    () -> null);
+        }
         return results;
     }
 
@@ -230,7 +254,8 @@ public class MavenPomResolver implements MavenResolver {
                                                       Map<MavenDependencyKey, DependencyResolution> resolutions,
                                                       Map<MavenDependencyKey, MavenDependencyValue> managedDependencies,
                                                       SequencedSet<MavenDependencyKey> dependencies,
-                                                      ContextualPom current) throws IOException {
+                                                      ContextualPom current,
+                                                      List<Edge> edges) throws IOException {
         SequencedSet<MavenDependencyKey> conflicting = new LinkedHashSet<>();
         Queue<ContextualPom> queue = new ArrayDeque<>();
         do {
@@ -295,6 +320,7 @@ public class MavenPomResolver implements MavenResolver {
                     }
                 }
                 if (dependencies.add(entry.getKey())) {
+                    edges.add(new Edge(current.origin(), entry.getKey(), version, scope, true));
                     ResolvedPom pom = resolveOrCached(executor,
                             repository,
                             entry.getKey().groupId(),
@@ -307,7 +333,9 @@ public class MavenPomResolver implements MavenResolver {
                         exclusions = new HashSet<>(exclusions);
                         exclusions.addAll(value.exclusions());
                     }
-                    queue.add(new ContextualPom(pom, false, scope, exclusions));
+                    queue.add(new ContextualPom(pom, false, scope, exclusions, entry.getKey()));
+                } else {
+                    edges.add(new Edge(current.origin(), entry.getKey(), version, scope, false));
                 }
             }
         } while ((current = queue.poll()) != null);
@@ -918,7 +946,15 @@ public class MavenPomResolver implements MavenResolver {
     private record ContextualPom(ResolvedPom pom,
                                  boolean root,
                                  MavenDependencyScope scope,
-                                 Set<MavenDependencyName> exclusions) {
+                                 Set<MavenDependencyName> exclusions,
+                                 MavenDependencyKey origin) {
+    }
+
+    private record Edge(MavenDependencyKey parent,
+                        MavenDependencyKey child,
+                        String version,
+                        MavenDependencyScope scope,
+                        boolean followed) {
     }
 
     private static class DependencyResolution {

--- a/sources/build/jenesis/maven/MavenPomResolver.java
+++ b/sources/build/jenesis/maven/MavenPomResolver.java
@@ -74,7 +74,7 @@ public class MavenPomResolver implements MavenResolver {
         SequencedMap<String, String> resolved = new LinkedHashMap<>();
         dependencies(executor,
                 MavenRepository.of(repositories.getOrDefault(Resolver.base(prefix), Repository.empty())),
-                new ContextualPom(new ResolvedPom(managedDependencies, dependencies), true, null, Set.of(), null),
+                new ContextualPom(new ResolvedPom(managedDependencies, dependencies), true, null, Set.of(), null, null),
                 new HashMap<>(),
                 new HashMap<>(),
                 prefix,
@@ -95,11 +95,12 @@ public class MavenPomResolver implements MavenResolver {
                         true,
                         null,
                         Set.of(),
+                        null,
                         null),
                 new HashMap<>(),
                 new HashMap<>(),
                 null,
-                (_, _, _, _, _, _, _) -> {});
+                null);
     }
 
     @Override
@@ -152,7 +153,7 @@ public class MavenPomResolver implements MavenResolver {
                     new MavenDependencyValue(version, scope, null, null, null, rootPom.checksum()));
         }
         return dependencies(executor, repository,
-                new ContextualPom(new ResolvedPom(managedDependencies, dependencies), true, scope, Set.of(), null),
+                new ContextualPom(new ResolvedPom(managedDependencies, dependencies), true, scope, Set.of(), null, null),
                 unresolved, resolved, prefix, listener);
     }
 
@@ -162,6 +163,23 @@ public class MavenPomResolver implements MavenResolver {
                                                                                String artifactId,
                                                                                String version,
                                                                                MavenDependencyScope scope)
+            throws IOException {
+        return dependencies(executor,
+                repository,
+                groupId,
+                artifactId,
+                version,
+                scope,
+                null);
+    }
+
+    public SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies(Executor executor,
+                                                                               MavenRepository repository,
+                                                                               String groupId,
+                                                                               String artifactId,
+                                                                               String version,
+                                                                               MavenDependencyScope scope,
+                                                                               ResolutionListener listener)
             throws IOException {
         Map<DependencyCoordinate, UnresolvedPom> unresolved = new HashMap<>();
         Map<DependencyCoordinate, ResolvedPom> resolved = new HashMap<>();
@@ -173,11 +191,11 @@ public class MavenPomResolver implements MavenResolver {
                         artifactId,
                         version,
                         resolved,
-                        unresolved), true, scope, Set.of(), null),
+                        unresolved), true, scope, Set.of(), null, null),
                 unresolved,
                 resolved,
                 null,
-                (_, _, _, _, _, _, _) -> {});
+                listener);
     }
 
     private SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies(
@@ -190,11 +208,9 @@ public class MavenPomResolver implements MavenResolver {
             ResolutionListener listener) throws IOException {
         Map<MavenDependencyKey, DependencyResolution> resolutions = new HashMap<>();
         SequencedSet<MavenDependencyKey> dependencies = new LinkedHashSet<>(), conflicts;
-        List<Edge> edges = new ArrayList<>();
         MavenVersionNegotiator negotiator = negotiatorSupplier.get();
         do {
             dependencies.clear();
-            edges.clear();
             conflicts = traverse(executor,
                     repository,
                     negotiator,
@@ -204,7 +220,8 @@ public class MavenPomResolver implements MavenResolver {
                     initial.pom().managedDependencies(),
                     dependencies,
                     initial,
-                    edges);
+                    prefix,
+                    null);
             Iterator<MavenDependencyKey> it = conflicts.iterator();
             while (it.hasNext()) {
                 MavenDependencyKey key = it.next();
@@ -243,17 +260,22 @@ public class MavenPomResolver implements MavenResolver {
                     resolution.optional,
                     resolution.checksum));
         });
-        for (Edge edge : edges) {
-            DependencyResolution parent = edge.parent() == null ? null : resolutions.get(edge.parent());
-            listener.onDependency(prefix,
-                    edge.parent() == null
-                            ? null
-                            : edge.parent().coordinate(prefix, parent == null ? null : parent.currentVersion),
-                    edge.child().coordinate(prefix, edge.version()),
-                    edge.version(),
-                    edge.scope() == null ? null : edge.scope().name().toLowerCase(Locale.ROOT),
-                    edge.followed(),
-                    () -> null);
+        if (listener != null) {
+            dependencies.clear();
+            traverse(executor,
+                    repository,
+                    negotiator,
+                    resolved,
+                    unresolved,
+                    resolutions,
+                    initial.pom().managedDependencies(),
+                    dependencies,
+                    initial,
+                    prefix,
+                    listener);
+            results.forEach((key, value) -> listener.onResolution(prefix,
+                    key.coordinate(prefix, null),
+                    value.version()));
         }
         return results;
     }
@@ -267,7 +289,8 @@ public class MavenPomResolver implements MavenResolver {
                                                       Map<MavenDependencyKey, MavenDependencyValue> managedDependencies,
                                                       SequencedSet<MavenDependencyKey> dependencies,
                                                       ContextualPom current,
-                                                      List<Edge> edges) throws IOException {
+                                                      String prefix,
+                                                      ResolutionListener listener) throws IOException {
         SequencedSet<MavenDependencyKey> conflicting = new LinkedHashSet<>();
         Queue<ContextualPom> queue = new ArrayDeque<>();
         do {
@@ -331,8 +354,19 @@ public class MavenPomResolver implements MavenResolver {
                         conflicting.add(entry.getKey());
                     }
                 }
-                if (dependencies.add(entry.getKey())) {
-                    edges.add(new Edge(current.origin(), entry.getKey(), version, scope, true));
+                boolean followed = dependencies.add(entry.getKey());
+                if (listener != null) {
+                    listener.onDependency(prefix,
+                            current.origin() == null
+                                    ? null
+                                    : current.origin().coordinate(prefix, current.originVersion()),
+                            entry.getKey().coordinate(prefix, value.version()),
+                            value.version(),
+                            scope.name().toLowerCase(Locale.ROOT),
+                            followed,
+                            () -> null);
+                }
+                if (followed) {
                     ResolvedPom pom = resolveOrCached(executor,
                             repository,
                             entry.getKey().groupId(),
@@ -345,9 +379,7 @@ public class MavenPomResolver implements MavenResolver {
                         exclusions = new HashSet<>(exclusions);
                         exclusions.addAll(value.exclusions());
                     }
-                    queue.add(new ContextualPom(pom, false, scope, exclusions, entry.getKey()));
-                } else {
-                    edges.add(new Edge(current.origin(), entry.getKey(), version, scope, false));
+                    queue.add(new ContextualPom(pom, false, scope, exclusions, entry.getKey(), value.version()));
                 }
             }
         } while ((current = queue.poll()) != null);
@@ -959,14 +991,8 @@ public class MavenPomResolver implements MavenResolver {
                                  boolean root,
                                  MavenDependencyScope scope,
                                  Set<MavenDependencyName> exclusions,
-                                 MavenDependencyKey origin) {
-    }
-
-    private record Edge(MavenDependencyKey parent,
-                        MavenDependencyKey child,
-                        String version,
-                        MavenDependencyScope scope,
-                        boolean followed) {
+                                 MavenDependencyKey origin,
+                                 String originVersion) {
     }
 
     private static class DependencyResolution {

--- a/sources/build/jenesis/maven/MavenPomResolver.java
+++ b/sources/build/jenesis/maven/MavenPomResolver.java
@@ -104,7 +104,9 @@ public class MavenPomResolver implements MavenResolver {
             MavenRepository repository,
             List<RootPom> rootPoms,
             List<RootPom> managedPoms,
-            MavenDependencyScope scope) throws IOException {
+            MavenDependencyScope scope,
+            String prefix,
+            ResolutionListener listener) throws IOException {
         Map<DependencyCoordinate, UnresolvedPom> unresolved = new HashMap<>();
         Map<DependencyCoordinate, ResolvedPom> resolved = new HashMap<>();
         Map<MavenDependencyKey, MavenDependencyValue> managedDependencies = new LinkedHashMap<>();
@@ -147,7 +149,7 @@ public class MavenPomResolver implements MavenResolver {
         }
         return dependencies(executor, repository,
                 new ContextualPom(new ResolvedPom(managedDependencies, dependencies), true, scope, Set.of(), null),
-                unresolved, resolved, null, (p, par, c, v, s, f, ctx) -> {});
+                unresolved, resolved, prefix, listener);
     }
 
     public SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies(Executor executor,

--- a/sources/build/jenesis/maven/MavenPomResolver.java
+++ b/sources/build/jenesis/maven/MavenPomResolver.java
@@ -2,6 +2,7 @@ package build.jenesis.maven;
 
 import module java.base;
 import module java.xml;
+import build.jenesis.DependencyScope;
 import build.jenesis.Repository;
 import build.jenesis.RepositoryItem;
 import build.jenesis.ResolutionContext;
@@ -32,7 +33,7 @@ public class MavenPomResolver implements MavenResolver {
                                                      Map<String, Repository> repositories,
                                                      SequencedMap<String, SequencedSet<String>> coordinates,
                                                      SequencedMap<String, String> versions,
-                                                     boolean compile,
+                                                     DependencyScope scope,
                                                      ResolutionListener listener) throws IOException {
         Map<MavenDependencyKey, MavenDependencyValue> managedDependencies = new LinkedHashMap<>();
         versions.forEach((coordinate, value) -> {

--- a/sources/build/jenesis/maven/MavenProject.java
+++ b/sources/build/jenesis/maven/MavenProject.java
@@ -2,6 +2,7 @@ package build.jenesis.maven;
 
 import module java.base;
 import build.jenesis.Pinning;
+import build.jenesis.ResolutionListener;
 import module java.xml;
 import build.jenesis.BuildExecutor;
 import build.jenesis.BuildExecutorModule;
@@ -62,6 +63,7 @@ public class MavenProject implements BuildExecutorModule {
                 Map.of("maven", new MavenPomResolver()),
                 null,
                 new HashDigestFunction("MD5"),
+                null,
                 assembler);
     }
 
@@ -71,6 +73,7 @@ public class MavenProject implements BuildExecutorModule {
                                            Map<String, Resolver> resolvers,
                                            Pinning pinning,
                                            HashDigestFunction digest,
+                                           Supplier<ResolutionListener> listener,
                                            MultiProjectAssembler<? super MavenModuleDescriptor> assembler) {
         MavenRepository repository = MavenRepository.of(requireNonNull(repositories.get(prefix)));
         MavenResolver resolver = MavenResolver.of(resolvers.get(prefix));
@@ -97,7 +100,8 @@ public class MavenProject implements BuildExecutorModule {
                                             digest),
                                     scopeInherited.sequencedKeySet());
                             scopeExec.addModule(DEPENDENCIES,
-                                    new DependenciesModule(mergedRepositories, resolvers, scope == DependencyScope.COMPILE, pinning),
+                                    new DependenciesModule(mergedRepositories, resolvers, scope == DependencyScope.COMPILE, pinning)
+                                            .listener(listener),
                                     PREPARE);
                         }, inherited.sequencedKeySet());
                     }

--- a/sources/build/jenesis/maven/MavenProject.java
+++ b/sources/build/jenesis/maven/MavenProject.java
@@ -100,7 +100,7 @@ public class MavenProject implements BuildExecutorModule {
                                             digest),
                                     scopeInherited.sequencedKeySet());
                             scopeExec.addModule(DEPENDENCIES,
-                                    new DependenciesModule(mergedRepositories, resolvers, scope, pinning)
+                                    new DependenciesModule(mergedRepositories, resolvers, scope).pinning(pinning)
                                             .listener(listener),
                                     PREPARE);
                         }, inherited.sequencedKeySet());

--- a/sources/build/jenesis/maven/MavenProject.java
+++ b/sources/build/jenesis/maven/MavenProject.java
@@ -19,7 +19,7 @@ import build.jenesis.project.ProjectModule;
 import build.jenesis.project.MultiProjectAssembler;
 import build.jenesis.project.MultiProjectDependencies;
 import build.jenesis.project.MultiProjectModule;
-import build.jenesis.project.DependencyScope;
+import build.jenesis.DependencyScope;
 import build.jenesis.step.Assign;
 import build.jenesis.step.Bind;
 import build.jenesis.step.Inventory;
@@ -100,7 +100,7 @@ public class MavenProject implements BuildExecutorModule {
                                             digest),
                                     scopeInherited.sequencedKeySet());
                             scopeExec.addModule(DEPENDENCIES,
-                                    new DependenciesModule(mergedRepositories, resolvers, scope == DependencyScope.COMPILE, pinning)
+                                    new DependenciesModule(mergedRepositories, resolvers, scope, pinning)
                                             .listener(listener),
                                     PREPARE);
                         }, inherited.sequencedKeySet());

--- a/sources/build/jenesis/maven/MavenResolver.java
+++ b/sources/build/jenesis/maven/MavenResolver.java
@@ -2,6 +2,7 @@ package build.jenesis.maven;
 
 import module java.base;
 import build.jenesis.Repository;
+import build.jenesis.ResolutionListener;
 import build.jenesis.Resolver;
 
 public interface MavenResolver extends Resolver {
@@ -12,7 +13,9 @@ public interface MavenResolver extends Resolver {
                                                                         MavenRepository repository,
                                                                         List<RootPom> rootPoms,
                                                                         List<RootPom> managedPoms,
-                                                                        MavenDependencyScope scope) throws IOException;
+                                                                        MavenDependencyScope scope,
+                                                                        String prefix,
+                                                                        ResolutionListener listener) throws IOException;
 
     static MavenResolver of(Resolver resolver) {
         if (resolver instanceof MavenResolver mavenResolver) {

--- a/sources/build/jenesis/maven/Pom.java
+++ b/sources/build/jenesis/maven/Pom.java
@@ -6,7 +6,7 @@ import build.jenesis.BuildStepArgument;
 import build.jenesis.BuildStepContext;
 import build.jenesis.BuildStepResult;
 import build.jenesis.SequencedProperties;
-import build.jenesis.project.DependencyScope;
+import build.jenesis.DependencyScope;
 
 public class Pom implements BuildStep {
 

--- a/sources/build/jenesis/module/ModularJarResolver.java
+++ b/sources/build/jenesis/module/ModularJarResolver.java
@@ -3,6 +3,7 @@ package build.jenesis.module;
 import module java.base;
 import build.jenesis.Repository;
 import build.jenesis.RepositoryItem;
+import build.jenesis.ResolutionListener;
 import build.jenesis.Resolver;
 
 public class ModularJarResolver implements Resolver {
@@ -27,7 +28,8 @@ public class ModularJarResolver implements Resolver {
                                                      Map<String, Repository> repositories,
                                                      SequencedMap<String, SequencedSet<String>> coordinates,
                                                      SequencedMap<String, String> versions,
-                                                     boolean compile) throws IOException {
+                                                     boolean compile,
+                                                     ResolutionListener listener) throws IOException {
         coordinates.forEach((coordinate, exclusions) -> {
             if (!exclusions.isEmpty()) {
                 throw new IllegalArgumentException(
@@ -160,7 +162,7 @@ public class ModularJarResolver implements Resolver {
             for (String coordinate : unresolved) {
                 unresolvedCoordinates.put(coordinate, Collections.emptyNavigableSet());
             }
-            fallback.dependencies(executor, prefix, repositories, unresolvedCoordinates, hints, compile)
+            fallback.dependencies(executor, prefix, repositories, unresolvedCoordinates, hints, compile, listener)
                     .forEach(dependencies::putIfAbsent);
         }
         return dependencies;

--- a/sources/build/jenesis/module/ModularJarResolver.java
+++ b/sources/build/jenesis/module/ModularJarResolver.java
@@ -41,8 +41,9 @@ public class ModularJarResolver implements Resolver {
         SequencedSet<String> unresolved = new LinkedHashSet<>();
         SequencedMap<String, String> propagated = new LinkedHashMap<>();
         SequencedMap<String, String> hints = new LinkedHashMap<>(versions);
-        Map<String, String> parents = new HashMap<>();
-        Map<String, String> moduleCoordinates = new HashMap<>();
+        boolean observes = listener != null;
+        Map<String, String> parents = observes ? new HashMap<>() : null;
+        Map<String, String> moduleCoordinates = observes ? new HashMap<>() : null;
         Queue<String> queue = new ArrayDeque<>(coordinates.sequencedKeySet());
         int runtime = Runtime.version().feature();
         while (!queue.isEmpty()) {
@@ -145,15 +146,17 @@ public class ModularJarResolver implements Resolver {
                 String currentCoordinate = prefix + "/" + current + (version == null ? "" : "/" + version);
                 dependencies.put(currentCoordinate, checksum == null ? "" : checksum);
                 resolved.add(current);
-                moduleCoordinates.put(current, currentCoordinate);
-                String parent = parents.get(current);
-                listener.onDependency(prefix,
-                        parent == null ? null : moduleCoordinates.get(parent),
-                        currentCoordinate,
-                        version,
-                        null,
-                        true,
-                        () -> null);
+                if (observes) {
+                    moduleCoordinates.put(current, currentCoordinate);
+                    String parent = parents.get(current);
+                    listener.onDependency(prefix,
+                            parent == null ? null : moduleCoordinates.get(parent),
+                            currentCoordinate,
+                            version,
+                            null,
+                            true,
+                            () -> null);
+                }
                 descriptor.requires().stream()
                         .filter(requires -> !requires.accessFlags().contains(AccessFlag.STATIC_PHASE)
                                 || compile && requires.accessFlags().contains(AccessFlag.TRANSITIVE))
@@ -162,10 +165,12 @@ public class ModularJarResolver implements Resolver {
                         .forEach(requires -> {
                             String name = requires.name();
                             requires.rawCompiledVersion().ifPresent(v -> propagated.putIfAbsent(name, v));
-                            parents.putIfAbsent(name, current);
+                            if (observes) {
+                                parents.putIfAbsent(name, current);
+                            }
                             if (!unresolved.contains(name) && !resolved.contains(name)) {
                                 queue.add(name);
-                            } else if (resolved.contains(name)) {
+                            } else if (observes && resolved.contains(name)) {
                                 listener.onDependency(prefix,
                                         currentCoordinate,
                                         moduleCoordinates.get(name),

--- a/sources/build/jenesis/module/ModularJarResolver.java
+++ b/sources/build/jenesis/module/ModularJarResolver.java
@@ -1,6 +1,7 @@
 package build.jenesis.module;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import build.jenesis.Repository;
 import build.jenesis.RepositoryItem;
 import build.jenesis.ResolutionListener;
@@ -28,7 +29,7 @@ public class ModularJarResolver implements Resolver {
                                                      Map<String, Repository> repositories,
                                                      SequencedMap<String, SequencedSet<String>> coordinates,
                                                      SequencedMap<String, String> versions,
-                                                     boolean compile,
+                                                     DependencyScope scope,
                                                      ResolutionListener listener) throws IOException {
         coordinates.forEach((coordinate, exclusions) -> {
             if (!exclusions.isEmpty()) {
@@ -159,7 +160,7 @@ public class ModularJarResolver implements Resolver {
                 }
                 descriptor.requires().stream()
                         .filter(requires -> !requires.accessFlags().contains(AccessFlag.STATIC_PHASE)
-                                || compile && requires.accessFlags().contains(AccessFlag.TRANSITIVE))
+                                || scope == DependencyScope.COMPILE && requires.accessFlags().contains(AccessFlag.TRANSITIVE))
                         .filter(requires -> !requires.name().startsWith("java.") && !requires.name().startsWith("jdk."))
                         .sorted(Comparator.comparing(ModuleDescriptor.Requires::name))
                         .forEach(requires -> {
@@ -187,7 +188,7 @@ public class ModularJarResolver implements Resolver {
             for (String coordinate : unresolved) {
                 unresolvedCoordinates.put(coordinate, Collections.emptyNavigableSet());
             }
-            fallback.dependencies(executor, prefix, repositories, unresolvedCoordinates, hints, compile, listener)
+            fallback.dependencies(executor, prefix, repositories, unresolvedCoordinates, hints, scope, listener)
                     .forEach(dependencies::putIfAbsent);
         }
         return dependencies;

--- a/sources/build/jenesis/module/ModularJarResolver.java
+++ b/sources/build/jenesis/module/ModularJarResolver.java
@@ -41,6 +41,8 @@ public class ModularJarResolver implements Resolver {
         SequencedSet<String> unresolved = new LinkedHashSet<>();
         SequencedMap<String, String> propagated = new LinkedHashMap<>();
         SequencedMap<String, String> hints = new LinkedHashMap<>(versions);
+        Map<String, String> parents = new HashMap<>();
+        Map<String, String> moduleCoordinates = new HashMap<>();
         Queue<String> queue = new ArrayDeque<>(coordinates.sequencedKeySet());
         int runtime = Runtime.version().feature();
         while (!queue.isEmpty()) {
@@ -140,9 +142,18 @@ public class ModularJarResolver implements Resolver {
                             "Expected version " + requested + " for " + current + " but jar declares " + declared);
                 }
                 String version = requested != null ? requested : declared;
-                dependencies.put(prefix + "/" + current + (version == null ? "" : "/" + version),
-                        checksum == null ? "" : checksum);
+                String currentCoordinate = prefix + "/" + current + (version == null ? "" : "/" + version);
+                dependencies.put(currentCoordinate, checksum == null ? "" : checksum);
                 resolved.add(current);
+                moduleCoordinates.put(current, currentCoordinate);
+                String parent = parents.get(current);
+                listener.onDependency(prefix,
+                        parent == null ? null : moduleCoordinates.get(parent),
+                        currentCoordinate,
+                        version,
+                        null,
+                        true,
+                        () -> null);
                 descriptor.requires().stream()
                         .filter(requires -> !requires.accessFlags().contains(AccessFlag.STATIC_PHASE)
                                 || compile && requires.accessFlags().contains(AccessFlag.TRANSITIVE))
@@ -151,8 +162,17 @@ public class ModularJarResolver implements Resolver {
                         .forEach(requires -> {
                             String name = requires.name();
                             requires.rawCompiledVersion().ifPresent(v -> propagated.putIfAbsent(name, v));
+                            parents.putIfAbsent(name, current);
                             if (!unresolved.contains(name) && !resolved.contains(name)) {
                                 queue.add(name);
+                            } else if (resolved.contains(name)) {
+                                listener.onDependency(prefix,
+                                        currentCoordinate,
+                                        moduleCoordinates.get(name),
+                                        null,
+                                        null,
+                                        false,
+                                        () -> null);
                             }
                         });
             }

--- a/sources/build/jenesis/module/ModularProject.java
+++ b/sources/build/jenesis/module/ModularProject.java
@@ -2,6 +2,7 @@ package build.jenesis.module;
 
 import module java.base;
 import build.jenesis.Pinning;
+import build.jenesis.ResolutionListener;
 import build.jenesis.BuildExecutor;
 import build.jenesis.BuildExecutorModule;
 import build.jenesis.BuildStep;
@@ -56,6 +57,7 @@ public class ModularProject implements BuildExecutorModule {
                 null,
                 true,
                 new HashDigestFunction("MD5"),
+                null,
                 assembler);
     }
 
@@ -67,6 +69,7 @@ public class ModularProject implements BuildExecutorModule {
                                            Pinning pinning,
                                            boolean modular,
                                            HashDigestFunction digest,
+                                           Supplier<ResolutionListener> listener,
                                            MultiProjectAssembler<? super ModularModuleDescriptor> assembler) {
         return new MultiProjectModule(new ModularProject(prefix, root, filter, modular),
                 identity -> Optional.of(identity.substring(0, identity.indexOf('/'))),
@@ -91,7 +94,8 @@ public class ModularProject implements BuildExecutorModule {
                                             digest),
                                     scopeInherited.sequencedKeySet());
                             scopeExec.addModule(DEPENDENCIES,
-                                    new DependenciesModule(mergedRepositories, resolvers, scope == DependencyScope.COMPILE, pinning),
+                                    new DependenciesModule(mergedRepositories, resolvers, scope == DependencyScope.COMPILE, pinning)
+                                            .listener(listener),
                                     PREPARE);
                         }, inherited.sequencedKeySet());
                     }

--- a/sources/build/jenesis/module/ModularProject.java
+++ b/sources/build/jenesis/module/ModularProject.java
@@ -94,7 +94,7 @@ public class ModularProject implements BuildExecutorModule {
                                             digest),
                                     scopeInherited.sequencedKeySet());
                             scopeExec.addModule(DEPENDENCIES,
-                                    new DependenciesModule(mergedRepositories, resolvers, scope, pinning)
+                                    new DependenciesModule(mergedRepositories, resolvers, scope).pinning(pinning)
                                             .listener(listener),
                                     PREPARE);
                         }, inherited.sequencedKeySet());

--- a/sources/build/jenesis/module/ModularProject.java
+++ b/sources/build/jenesis/module/ModularProject.java
@@ -18,7 +18,7 @@ import build.jenesis.project.ProjectModule;
 import build.jenesis.project.MultiProjectAssembler;
 import build.jenesis.project.MultiProjectDependencies;
 import build.jenesis.project.MultiProjectModule;
-import build.jenesis.project.DependencyScope;
+import build.jenesis.DependencyScope;
 import build.jenesis.step.Assign;
 import build.jenesis.step.Bind;
 import build.jenesis.step.Inventory;
@@ -94,7 +94,7 @@ public class ModularProject implements BuildExecutorModule {
                                             digest),
                                     scopeInherited.sequencedKeySet());
                             scopeExec.addModule(DEPENDENCIES,
-                                    new DependenciesModule(mergedRepositories, resolvers, scope == DependencyScope.COMPILE, pinning)
+                                    new DependenciesModule(mergedRepositories, resolvers, scope, pinning)
                                             .listener(listener),
                                     PREPARE);
                         }, inherited.sequencedKeySet());

--- a/sources/build/jenesis/project/DependenciesModule.java
+++ b/sources/build/jenesis/project/DependenciesModule.java
@@ -5,6 +5,7 @@ import build.jenesis.Pinning;
 import build.jenesis.BuildExecutor;
 import build.jenesis.BuildExecutorModule;
 import build.jenesis.Repository;
+import build.jenesis.ResolutionListener;
 import build.jenesis.Resolver;
 import build.jenesis.step.Download;
 import build.jenesis.step.Resolve;
@@ -13,25 +14,38 @@ public record DependenciesModule(Map<String, Repository> repositories,
                                  Map<String, Resolver> resolvers,
                                  boolean compile,
                                  Pinning pinning,
-                                 String scope) implements BuildExecutorModule {
+                                 String scope,
+                                 Supplier<ResolutionListener> listener) implements BuildExecutorModule {
 
     public static final String RESOLVED = "resolved", ARTIFACTS = "artifacts";
 
     public DependenciesModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers, boolean compile) {
-        this(repositories, resolvers, compile, null, null);
+        this(repositories, resolvers, compile, null, null, null);
     }
 
     public DependenciesModule(Map<String, Repository> repositories,
                               Map<String, Resolver> resolvers,
                               boolean compile,
                               Pinning pinning) {
-        this(repositories, resolvers, compile, pinning, null);
+        this(repositories, resolvers, compile, pinning, null, null);
+    }
+
+    public DependenciesModule(Map<String, Repository> repositories,
+                              Map<String, Resolver> resolvers,
+                              boolean compile,
+                              Pinning pinning,
+                              String scope) {
+        this(repositories, resolvers, compile, pinning, scope, null);
+    }
+
+    public DependenciesModule listener(Supplier<ResolutionListener> listener) {
+        return new DependenciesModule(repositories, resolvers, compile, pinning, scope, listener);
     }
 
     @Override
     public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
         buildExecutor.addStep(RESOLVED,
-                new Resolve(repositories, resolvers, compile).pinned(pinning != Pinning.IGNORE),
+                new Resolve(repositories, resolvers, compile).pinned(pinning != Pinning.IGNORE).listening(listener),
                 inherited.sequencedKeySet());
         buildExecutor.addStep(ARTIFACTS,
                 new Download(repositories, pinning, scope),

--- a/sources/build/jenesis/project/DependenciesModule.java
+++ b/sources/build/jenesis/project/DependenciesModule.java
@@ -24,19 +24,12 @@ public record DependenciesModule(Map<String, Repository> repositories,
         this(repositories, resolvers, scope, null, null, null);
     }
 
-    public DependenciesModule(Map<String, Repository> repositories,
-                              Map<String, Resolver> resolvers,
-                              DependencyScope scope,
-                              Pinning pinning) {
-        this(repositories, resolvers, scope, pinning, null, null);
+    public DependenciesModule pinning(Pinning pinning) {
+        return new DependenciesModule(repositories, resolvers, scope, pinning, tag, listener);
     }
 
-    public DependenciesModule(Map<String, Repository> repositories,
-                              Map<String, Resolver> resolvers,
-                              DependencyScope scope,
-                              Pinning pinning,
-                              String tag) {
-        this(repositories, resolvers, scope, pinning, tag, null);
+    public DependenciesModule tag(String tag) {
+        return new DependenciesModule(repositories, resolvers, scope, pinning, tag, listener);
     }
 
     public DependenciesModule listener(Supplier<ResolutionListener> listener) {
@@ -49,7 +42,7 @@ public record DependenciesModule(Map<String, Repository> repositories,
                 new Resolve(repositories, resolvers, scope).pinned(pinning != Pinning.IGNORE).listening(listener),
                 inherited.sequencedKeySet());
         buildExecutor.addStep(ARTIFACTS,
-                new Download(repositories, pinning, tag),
+                new Download(repositories).pinning(pinning).tag(tag),
                 RESOLVED);
     }
 }

--- a/sources/build/jenesis/project/DependenciesModule.java
+++ b/sources/build/jenesis/project/DependenciesModule.java
@@ -1,6 +1,7 @@
 package build.jenesis.project;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import build.jenesis.Pinning;
 import build.jenesis.BuildExecutor;
 import build.jenesis.BuildExecutorModule;
@@ -12,43 +13,43 @@ import build.jenesis.step.Resolve;
 
 public record DependenciesModule(Map<String, Repository> repositories,
                                  Map<String, Resolver> resolvers,
-                                 boolean compile,
+                                 DependencyScope scope,
                                  Pinning pinning,
-                                 String scope,
+                                 String tag,
                                  Supplier<ResolutionListener> listener) implements BuildExecutorModule {
 
     public static final String RESOLVED = "resolved", ARTIFACTS = "artifacts";
 
-    public DependenciesModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers, boolean compile) {
-        this(repositories, resolvers, compile, null, null, null);
+    public DependenciesModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers, DependencyScope scope) {
+        this(repositories, resolvers, scope, null, null, null);
     }
 
     public DependenciesModule(Map<String, Repository> repositories,
                               Map<String, Resolver> resolvers,
-                              boolean compile,
+                              DependencyScope scope,
                               Pinning pinning) {
-        this(repositories, resolvers, compile, pinning, null, null);
+        this(repositories, resolvers, scope, pinning, null, null);
     }
 
     public DependenciesModule(Map<String, Repository> repositories,
                               Map<String, Resolver> resolvers,
-                              boolean compile,
+                              DependencyScope scope,
                               Pinning pinning,
-                              String scope) {
-        this(repositories, resolvers, compile, pinning, scope, null);
+                              String tag) {
+        this(repositories, resolvers, scope, pinning, tag, null);
     }
 
     public DependenciesModule listener(Supplier<ResolutionListener> listener) {
-        return new DependenciesModule(repositories, resolvers, compile, pinning, scope, listener);
+        return new DependenciesModule(repositories, resolvers, scope, pinning, tag, listener);
     }
 
     @Override
     public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
         buildExecutor.addStep(RESOLVED,
-                new Resolve(repositories, resolvers, compile).pinned(pinning != Pinning.IGNORE).listening(listener),
+                new Resolve(repositories, resolvers, scope).pinned(pinning != Pinning.IGNORE).listening(listener),
                 inherited.sequencedKeySet());
         buildExecutor.addStep(ARTIFACTS,
-                new Download(repositories, pinning, scope),
+                new Download(repositories, pinning, tag),
                 RESOLVED);
     }
 }

--- a/sources/build/jenesis/project/ExternalModule.java
+++ b/sources/build/jenesis/project/ExternalModule.java
@@ -1,6 +1,7 @@
 package build.jenesis.project;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import build.jenesis.BuildExecutor;
 import build.jenesis.BuildExecutorModule;
 import build.jenesis.BuildStep;
@@ -110,7 +111,7 @@ public class ExternalModule implements BuildExecutorModule {
                 new WriteCoordinates(coordinates, qualifier == null ? base : base + "@" + qualifier),
                 inherited.sequencedKeySet().stream());
         buildExecutor.addModule(DEPENDENCIES,
-                new DependenciesModule(repositories, resolvers, false, pinning,
+                new DependenciesModule(repositories, resolvers, DependencyScope.RUNTIME, pinning,
                         qualifier == null ? null : "module:" + qualifier),
                 COORDINATE);
         buildExecutor.addModule(DELEGATE, (delegateExecutor, delegated) -> {

--- a/sources/build/jenesis/project/ExternalModule.java
+++ b/sources/build/jenesis/project/ExternalModule.java
@@ -111,8 +111,9 @@ public class ExternalModule implements BuildExecutorModule {
                 new WriteCoordinates(coordinates, qualifier == null ? base : base + "@" + qualifier),
                 inherited.sequencedKeySet().stream());
         buildExecutor.addModule(DEPENDENCIES,
-                new DependenciesModule(repositories, resolvers, DependencyScope.RUNTIME, pinning,
-                        qualifier == null ? null : "module:" + qualifier),
+                new DependenciesModule(repositories, resolvers, DependencyScope.RUNTIME)
+                        .pinning(pinning)
+                        .tag(qualifier == null ? null : "module:" + qualifier),
                 COORDINATE);
         buildExecutor.addModule(DELEGATE, (delegateExecutor, delegated) -> {
             Path depArtifacts = delegated.get(PREVIOUS + EXTERNAL_ARTIFACTS).resolve(BuildStep.DEPENDENCIES);

--- a/sources/build/jenesis/project/GroovyCompilerModule.java
+++ b/sources/build/jenesis/project/GroovyCompilerModule.java
@@ -41,12 +41,6 @@ public class GroovyCompilerModule implements BuildExecutorModule {
         this(repositories, resolvers, null, true, "groovy", null);
     }
 
-    public GroovyCompilerModule(Map<String, Repository> repositories,
-                                Map<String, Resolver> resolvers,
-                                Function<List<String>, ? extends ProcessHandler> factory) {
-        this(repositories, resolvers, null, true, "groovy", factory);
-    }
-
     private GroovyCompilerModule(Map<String, Repository> repositories,
                                  Map<String, Resolver> resolvers,
                                  Pinning pinning,
@@ -59,6 +53,10 @@ public class GroovyCompilerModule implements BuildExecutorModule {
         this.includeResources = includeResources;
         this.qualifier = qualifier;
         this.factory = factory;
+    }
+
+    public GroovyCompilerModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
+        return new GroovyCompilerModule(repositories, resolvers, pinning, includeResources, qualifier, factory);
     }
 
     public GroovyCompilerModule pinning(Pinning pinning) {
@@ -81,7 +79,7 @@ public class GroovyCompilerModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(upstream);
         buildExecutor.addStep(RESOLVED, new Resolve(repositories, resolvers, DependencyScope.RUNTIME).pinned(pinning != Pinning.IGNORE), resolveInputs);
-        buildExecutor.addStep(ARTIFACTS, new Download(repositories, pinning, "compiler:" + qualifier), RESOLVED);
+        buildExecutor.addStep(ARTIFACTS, new Download(repositories).pinning(pinning).tag("compiler:" + qualifier), RESOLVED);
         SequencedSet<String> compileInputs = new LinkedHashSet<>();
         compileInputs.add(ARTIFACTS);
         compileInputs.addAll(upstream);

--- a/sources/build/jenesis/project/GroovyCompilerModule.java
+++ b/sources/build/jenesis/project/GroovyCompilerModule.java
@@ -1,6 +1,7 @@
 package build.jenesis.project;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import build.jenesis.Pinning;
 import build.jenesis.BuildExecutor;
 import build.jenesis.BuildExecutorModule;
@@ -79,7 +80,7 @@ public class GroovyCompilerModule implements BuildExecutorModule {
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(upstream);
-        buildExecutor.addStep(RESOLVED, new Resolve(repositories, resolvers, false).pinned(pinning != Pinning.IGNORE), resolveInputs);
+        buildExecutor.addStep(RESOLVED, new Resolve(repositories, resolvers, DependencyScope.RUNTIME).pinned(pinning != Pinning.IGNORE), resolveInputs);
         buildExecutor.addStep(ARTIFACTS, new Download(repositories, pinning, "compiler:" + qualifier), RESOLVED);
         SequencedSet<String> compileInputs = new LinkedHashSet<>();
         compileInputs.add(ARTIFACTS);

--- a/sources/build/jenesis/project/InternalModule.java
+++ b/sources/build/jenesis/project/InternalModule.java
@@ -41,25 +41,21 @@ public class InternalModule implements BuildExecutorModule {
                           String qualifier,
                           Path source) {
         this(prefix,
-                qualifier,
                 source,
                 Map.of(prefix, new JenesisModuleRepository(true).prepend(JenesisModuleRepository.ofLocal())),
-                Map.of(prefix, new ModularJarResolver(true)));
-    }
-
-    public InternalModule(String prefix,
-                          String qualifier,
-                          Path source,
-                          Map<String, Repository> repositories,
-                          Map<String, Resolver> resolvers) {
-        this(prefix,
-                source,
-                repositories,
-                resolvers,
+                Map.of(prefix, new ModularJarResolver(true)),
                 Collections.emptyNavigableSet(),
                 null,
                 qualifier,
                 null);
+    }
+
+    public InternalModule repositories(Map<String, Repository> repositories) {
+        return new InternalModule(prefix, source, repositories, resolvers, additionalDependencies, buildModuleName, qualifier, pinning);
+    }
+
+    public InternalModule resolvers(Map<String, Resolver> resolvers) {
+        return new InternalModule(prefix, source, repositories, resolvers, additionalDependencies, buildModuleName, qualifier, pinning);
     }
 
     private InternalModule(String prefix,
@@ -151,8 +147,9 @@ public class InternalModule implements BuildExecutorModule {
                     new ParseModuleInfo(prefix, compile, additionalDependencies, qualifier),
                     Stream.concat(Stream.of(SOURCE), inherited.sequencedKeySet().stream()));
             buildExecutor.addModule(scope.label(),
-                    new DependenciesModule(repositories, resolvers, scope, pinning,
-                            qualifier == null ? null : "module:" + qualifier),
+                    new DependenciesModule(repositories, resolvers, scope)
+                            .pinning(pinning)
+                            .tag(qualifier == null ? null : "module:" + qualifier),
                     requiresId);
         }
         buildExecutor.addModule(JAVA, new JavaToolchainModule(), SOURCE, COMPILE_ARTIFACTS);

--- a/sources/build/jenesis/project/InternalModule.java
+++ b/sources/build/jenesis/project/InternalModule.java
@@ -1,6 +1,7 @@
 package build.jenesis.project;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import build.jenesis.Pinning;
 import build.jenesis.BuildExecutor;
 import build.jenesis.BuildExecutorModule;
@@ -150,7 +151,7 @@ public class InternalModule implements BuildExecutorModule {
                     new ParseModuleInfo(prefix, compile, additionalDependencies, qualifier),
                     Stream.concat(Stream.of(SOURCE), inherited.sequencedKeySet().stream()));
             buildExecutor.addModule(scope.label(),
-                    new DependenciesModule(repositories, resolvers, compile, pinning,
+                    new DependenciesModule(repositories, resolvers, scope, pinning,
                             qualifier == null ? null : "module:" + qualifier),
                     requiresId);
         }

--- a/sources/build/jenesis/project/JavaMultiProjectAssembler.java
+++ b/sources/build/jenesis/project/JavaMultiProjectAssembler.java
@@ -1,6 +1,7 @@
 package build.jenesis.project;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import build.jenesis.Pinning;
 import build.jenesis.BuildExecutorModule;
 import build.jenesis.BuildStep;

--- a/sources/build/jenesis/project/JavaMultiProjectAssembler.java
+++ b/sources/build/jenesis/project/JavaMultiProjectAssembler.java
@@ -95,12 +95,12 @@ public record JavaMultiProjectAssembler(boolean process,
             sub.addStep("prepare",
                     new Prepare(descriptor.modulePath()),
                     outerInherited.sequencedKeySet().stream());
-            sub.addModule("binary", new JavaToolchainModule(
-                    new InferredCompilerChainModule(repositories, resolvers)
+            sub.addModule("binary", new JavaToolchainModule()
+                    .compiler(new InferredCompilerChainModule(repositories, resolvers)
                             .process(process)
                             .pinning(descriptor.pinning())
-                            .modulePath(descriptor.modulePath()),
-                    (process ? Jar.process(Jar.Sort.CLASSES) : Jar.tool(Jar.Sort.CLASSES)).asModule("jar")),
+                            .modulePath(descriptor.modulePath()))
+                    .archiver((process ? Jar.process(Jar.Sort.CLASSES) : Jar.tool(Jar.Sort.CLASSES)).asModule("jar")),
                     Stream.concat(
                             Stream.of("prepare"),
                             Stream.concat(inputs(descriptor), descriptor.resources().stream())));

--- a/sources/build/jenesis/project/JavaToolchainModule.java
+++ b/sources/build/jenesis/project/JavaToolchainModule.java
@@ -19,8 +19,12 @@ public record JavaToolchainModule(BuildExecutorModule compiler,
         this(Javac.tool().asModule("javac"), null, null, Jar.tool(Jar.Sort.CLASSES).asModule("jar"));
     }
 
-    public JavaToolchainModule(BuildExecutorModule compiler, BuildExecutorModule archiver) {
-        this(compiler, null, null, archiver);
+    public JavaToolchainModule compiler(BuildExecutorModule compiler) {
+        return new JavaToolchainModule(compiler, transformer, validator, archiver);
+    }
+
+    public JavaToolchainModule archiver(BuildExecutorModule archiver) {
+        return new JavaToolchainModule(compiler, transformer, validator, archiver);
     }
 
     public JavaToolchainModule transformer(BuildExecutorModule transformer) {

--- a/sources/build/jenesis/project/KotlinCompilerModule.java
+++ b/sources/build/jenesis/project/KotlinCompilerModule.java
@@ -1,6 +1,7 @@
 package build.jenesis.project;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import build.jenesis.Pinning;
 import build.jenesis.BuildExecutor;
 import build.jenesis.BuildExecutorModule;
@@ -80,7 +81,7 @@ public class KotlinCompilerModule implements BuildExecutorModule {
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(upstream);
-        buildExecutor.addStep(RESOLVED, new Resolve(repositories, resolvers, false).pinned(pinning != Pinning.IGNORE), resolveInputs);
+        buildExecutor.addStep(RESOLVED, new Resolve(repositories, resolvers, DependencyScope.RUNTIME).pinned(pinning != Pinning.IGNORE), resolveInputs);
         buildExecutor.addStep(ARTIFACTS, new Download(repositories, pinning, "compiler:" + qualifier), RESOLVED);
         SequencedSet<String> compileInputs = new LinkedHashSet<>();
         compileInputs.add(ARTIFACTS);

--- a/sources/build/jenesis/project/KotlinCompilerModule.java
+++ b/sources/build/jenesis/project/KotlinCompilerModule.java
@@ -42,12 +42,6 @@ public class KotlinCompilerModule implements BuildExecutorModule {
         this(repositories, resolvers, null, true, "kotlin", null);
     }
 
-    public KotlinCompilerModule(Map<String, Repository> repositories,
-                                Map<String, Resolver> resolvers,
-                                Function<List<String>, ? extends ProcessHandler> factory) {
-        this(repositories, resolvers, null, true, "kotlin", factory);
-    }
-
     private KotlinCompilerModule(Map<String, Repository> repositories,
                                  Map<String, Resolver> resolvers,
                                  Pinning pinning,
@@ -60,6 +54,10 @@ public class KotlinCompilerModule implements BuildExecutorModule {
         this.includeResources = includeResources;
         this.qualifier = qualifier;
         this.factory = factory;
+    }
+
+    public KotlinCompilerModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
+        return new KotlinCompilerModule(repositories, resolvers, pinning, includeResources, qualifier, factory);
     }
 
     public KotlinCompilerModule pinning(Pinning pinning) {
@@ -82,7 +80,7 @@ public class KotlinCompilerModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(upstream);
         buildExecutor.addStep(RESOLVED, new Resolve(repositories, resolvers, DependencyScope.RUNTIME).pinned(pinning != Pinning.IGNORE), resolveInputs);
-        buildExecutor.addStep(ARTIFACTS, new Download(repositories, pinning, "compiler:" + qualifier), RESOLVED);
+        buildExecutor.addStep(ARTIFACTS, new Download(repositories).pinning(pinning).tag("compiler:" + qualifier), RESOLVED);
         SequencedSet<String> compileInputs = new LinkedHashSet<>();
         compileInputs.add(ARTIFACTS);
         compileInputs.addAll(upstream);

--- a/sources/build/jenesis/project/MultiProjectDependencies.java
+++ b/sources/build/jenesis/project/MultiProjectDependencies.java
@@ -1,6 +1,7 @@
 package build.jenesis.project;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import build.jenesis.BuildStep;
 import build.jenesis.BuildStepArgument;
 import build.jenesis.BuildStepContext;

--- a/sources/build/jenesis/project/MultiProjectModule.java
+++ b/sources/build/jenesis/project/MultiProjectModule.java
@@ -63,8 +63,8 @@ public record MultiProjectModule(BuildExecutorModule identifier,
                 }
             }
             process.addStep(GROUP,
-                    new Group(identifier -> Optional.of(modules.get(identifier)),
-                            BuildStep.REQUIRES),
+                    new Group(identifier -> Optional.of(modules.get(identifier)))
+                            .requiresPath(BuildStep.REQUIRES),
                     modules.sequencedKeySet());
             process.addModule(MODULE, (build, paths) -> {
                 SequencedMap<String, SequencedSet<String>> projects = new LinkedHashMap<>();

--- a/sources/build/jenesis/project/ProjectModule.java
+++ b/sources/build/jenesis/project/ProjectModule.java
@@ -1,6 +1,7 @@
 package build.jenesis.project;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 
 public interface ProjectModule {
 

--- a/sources/build/jenesis/project/ProjectModuleDescriptor.java
+++ b/sources/build/jenesis/project/ProjectModuleDescriptor.java
@@ -1,6 +1,7 @@
 package build.jenesis.project;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import build.jenesis.Pinning;
 import build.jenesis.BuildExecutorModule;
 import build.jenesis.PathPlacement;

--- a/sources/build/jenesis/project/ScalaCompilerModule.java
+++ b/sources/build/jenesis/project/ScalaCompilerModule.java
@@ -1,6 +1,7 @@
 package build.jenesis.project;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import build.jenesis.Pinning;
 import build.jenesis.BuildExecutor;
 import build.jenesis.BuildExecutorModule;
@@ -80,7 +81,7 @@ public class ScalaCompilerModule implements BuildExecutorModule {
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(upstream);
-        buildExecutor.addStep(RESOLVED, new Resolve(repositories, resolvers, false).pinned(pinning != Pinning.IGNORE), resolveInputs);
+        buildExecutor.addStep(RESOLVED, new Resolve(repositories, resolvers, DependencyScope.RUNTIME).pinned(pinning != Pinning.IGNORE), resolveInputs);
         buildExecutor.addStep(ARTIFACTS, new Download(repositories, pinning, "compiler:" + qualifier), RESOLVED);
         SequencedSet<String> compileInputs = new LinkedHashSet<>();
         compileInputs.add(ARTIFACTS);

--- a/sources/build/jenesis/project/ScalaCompilerModule.java
+++ b/sources/build/jenesis/project/ScalaCompilerModule.java
@@ -42,12 +42,6 @@ public class ScalaCompilerModule implements BuildExecutorModule {
         this(repositories, resolvers, null, true, "scala", null);
     }
 
-    public ScalaCompilerModule(Map<String, Repository> repositories,
-                               Map<String, Resolver> resolvers,
-                               Function<List<String>, ? extends ProcessHandler> factory) {
-        this(repositories, resolvers, null, true, "scala", factory);
-    }
-
     private ScalaCompilerModule(Map<String, Repository> repositories,
                                 Map<String, Resolver> resolvers,
                                 Pinning pinning,
@@ -60,6 +54,10 @@ public class ScalaCompilerModule implements BuildExecutorModule {
         this.includeResources = includeResources;
         this.qualifier = qualifier;
         this.factory = factory;
+    }
+
+    public ScalaCompilerModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
+        return new ScalaCompilerModule(repositories, resolvers, pinning, includeResources, qualifier, factory);
     }
 
     public ScalaCompilerModule pinning(Pinning pinning) {
@@ -82,7 +80,7 @@ public class ScalaCompilerModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(upstream);
         buildExecutor.addStep(RESOLVED, new Resolve(repositories, resolvers, DependencyScope.RUNTIME).pinned(pinning != Pinning.IGNORE), resolveInputs);
-        buildExecutor.addStep(ARTIFACTS, new Download(repositories, pinning, "compiler:" + qualifier), RESOLVED);
+        buildExecutor.addStep(ARTIFACTS, new Download(repositories).pinning(pinning).tag("compiler:" + qualifier), RESOLVED);
         SequencedSet<String> compileInputs = new LinkedHashSet<>();
         compileInputs.add(ARTIFACTS);
         compileInputs.addAll(upstream);

--- a/sources/build/jenesis/project/TestModule.java
+++ b/sources/build/jenesis/project/TestModule.java
@@ -313,7 +313,7 @@ public class TestModule implements BuildExecutorModule {
         resolveInputs.add(RESOLVED);
         resolveInputs.addAll(upstream);
         buildExecutor.addStep(REQUIRED, new Resolve(repositories, resolvers, DependencyScope.RUNTIME).pinned(pinning != Pinning.IGNORE), resolveInputs);
-        buildExecutor.addStep(ARTIFACTS, new Download(repositories, pinning), REQUIRED);
+        buildExecutor.addStep(ARTIFACTS, new Download(repositories).pinning(pinning), REQUIRED);
         buildExecutor.addStep(EXECUTED, new Run(
                         factory,
                         resolved,

--- a/sources/build/jenesis/project/TestModule.java
+++ b/sources/build/jenesis/project/TestModule.java
@@ -1,6 +1,7 @@
 package build.jenesis.project;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import build.jenesis.Pinning;
 import build.jenesis.BuildExecutor;
 import build.jenesis.BuildExecutorModule;
@@ -311,7 +312,7 @@ public class TestModule implements BuildExecutorModule {
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(RESOLVED);
         resolveInputs.addAll(upstream);
-        buildExecutor.addStep(REQUIRED, new Resolve(repositories, resolvers, false).pinned(pinning != Pinning.IGNORE), resolveInputs);
+        buildExecutor.addStep(REQUIRED, new Resolve(repositories, resolvers, DependencyScope.RUNTIME).pinned(pinning != Pinning.IGNORE), resolveInputs);
         buildExecutor.addStep(ARTIFACTS, new Download(repositories, pinning), REQUIRED);
         buildExecutor.addStep(EXECUTED, new Run(
                         factory,

--- a/sources/build/jenesis/step/Assign.java
+++ b/sources/build/jenesis/step/Assign.java
@@ -12,16 +12,20 @@ public class Assign implements BuildStep {
     private final BiFunction<Set<String>, SequencedSet<Path>, Map<String, Path>> assigner;
 
     public Assign() {
-        assigner = (BiFunction<Set<String>, SequencedSet<Path>, Map<String, Path>> & Serializable) ((coordinates, files) -> {
+        this((BiFunction<Set<String>, SequencedSet<Path>, Map<String, Path>> & Serializable) ((coordinates, files) -> {
             if (files.size() != 1) {
                 throw new IllegalArgumentException("Expected exactly one artifact: " + files);
             }
             return coordinates.stream().collect(Collectors.toMap(Function.identity(), _ -> files.getFirst()));
-        });
+        }));
     }
 
-    public <F extends BiFunction<Set<String>, SequencedSet<Path>, Map<String, Path>> & Serializable> Assign(F assigner) {
+    private Assign(BiFunction<Set<String>, SequencedSet<Path>, Map<String, Path>> assigner) {
         this.assigner = assigner;
+    }
+
+    public <F extends BiFunction<Set<String>, SequencedSet<Path>, Map<String, Path>> & Serializable> Assign assigner(F assigner) {
+        return new Assign(assigner);
     }
 
     @Override

--- a/sources/build/jenesis/step/Download.java
+++ b/sources/build/jenesis/step/Download.java
@@ -20,14 +20,18 @@ public class Download implements DependencyProcessingBuildStep {
         this(repositories, null, null);
     }
 
-    public Download(Map<String, Repository> repositories, Pinning pinning) {
-        this(repositories, pinning, null);
-    }
-
-    public Download(Map<String, Repository> repositories, Pinning pinning, String tag) {
+    private Download(Map<String, Repository> repositories, Pinning pinning, String tag) {
         this.repositories = repositories;
         this.pinning = pinning;
         this.tag = tag;
+    }
+
+    public Download pinning(Pinning pinning) {
+        return new Download(repositories, pinning, tag);
+    }
+
+    public Download tag(String tag) {
+        return new Download(repositories, pinning, tag);
     }
 
     @Override

--- a/sources/build/jenesis/step/Download.java
+++ b/sources/build/jenesis/step/Download.java
@@ -14,7 +14,7 @@ public class Download implements DependencyProcessingBuildStep {
 
     private final transient Map<String, Repository> repositories;
     private final Pinning pinning;
-    private final String scope;
+    private final String tag;
 
     public Download(Map<String, Repository> repositories) {
         this(repositories, null, null);
@@ -24,10 +24,10 @@ public class Download implements DependencyProcessingBuildStep {
         this(repositories, pinning, null);
     }
 
-    public Download(Map<String, Repository> repositories, Pinning pinning, String scope) {
+    public Download(Map<String, Repository> repositories, Pinning pinning, String tag) {
         this.repositories = repositories;
         this.pinning = pinning;
-        this.scope = scope;
+        this.tag = tag;
     }
 
     @Override
@@ -135,10 +135,10 @@ public class Download implements DependencyProcessingBuildStep {
             }
         }
         locations.store(context.next().resolve(LOCATIONS));
-        if (scope != null) {
+        if (tag != null) {
             SequencedProperties scopes = new SequencedProperties();
             for (String coordinate : locations.stringPropertyNames()) {
-                scopes.setProperty(coordinate, scope);
+                scopes.setProperty(coordinate, tag);
             }
             scopes.store(context.next().resolve(SCOPES));
         }

--- a/sources/build/jenesis/step/Group.java
+++ b/sources/build/jenesis/step/Group.java
@@ -19,9 +19,13 @@ public class Group implements BuildStep {
         this(identification, REQUIRES);
     }
 
-    public <F extends Function<String, Optional<String>> & Serializable> Group(F identification, String requiresPath) {
+    private Group(Function<String, Optional<String>> identification, String requiresPath) {
         this.identification = identification;
         this.requiresPath = requiresPath;
+    }
+
+    public Group requiresPath(String requiresPath) {
+        return new Group(identification, requiresPath);
     }
 
     @Override

--- a/sources/build/jenesis/step/Resolve.java
+++ b/sources/build/jenesis/step/Resolve.java
@@ -3,6 +3,7 @@ package build.jenesis.step;
 import module java.base;
 import build.jenesis.BuildStepArgument;
 import build.jenesis.BuildStepContext;
+import build.jenesis.DependencyScope;
 import build.jenesis.Repository;
 import build.jenesis.ResolutionListener;
 import build.jenesis.Resolver;
@@ -14,32 +15,32 @@ public class Resolve implements DependencyProcessingBuildStep {
 
     private final transient Map<String, Repository> repositories;
     private final Map<String, Resolver> resolvers;
-    private final boolean compile;
+    private final DependencyScope scope;
     private final boolean pinned;
     private final transient Supplier<ResolutionListener> listener;
 
-    public Resolve(Map<String, Repository> repositories, Map<String, Resolver> resolvers, boolean compile) {
-        this(repositories, resolvers, compile, true, null);
+    public Resolve(Map<String, Repository> repositories, Map<String, Resolver> resolvers, DependencyScope scope) {
+        this(repositories, resolvers, scope, true, null);
     }
 
     private Resolve(Map<String, Repository> repositories,
                     Map<String, Resolver> resolvers,
-                    boolean compile,
+                    DependencyScope scope,
                     boolean pinned,
                     Supplier<ResolutionListener> listener) {
         this.repositories = repositories;
         this.resolvers = new LinkedHashMap<>(resolvers);
-        this.compile = compile;
+        this.scope = scope;
         this.pinned = pinned;
         this.listener = listener;
     }
 
     public Resolve pinned(boolean pinned) {
-        return new Resolve(repositories, resolvers, compile, pinned, listener);
+        return new Resolve(repositories, resolvers, scope, pinned, listener);
     }
 
     public Resolve listening(Supplier<ResolutionListener> listener) {
-        return new Resolve(repositories, resolvers, compile, pinned, listener);
+        return new Resolve(repositories, resolvers, scope, pinned, listener);
     }
 
     @Override
@@ -101,10 +102,10 @@ public class Resolve implements DependencyProcessingBuildStep {
             }
             SequencedMap<String, String> resolved;
             if (listener == null) {
-                resolved = resolver.dependencies(executor, group.getKey(), repositories, coordinates, groupVersions, compile);
+                resolved = resolver.dependencies(executor, group.getKey(), repositories, coordinates, groupVersions, scope);
             } else {
                 ResolutionListener current = listener.get();
-                resolved = resolver.dependencies(executor, group.getKey(), repositories, coordinates, groupVersions, compile, current);
+                resolved = resolver.dependencies(executor, group.getKey(), repositories, coordinates, groupVersions, scope, current);
                 current.onResolved();
             }
             for (Map.Entry<String, String> entry : resolved.entrySet()) {

--- a/sources/build/jenesis/step/Resolve.java
+++ b/sources/build/jenesis/step/Resolve.java
@@ -4,6 +4,7 @@ import module java.base;
 import build.jenesis.BuildStepArgument;
 import build.jenesis.BuildStepContext;
 import build.jenesis.Repository;
+import build.jenesis.ResolutionListener;
 import build.jenesis.Resolver;
 import build.jenesis.SequencedProperties;
 
@@ -15,24 +16,37 @@ public class Resolve implements DependencyProcessingBuildStep {
     private final Map<String, Resolver> resolvers;
     private final boolean compile;
     private final boolean pinned;
+    private final transient Supplier<ResolutionListener> listener;
 
     public Resolve(Map<String, Repository> repositories, Map<String, Resolver> resolvers, boolean compile) {
-        this(repositories, resolvers, compile, true);
+        this(repositories, resolvers, compile, true, null);
     }
 
-    private Resolve(Map<String, Repository> repositories, Map<String, Resolver> resolvers, boolean compile, boolean pinned) {
+    private Resolve(Map<String, Repository> repositories,
+                    Map<String, Resolver> resolvers,
+                    boolean compile,
+                    boolean pinned,
+                    Supplier<ResolutionListener> listener) {
         this.repositories = repositories;
         this.resolvers = new LinkedHashMap<>(resolvers);
         this.compile = compile;
         this.pinned = pinned;
+        this.listener = listener;
     }
 
     public Resolve pinned(boolean pinned) {
-        return new Resolve(repositories, resolvers, compile, pinned);
+        return new Resolve(repositories, resolvers, compile, pinned, listener);
+    }
+
+    public Resolve listening(Supplier<ResolutionListener> listener) {
+        return new Resolve(repositories, resolvers, compile, pinned, listener);
     }
 
     @Override
     public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+        if (listener != null) {
+            return true;
+        }
         return arguments.values().stream().anyMatch(argument -> argument.hasChanged(
                 Path.of(REQUIRES),
                 Path.of(VERSIONS),
@@ -85,13 +99,15 @@ public class Resolve implements DependencyProcessingBuildStep {
                     versions.getOrDefault(managed, new LinkedHashMap<>()).forEach(groupVersions::putIfAbsent);
                 }
             }
-            for (Map.Entry<String, String> entry : resolver.dependencies(
-                    executor,
-                    group.getKey(),
-                    repositories,
-                    coordinates,
-                    groupVersions,
-                    compile).entrySet()) {
+            SequencedMap<String, String> resolved;
+            if (listener == null) {
+                resolved = resolver.dependencies(executor, group.getKey(), repositories, coordinates, groupVersions, compile);
+            } else {
+                ResolutionListener current = listener.get();
+                resolved = resolver.dependencies(executor, group.getKey(), repositories, coordinates, groupVersions, compile, current);
+                current.onResolved();
+            }
+            for (Map.Entry<String, String> entry : resolved.entrySet()) {
                 String value;
                 if (Objects.equals(group.getKey(), entry.getKey().substring(0, entry.getKey().indexOf('/')))) {
                     String declared = group.getValue().get(entry.getKey().substring(entry.getKey().indexOf('/') + 1));

--- a/tests/build/jenesis/test/DependencyTreeReportTest.java
+++ b/tests/build/jenesis/test/DependencyTreeReportTest.java
@@ -1,0 +1,85 @@
+package build.jenesis.test;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.DependencyTreeReport;
+import build.jenesis.ResolutionContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DependencyTreeReportTest {
+
+    private ByteArrayOutputStream bytes;
+    private DependencyTreeReport report;
+
+    @BeforeEach
+    public void setUp() {
+        bytes = new ByteArrayOutputStream();
+        report = new DependencyTreeReport(new PrintStream(bytes, true, StandardCharsets.UTF_8));
+    }
+
+    private String output() {
+        return bytes.toString(StandardCharsets.UTF_8).replaceAll("\\[[0-9;]*m", "");
+    }
+
+    @Test
+    public void renders_followed_tree_with_connectors_versions_and_scope() {
+        report.onDependency("maven", null, "maven/g/a/1.0", "1.0", "compile", true, () -> null);
+        report.onDependency("maven", "maven/g/a/1.0", "maven/g/b/2.0", "2.0", "compile", true, () -> null);
+        report.onDependency("maven", "maven/g/a/1.0", "maven/g/d/4.0", "4.0", "compile", true, () -> null);
+        report.onDependency("maven", "maven/g/b/2.0", "maven/g/c/3.0", "3.0", "runtime", true, () -> null);
+        report.onResolved();
+        String text = output();
+        assertThat(text).contains("Dependency tree:");
+        assertThat(text).contains("maven/g/a 1.0 [compile]");
+        assertThat(text).contains("├─ maven/g/b 2.0 [compile]");
+        assertThat(text).contains("│  └─ maven/g/c 3.0 [runtime]");
+        assertThat(text).contains("└─ maven/g/d 4.0 [compile]");
+    }
+
+    @Test
+    public void marks_not_followed_duplicates_and_does_not_expand_them() {
+        report.onDependency("maven", null, "maven/g/a/1.0", "1.0", "compile", true, () -> null);
+        report.onDependency("maven", "maven/g/a/1.0", "maven/g/b/2.0", "2.0", "compile", true, () -> null);
+        report.onDependency("maven", "maven/g/b/2.0", "maven/g/c/3.0", "3.0", "compile", true, () -> null);
+        report.onDependency("maven", "maven/g/a/1.0", "maven/g/c/3.0", "3.0", "compile", false, () -> null);
+        report.onResolved();
+        String text = output();
+        assertThat(text).contains("maven/g/c 3.0 [compile] (*)");
+        assertThat(text.split("\\(\\*\\)", -1).length - 1).isEqualTo(1);
+    }
+
+    @Test
+    public void annotates_the_negotiated_version_when_it_differs_from_the_requested_one() {
+        report.onDependency("maven", null, "maven/g/a/[1,2]", "[1,2]", "compile", true, () -> null);
+        report.onResolution("maven", "maven/g/a", "2");
+        report.onResolved();
+        assertThat(output()).contains("maven/g/a [1,2] -> 2");
+    }
+
+    @Test
+    public void renders_resolution_context_metadata() {
+        report.onDependency("module", null, "module/org.foo/1.0", "1.0", null, true,
+                () -> new ResolutionContext("org.foo", "1.0", Boolean.TRUE, "maven/org.foo/foo/1.0"));
+        report.onResolved();
+        String text = output();
+        assertThat(text).contains("(module org.foo@1.0, automatic)");
+        assertThat(text).contains("=> maven/org.foo/foo/1.0");
+    }
+
+    @Test
+    public void lists_resolved_dependencies_below_the_tree() {
+        report.onDependency("maven", null, "maven/g/a/1.0", "1.0", "compile", true, () -> null);
+        report.onResolution("maven", "maven/g/a", "1.0");
+        report.onResolved();
+        String text = output();
+        assertThat(text).contains("Resolved dependencies:");
+        assertThat(text).contains("maven/g/a -> 1.0");
+    }
+
+    @Test
+    public void prints_nothing_when_no_dependencies_were_observed() {
+        report.onResolved();
+        assertThat(bytes.toString(StandardCharsets.UTF_8)).isEmpty();
+    }
+}

--- a/tests/build/jenesis/test/ExecuteTest.java
+++ b/tests/build/jenesis/test/ExecuteTest.java
@@ -212,7 +212,7 @@ public class ExecuteTest {
     }
 
     private Project.Layout layoutWithModules(Map<String, Path> modules) {
-        return (executor, _, _) -> {
+        return (executor, _, _, _) -> {
             executor.addModule(Project.BUILD, (sub, _) -> {
                 for (Map.Entry<String, Path> entry : modules.entrySet()) {
                     sub.addModule(entry.getKey(), (inner, _) -> inner.addSource("manifests", entry.getValue()));

--- a/tests/build/jenesis/test/ProjectTest.java
+++ b/tests/build/jenesis/test/ProjectTest.java
@@ -202,7 +202,7 @@ public class ProjectTest {
                         BuildStepHashFunction.ofSerializationDigest("MD5"),
                         BuildExecutorCallback.nop(), false),
                 project,
-                new JavaMultiProjectAssembler());
+                new JavaMultiProjectAssembler(), null);
         assertThat(resolver.apply("sources")).isEqualTo("build/maven/compose/module/module-sources");
         assertThat(resolver.apply("")).isEqualTo("build/maven/compose/module/module-");
     }
@@ -218,7 +218,7 @@ public class ProjectTest {
                         BuildStepHashFunction.ofSerializationDigest("MD5"),
                         BuildExecutorCallback.nop(), false),
                 project,
-                new JavaMultiProjectAssembler());
+                new JavaMultiProjectAssembler(), null);
         assertThat(resolver.apply("sources")).isEqualTo("build/modules/compose/module/module-sources");
         assertThat(resolver.apply("")).isEqualTo("build/modules/compose/module/module-");
     }
@@ -234,7 +234,7 @@ public class ProjectTest {
                         BuildStepHashFunction.ofSerializationDigest("MD5"),
                         BuildExecutorCallback.nop(), false),
                 project,
-                new JavaMultiProjectAssembler());
+                new JavaMultiProjectAssembler(), null);
         assertThat(resolver.apply("sources/compile/dependencies/resolved"))
                 .isEqualTo("build/maven/compose/module/module-sources/compile/dependencies/resolved");
         assertThat(resolver.apply("/compile"))
@@ -252,7 +252,7 @@ public class ProjectTest {
                         BuildStepHashFunction.ofSerializationDigest("MD5"),
                         BuildExecutorCallback.nop(), false),
                 project,
-                new JavaMultiProjectAssembler());
+                new JavaMultiProjectAssembler(), null);
         assertThat(resolver.apply("sources/compile/dependencies/resolved"))
                 .isEqualTo("build/modules/compose/module/module-sources/compile/dependencies/resolved");
         assertThat(resolver.apply("/compile"))
@@ -270,7 +270,7 @@ public class ProjectTest {
                         BuildStepHashFunction.ofSerializationDigest("MD5"),
                         BuildExecutorCallback.nop(), false),
                 project,
-                new JavaMultiProjectAssembler());
+                new JavaMultiProjectAssembler(), null);
         assertThat(resolver.apply("sources/compile/dependencies/resolved"))
                 .isEqualTo("build/modules/compose/module/module-sources/compile/dependencies/resolved");
         assertThat(resolver.apply("/compile"))
@@ -287,7 +287,7 @@ public class ProjectTest {
                 BuildStepHashFunction.ofSerializationDigest("MD5"),
                 BuildExecutorCallback.nop(), false);
 
-        Project.Layout.MODULAR.apply(executor, project, new JavaMultiProjectAssembler());
+        Project.Layout.MODULAR.apply(executor, project, new JavaMultiProjectAssembler(), null);
 
         // replaceStep throws when nothing is registered at the identity, so a no-throw call proves
         // the layout wired the `export` registration.
@@ -305,7 +305,7 @@ public class ProjectTest {
                         BuildStepHashFunction.ofSerializationDigest("MD5"),
                         BuildExecutorCallback.nop(), false),
                 project,
-                new JavaMultiProjectAssembler());
+                new JavaMultiProjectAssembler(), null);
         assertThat(resolver.apply("sources")).isEqualTo("build/modules/compose/module/module-sources");
         assertThat(resolver.apply("")).isEqualTo("build/modules/compose/module/module-");
     }
@@ -314,7 +314,7 @@ public class ProjectTest {
     public void build_returns_paths_for_the_default_target() throws IOException {
         Path target = Files.createDirectory(root.resolve("target"));
         Path source = Files.createDirectory(root.resolve("source"));
-        Project.Layout layout = (executor, _, _) -> {
+        Project.Layout layout = (executor, _, _, _) -> {
             executor.addSource(Project.BUILD, source);
             return name -> name;
         };
@@ -331,7 +331,7 @@ public class ProjectTest {
         Path target = Files.createDirectory(root.resolve("target"));
         Path alpha = Files.createDirectory(root.resolve("alpha"));
         Path beta = Files.createDirectory(root.resolve("beta"));
-        Project.Layout layout = (executor, _, _) -> {
+        Project.Layout layout = (executor, _, _, _) -> {
             executor.addSource("alpha", alpha);
             executor.addSource("beta", beta);
             return name -> name;
@@ -348,7 +348,7 @@ public class ProjectTest {
     public void build_resolves_plus_prefixed_selectors_via_the_layout() throws IOException {
         Path target = Files.createDirectory(root.resolve("target"));
         Path source = Files.createDirectory(root.resolve("source"));
-        Project.Layout layout = (executor, _, _) -> {
+        Project.Layout layout = (executor, _, _, _) -> {
             executor.addSource("resolved", source);
             return name -> "resolved";
         };

--- a/tests/build/jenesis/test/maven/MavenModuleResolverTest.java
+++ b/tests/build/jenesis/test/maven/MavenModuleResolverTest.java
@@ -1,6 +1,7 @@
 package build.jenesis.test.maven;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import module org.junit.jupiter.api;
 import build.jenesis.Repository;
 import build.jenesis.RepositoryItem;
@@ -40,7 +41,7 @@ public class MavenModuleResolverTest {
                 Map.of("maven", new MavenDefaultRepository(mavenRepoFolder.toUri(), null, Map.of(), _ -> {})),
                 new LinkedHashMap<>(Map.of("foo.bar", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
 
         assertThat(resolved).containsExactly(Map.entry("maven/org.example/example-core/1.2.3", ""));
         assertThat(fetched).containsOnlyKeys("foo.bar:pom");
@@ -62,7 +63,7 @@ public class MavenModuleResolverTest {
                 Map.of("maven", new MavenDefaultRepository(mavenRepoFolder.toUri(), null, Map.of(), _ -> {})),
                 new LinkedHashMap<>(Map.of("foo.bar", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(Map.of("foo.bar", "9.9")),
-                true);
+                DependencyScope.COMPILE);
 
         assertThat(resolved).containsExactly(Map.entry("maven/org.example/example-core/9.9", ""));
         assertThat(fetched).containsOnlyKeys("foo.bar/9.9:pom");
@@ -83,7 +84,7 @@ public class MavenModuleResolverTest {
                 Map.of("maven", new MavenDefaultRepository(mavenRepoFolder.toUri(), null, Map.of(), _ -> {})),
                 new LinkedHashMap<>(Map.of("foo.bar", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(Map.of("foo.bar", "1.0 SHA-256/deadbeef")),
-                true);
+                DependencyScope.COMPILE);
 
         assertThat(resolved).containsExactly(Map.entry("maven/org.example/example-core/1.0", "SHA-256/deadbeef"));
     }
@@ -116,7 +117,7 @@ public class MavenModuleResolverTest {
                 Map.of("maven", new MavenDefaultRepository(mavenRepoFolder.toUri(), null, Map.of(), _ -> {})),
                 new LinkedHashMap<>(Map.of("foo.bar", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
 
         assertThat(resolved).containsExactly(
                 Map.entry("maven/org.example/example-core/1.0", ""),
@@ -139,7 +140,7 @@ public class MavenModuleResolverTest {
                 Map.of("maven", new MavenDefaultRepository(mavenRepoFolder.toUri(), null, Map.of(), _ -> {})),
                 new LinkedHashMap<>(Map.of("foo.bar", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
 
         assertThat(Files.exists(mavenRepoFolder.resolve("org.example/example-core/1.0/example-core-1.0.pom"))).isFalse();
     }
@@ -154,7 +155,7 @@ public class MavenModuleResolverTest {
                 Map.of("maven", new MavenDefaultRepository(mavenRepoFolder.toUri(), null, Map.of(), _ -> {})),
                 new LinkedHashMap<>(Map.of("foo.bar", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true))
+                DependencyScope.COMPILE))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("No POM found for foo.bar");
     }
@@ -169,7 +170,7 @@ public class MavenModuleResolverTest {
                 Map.of("maven", new MavenDefaultRepository(mavenRepoFolder.toUri(), null, Map.of(), _ -> {})),
                 new LinkedHashMap<>(Map.of("foo.bar", new LinkedHashSet<>(List.of("org.x/y")))),
                 new LinkedHashMap<>(),
-                true))
+                DependencyScope.COMPILE))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("exclusions");
     }
@@ -224,7 +225,7 @@ public class MavenModuleResolverTest {
                 Map.of("maven", new MavenDefaultRepository(mavenRepoFolder.toUri(), null, Map.of(), _ -> {})),
                 new LinkedHashMap<>(Map.of("foo.bar", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
 
         assertThat(resolved).containsExactly(
                 Map.entry("maven/org.example/example-core/1.0", ""),
@@ -281,7 +282,7 @@ public class MavenModuleResolverTest {
                 Map.of("maven", new MavenDefaultRepository(mavenRepoFolder.toUri(), null, Map.of(), _ -> {})),
                 new LinkedHashMap<>(Map.of("foo.bar", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(Map.of("lib.module", "2.0")),
-                true);
+                DependencyScope.COMPILE);
 
         assertThat(resolved).containsExactly(
                 Map.entry("maven/org.example/example-core/1.0", ""),

--- a/tests/build/jenesis/test/maven/MavenPomResolverTest.java
+++ b/tests/build/jenesis/test/maven/MavenPomResolverTest.java
@@ -2,6 +2,7 @@ package build.jenesis.test.maven;
 
 import module java.base;
 import module org.junit.jupiter.api;
+import build.jenesis.DependencyScope;
 import build.jenesis.ResolutionContext;
 import build.jenesis.ResolutionListener;
 import build.jenesis.maven.MavenDefaultRepository;
@@ -3816,7 +3817,7 @@ public class MavenPomResolverTest {
                 Map.of("maven", mavenRepository),
                 new LinkedHashMap<>(Map.of("group/artifact/1", Collections.emptyNavigableSet())),
                 versions,
-                true);
+                DependencyScope.COMPILE);
         assertThat(resolved).containsOnlyKeys(
                 "maven/group/artifact/1",
                 "maven/other/artifact/1",
@@ -3858,7 +3859,7 @@ public class MavenPomResolverTest {
                 Map.of("maven", mavenRepository),
                 new LinkedHashMap<>(Map.of("group/artifact/1", Collections.emptyNavigableSet())),
                 versions,
-                true);
+                DependencyScope.COMPILE);
         assertThat(resolved).containsOnlyKeys(
                 "maven/group/artifact/1",
                 "maven/pinned/artifact/5");
@@ -3900,7 +3901,7 @@ public class MavenPomResolverTest {
                 Map.of("maven", mavenRepository),
                 new LinkedHashMap<>(Map.of("group/artifact/1", Collections.emptyNavigableSet())),
                 versions,
-                true);
+                DependencyScope.COMPILE);
         assertThat(resolved).containsOnlyKeys(
                 "maven/group/artifact/1",
                 "maven/pinned/artifact/jar/sources/3");
@@ -3933,7 +3934,7 @@ public class MavenPomResolverTest {
                 Map.of("maven", mavenRepository),
                 new LinkedHashMap<>(Map.of("group/artifact/1", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(resolved).containsOnlyKeys(
                 "maven/group/artifact/1",
                 "maven/other/artifact/1");
@@ -3987,7 +3988,7 @@ public class MavenPomResolverTest {
                 Map.of("maven", mavenRepository),
                 new LinkedHashMap<>(Map.of("group/artifact/1", Collections.emptyNavigableSet())),
                 versions,
-                true);
+                DependencyScope.COMPILE);
         assertThat(resolved).containsOnlyKeys(
                 "maven/group/artifact/1",
                 "maven/middle/artifact/1",

--- a/tests/build/jenesis/test/maven/MavenPomResolverTest.java
+++ b/tests/build/jenesis/test/maven/MavenPomResolverTest.java
@@ -2,6 +2,8 @@ package build.jenesis.test.maven;
 
 import module java.base;
 import module org.junit.jupiter.api;
+import build.jenesis.ResolutionContext;
+import build.jenesis.ResolutionListener;
 import build.jenesis.maven.MavenDefaultRepository;
 import build.jenesis.maven.MavenDefaultVersionNegotiator;
 import build.jenesis.maven.MavenDependencyKey;
@@ -1615,6 +1617,68 @@ public class MavenPomResolverTest {
     }
 
     @Test
+    public void listener_reports_discovered_range_and_negotiated_version() throws IOException {
+        addToRepository("group", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>transitive</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>[1,2]</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        addToRepository("transitive", "artifact", "2", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                </project>
+                """);
+        Files.writeString(Files
+                .createDirectories(repository.resolve("transitive/artifact/"))
+                .resolve("maven-metadata.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <metadata modelVersion="1.1.0">
+                  <versioning>
+                    <latest>2</latest>
+                    <release>1</release>
+                    <versions>
+                      <version>1</version>
+                      <version>2</version>
+                    </versions>
+                  </versioning>
+                </metadata>
+                """);
+        List<String> nodes = new ArrayList<>();
+        List<String> negotiated = new ArrayList<>();
+        mavenPomResolver.dependencies(Runnable::run, mavenRepository, "group", "artifact", "1", null,
+                new ResolutionListener() {
+                    @Override
+                    public void onDependency(String prefix,
+                                             String parent,
+                                             String coordinate,
+                                             String version,
+                                             String scope,
+                                             boolean followed,
+                                             Supplier<ResolutionContext> context) {
+                        if (followed) {
+                            nodes.add(coordinate);
+                        }
+                    }
+
+                    @Override
+                    public void onResolution(String prefix, String coordinate, String version) {
+                        negotiated.add(coordinate + " -> " + version);
+                    }
+                });
+        assertThat(nodes).containsExactly("transitive/artifact/[1,2]");
+        assertThat(negotiated).containsExactly("transitive/artifact -> 2");
+    }
+
+    @Test
     public void can_resolve_open_range_version() throws IOException {
         addToRepository("group", "artifact", "1", """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -2380,6 +2444,125 @@ public class MavenPomResolverTest {
                 Map.entry(
                         new MavenDependencyKey("transitive", "artifact", "jar", null),
                         new MavenDependencyValue("1", MavenDependencyScope.COMPILE, null, null, null)));
+    }
+
+    @Test
+    public void listener_only_observes_the_converged_graph() throws IOException {
+        addToRepository("group", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>mid</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>forcer</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>1</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        addToRepository("mid", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>conflict</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>1</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        addToRepository("forcer", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>conflict</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>[2]</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        addToRepository("conflict", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>childone</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>1</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        addToRepository("conflict", "artifact", "2", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>childtwo</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>1</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        addToRepository("childone", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                </project>
+                """);
+        addToRepository("childtwo", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                </project>
+                """);
+        Files.writeString(Files
+                .createDirectories(repository.resolve("conflict/artifact/"))
+                .resolve("maven-metadata.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <metadata modelVersion="1.1.0">
+                  <versioning>
+                    <latest>2</latest>
+                    <release>2</release>
+                    <versions>
+                      <version>1</version>
+                      <version>2</version>
+                    </versions>
+                  </versioning>
+                </metadata>
+                """);
+        List<String> followedCoordinates = new ArrayList<>();
+        mavenPomResolver.dependencies(Runnable::run, mavenRepository, "group", "artifact", "1", null,
+                new ResolutionListener() {
+                    @Override
+                    public void onDependency(String prefix,
+                                             String parent,
+                                             String coordinate,
+                                             String version,
+                                             String scope,
+                                             boolean followed,
+                                             Supplier<ResolutionContext> context) {
+                        if (followed) {
+                            followedCoordinates.add(coordinate);
+                        }
+                    }
+                });
+        assertThat(followedCoordinates).contains("childtwo/artifact/1");
+        assertThat(followedCoordinates).doesNotContain("childone/artifact/1");
     }
 
     @Test

--- a/tests/build/jenesis/test/maven/MavenProjectTest.java
+++ b/tests/build/jenesis/test/maven/MavenProjectTest.java
@@ -506,6 +506,7 @@ public class MavenProjectTest {
                 Map.of("maven", new MavenPomResolver()),
                 null,
                 new HashDigestFunction("MD5"),
+                null,
                 (descriptor, _, _) -> {
                     switch (descriptor.name()) {
                         case "module-foo" -> assertThat(descriptor.dependencies()).isEmpty();

--- a/tests/build/jenesis/test/maven/MavenProjectTest.java
+++ b/tests/build/jenesis/test/maven/MavenProjectTest.java
@@ -14,7 +14,7 @@ import build.jenesis.maven.MavenPomResolver;
 import build.jenesis.maven.MavenProject;
 import build.jenesis.maven.MavenRepository;
 import build.jenesis.project.JavaToolchainModule;
-import build.jenesis.project.DependencyScope;
+import build.jenesis.DependencyScope;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;

--- a/tests/build/jenesis/test/maven/PomTest.java
+++ b/tests/build/jenesis/test/maven/PomTest.java
@@ -9,7 +9,7 @@ import build.jenesis.BuildStepResult;
 import build.jenesis.ChecksumStatus;
 import build.jenesis.SequencedProperties;
 import build.jenesis.maven.Pom;
-import build.jenesis.project.DependencyScope;
+import build.jenesis.DependencyScope;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/tests/build/jenesis/test/module/ModularJarResolverTest.java
+++ b/tests/build/jenesis/test/module/ModularJarResolverTest.java
@@ -4,6 +4,8 @@ import module java.base;
 import build.jenesis.DependencyScope;
 import module org.junit.jupiter.api;
 import build.jenesis.RepositoryItem;
+import build.jenesis.ResolutionContext;
+import build.jenesis.ResolutionListener;
 import build.jenesis.module.ModularJarResolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +34,44 @@ public class ModularJarResolverTest {
                 Map.entry("foo/root", ""),
                 Map.entry("foo/transitive", ""),
                 Map.entry("foo/last", ""));
+    }
+
+    @Test
+    public void emits_followed_and_not_followed_module_edges_to_the_listener() throws IOException {
+        List<String> followedEdges = new ArrayList<>();
+        List<String> notFollowedEdges = new ArrayList<>();
+        new ModularJarResolver(false).dependencies(
+                Runnable::run,
+                "foo",
+                Map.of("foo", (_, coordinate) -> {
+                    RepositoryItem item = switch (coordinate) {
+                        case "root" -> () -> toJar("root", require("a", 0), require("b", 0));
+                        case "a" -> () -> toJar("a");
+                        case "b" -> () -> toJar("b", require("a", 0));
+                        default -> null;
+                    };
+                    return Optional.ofNullable(item);
+                }),
+                new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
+                new LinkedHashMap<>(),
+                DependencyScope.COMPILE,
+                new ResolutionListener() {
+                    @Override
+                    public void onDependency(String prefix,
+                                             String parent,
+                                             String coordinate,
+                                             String version,
+                                             String scope,
+                                             boolean followed,
+                                             Supplier<ResolutionContext> context) {
+                        (followed ? followedEdges : notFollowedEdges).add(parent + " -> " + coordinate);
+                    }
+                });
+        assertThat(followedEdges).containsExactly(
+                "null -> foo/root",
+                "foo/root -> foo/a",
+                "foo/root -> foo/b");
+        assertThat(notFollowedEdges).containsExactly("foo/b -> foo/a");
     }
 
     @Test

--- a/tests/build/jenesis/test/module/ModularJarResolverTest.java
+++ b/tests/build/jenesis/test/module/ModularJarResolverTest.java
@@ -1,6 +1,7 @@
 package build.jenesis.test.module;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import module org.junit.jupiter.api;
 import build.jenesis.RepositoryItem;
 import build.jenesis.module.ModularJarResolver;
@@ -26,7 +27,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(dependencies).containsExactly(
                 Map.entry("foo/root", ""),
                 Map.entry("foo/transitive", ""),
@@ -48,7 +49,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(dependencies).containsExactly(Map.entry("foo/root", ""));
     }
 
@@ -68,7 +69,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(dependencies).containsExactly(
                 Map.entry("foo/root", ""),
                 Map.entry("foo/propagated", ""));
@@ -92,7 +93,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(dependencies).containsExactly(
                 Map.entry("foo/root", ""),
                 Map.entry("foo/alpha", ""),
@@ -116,7 +117,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                false);
+                DependencyScope.RUNTIME);
         assertThat(dependencies).containsExactly(Map.entry("foo/root", ""));
     }
 
@@ -166,7 +167,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(dependencies).containsExactly(Map.entry("foo/root/1.2.3", ""));
     }
 
@@ -184,7 +185,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(dependencies).containsExactly(Map.entry("foo/root", ""));
     }
 
@@ -202,7 +203,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true))
+                DependencyScope.COMPILE))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("root")
                 .hasMessageContaining("imposter");
@@ -222,7 +223,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(Map.of("root", "9.9")),
-                true);
+                DependencyScope.COMPILE);
         assertThat(dependencies).containsExactly(Map.entry("foo/root/9.9", ""));
     }
 
@@ -240,7 +241,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(Map.of("root", "9.9")),
-                true))
+                DependencyScope.COMPILE))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("9.9")
                 .hasMessageContaining("1.0");
@@ -262,7 +263,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(Map.of("root", "9.9")),
-                true))
+                DependencyScope.COMPILE))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("No module found for root");
         assertThat(fetched).containsOnlyKeys("root/9.9");
@@ -282,7 +283,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(Map.of("root", "9.9")),
-                true);
+                DependencyScope.COMPILE);
         assertThat(dependencies).containsExactly(Map.entry("foo/root/9.9", ""));
     }
 
@@ -300,7 +301,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(Map.of("root", "7.0")),
-                true);
+                DependencyScope.COMPILE);
         assertThat(dependencies).containsExactly(Map.entry("foo/root/7.0", ""));
     }
 
@@ -319,7 +320,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(dependencies).containsExactly(
                 Map.entry("foo/root/1.0", ""),
                 Map.entry("foo/transitive/2.0", ""));
@@ -343,7 +344,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(dependencies).containsExactly(
                 Map.entry("foo/root/1.0", ""),
                 Map.entry("foo/alpha/2.0", ""),
@@ -367,7 +368,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(fetched).containsOnlyKeys("root", "pinned/1.0");
         assertThat(dependencies).containsExactly(
                 Map.entry("foo/root/1.0", ""),
@@ -391,7 +392,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(fetched).containsOnlyKeys("root", "plain");
         assertThat(dependencies).containsExactly(
                 Map.entry("foo/root/1.0", ""),
@@ -415,7 +416,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(Map.of("dep", "9.9")),
-                true);
+                DependencyScope.COMPILE);
         assertThat(fetched).containsOnlyKeys("root", "dep/9.9");
         assertThat(dependencies).containsExactly(
                 Map.entry("foo/root/1.0", ""),
@@ -440,7 +441,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(fetched).containsOnlyKeys("root", "middle/1.0", "deep/1.0");
         assertThat(dependencies).containsExactly(
                 Map.entry("foo/root/1.0", ""),
@@ -468,7 +469,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(fetched).contains(Map.entry("shared/1.0", ""));
         assertThat(dependencies).containsEntry("foo/shared/1.0", "");
     }
@@ -488,7 +489,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(Map.of("transitive", "9.9")),
-                true);
+                DependencyScope.COMPILE);
         assertThat(dependencies).containsExactly(
                 Map.entry("foo/root/1.0", ""),
                 Map.entry("foo/transitive/9.9", ""));
@@ -512,7 +513,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(dependencies).containsExactly(Map.entry("foo/root/2.0", ""));
     }
 
@@ -533,7 +534,7 @@ public class ModularJarResolverTest {
                 }),
                 new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
                 new LinkedHashMap<>(),
-                true);
+                DependencyScope.COMPILE);
         assertThat(dependencies).containsExactly(Map.entry("foo/root/1.0", ""));
     }
 

--- a/tests/build/jenesis/test/module/ModularProjectTest.java
+++ b/tests/build/jenesis/test/module/ModularProjectTest.java
@@ -184,6 +184,7 @@ public class ModularProjectTest {
                 null,
                 true,
                 new HashDigestFunction("MD5"),
+                null,
                 (descriptor, _, _) -> {
                     switch (descriptor.name()) {
                         case "module-foo" -> assertThat(descriptor.dependencies()).isEmpty();

--- a/tests/build/jenesis/test/project/DependenciesModuleTest.java
+++ b/tests/build/jenesis/test/project/DependenciesModuleTest.java
@@ -1,6 +1,7 @@
 package build.jenesis.test.project;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import module org.junit.jupiter.api;
 import build.jenesis.BuildExecutor;
 import build.jenesis.BuildExecutorCallback;
@@ -38,7 +39,7 @@ public class DependenciesModuleTest {
                 Map.of("foo", (_, coordinate) -> Optional.of(() -> new ByteArrayInputStream(
                         coordinate.getBytes(StandardCharsets.UTF_8)))),
                 Map.of("foo", Resolver.identity()),
-                true), "input");
+                DependencyScope.COMPILE), "input");
         SequencedMap<String, Path> steps = buildExecutor.execute();
         assertThat(steps).containsKeys("output/resolved", "output/artifacts");
         SequencedProperties resolved = SequencedProperties.ofFiles(steps.get("output/resolved").resolve(BuildStep.REQUIRES));

--- a/tests/build/jenesis/test/project/GroovyCompilerModuleTest.java
+++ b/tests/build/jenesis/test/project/GroovyCompilerModuleTest.java
@@ -170,7 +170,7 @@ public class GroovyCompilerModuleTest {
                 "groovy",
                 new GroovyCompilerModule(
                         Map.of(),
-                        Map.of("module", (_, _, _, _, _, _) -> new LinkedHashMap<>())),
+                        Map.of("module", (_, _, _, _, _, _, _) -> new LinkedHashMap<>())),
                 "project");
         executor.execute("groovy/" + "required");
 
@@ -189,7 +189,7 @@ public class GroovyCompilerModuleTest {
                 "groovy",
                 new GroovyCompilerModule(
                         Map.of(),
-                        Map.of("maven", (_, _, _, _, _, _) -> new LinkedHashMap<>())),
+                        Map.of("maven", (_, _, _, _, _, _, _) -> new LinkedHashMap<>())),
                 "project");
         executor.execute("groovy/" + "required");
 
@@ -208,7 +208,7 @@ public class GroovyCompilerModuleTest {
                 "groovy",
                 new GroovyCompilerModule(
                         Map.of(),
-                        Map.of("vendor", (_, _, _, _, _, _) -> new LinkedHashMap<>())),
+                        Map.of("vendor", (_, _, _, _, _, _, _) -> new LinkedHashMap<>())),
                 "project");
 
         assertThatThrownBy(() -> executor.execute("groovy/" + "required"))
@@ -225,7 +225,7 @@ public class GroovyCompilerModuleTest {
                 "groovy",
                 new GroovyCompilerModule(
                         Map.of(),
-                        Map.of("maven", (_, _, _, _, _, _) -> new LinkedHashMap<>())),
+                        Map.of("maven", (_, _, _, _, _, _, _) -> new LinkedHashMap<>())),
                 "project");
         SequencedMap<String, Path> outputs = executor.execute();
 

--- a/tests/build/jenesis/test/project/InternalModuleTest.java
+++ b/tests/build/jenesis/test/project/InternalModuleTest.java
@@ -91,9 +91,9 @@ public class InternalModuleTest {
         buildExecutor.addModule("internal", new InternalModule(
                 "module",
                 null,
-                source,
-                Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))),
-                Map.of("module", new ModularJarResolver(true))));
+                source)
+                .repositories(Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))))
+                .resolvers(Map.of("module", new ModularJarResolver(true))));
 
         SequencedMap<String, Path> steps = buildExecutor.execute();
         assertThat(steps).containsKey("internal/marker");
@@ -132,9 +132,9 @@ public class InternalModuleTest {
         buildExecutor.addModule("internal", new InternalModule(
                 "module",
                 null,
-                source,
-                Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))),
-                Map.of("module", new ModularJarResolver(true))));
+                source)
+                .repositories(Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))))
+                .resolvers(Map.of("module", new ModularJarResolver(true))));
 
         SequencedMap<String, Path> steps = buildExecutor.execute();
         assertThat(steps.get("internal/second").resolve("out.txt")).content().isEqualTo("seen:produced");
@@ -168,9 +168,9 @@ public class InternalModuleTest {
         buildExecutor.addModule("internal", new InternalModule(
                 "module",
                 null,
-                source,
-                Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))),
-                Map.of("module", new ModularJarResolver(true))));
+                source)
+                .repositories(Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))))
+                .resolvers(Map.of("module", new ModularJarResolver(true))));
 
         SequencedMap<String, Path> steps = buildExecutor.execute();
         assertThat(steps.get("internal/inner/marker").resolve("out.txt")).content().isEqualTo("nested");
@@ -184,9 +184,9 @@ public class InternalModuleTest {
         buildExecutor.addModule("internal", new InternalModule(
                 "module",
                 null,
-                source,
-                Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))),
-                Map.of("module", new ModularJarResolver(true))));
+                source)
+                .repositories(Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))))
+                .resolvers(Map.of("module", new ModularJarResolver(true))));
 
         assertThatThrownBy(() -> buildExecutor.execute())
                 .rootCause()
@@ -222,9 +222,9 @@ public class InternalModuleTest {
         buildExecutor.addModule("internal", new InternalModule(
                 "module",
                 null,
-                source,
-                Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))),
-                Map.of("module", new ModularJarResolver(true)))
+                source)
+                .repositories(Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))))
+                .resolvers(Map.of("module", new ModularJarResolver(true)))
                 .buildModuleName("foo"));
 
         SequencedMap<String, Path> steps = buildExecutor.execute();
@@ -251,9 +251,9 @@ public class InternalModuleTest {
         buildExecutor.addModule("internal", new InternalModule(
                 "module",
                 null,
-                source,
-                Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))),
-                Map.of("module", new ModularJarResolver(true)))
+                source)
+                .repositories(Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))))
+                .resolvers(Map.of("module", new ModularJarResolver(true)))
                 .buildModuleName("bar"));
 
         assertThatThrownBy(() -> buildExecutor.execute())
@@ -282,9 +282,9 @@ public class InternalModuleTest {
         buildExecutor.addModule("internal", new InternalModule(
                 "module",
                 null,
-                source,
-                Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))),
-                Map.of("module", new ModularJarResolver(true))));
+                source)
+                .repositories(Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))))
+                .resolvers(Map.of("module", new ModularJarResolver(true))));
 
         assertThatThrownBy(() -> buildExecutor.execute())
                 .rootCause()
@@ -321,9 +321,9 @@ public class InternalModuleTest {
         buildExecutor.addModule("internal", new InternalModule(
                 "module",
                 null,
-                source,
-                Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))),
-                Map.of("module", new ModularJarResolver(true))));
+                source)
+                .repositories(Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))))
+                .resolvers(Map.of("module", new ModularJarResolver(true))));
 
         assertThatThrownBy(() -> buildExecutor.execute())
                 .rootCause()
@@ -362,9 +362,9 @@ public class InternalModuleTest {
         buildExecutor.addModule("internal", new InternalModule(
                 "module",
                 "tool",
-                source,
-                Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))),
-                Map.of("module", new ModularJarResolver(true))), "manifests");
+                source)
+                .repositories(Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))))
+                .resolvers(Map.of("module", new ModularJarResolver(true))), "manifests");
 
         SequencedMap<String, Path> steps = buildExecutor.execute();
         assertThat(steps.get("internal/marker").resolve("out.txt")).content().isEqualTo("hello");
@@ -401,9 +401,9 @@ public class InternalModuleTest {
         buildExecutor.addModule("internal", new InternalModule(
                 "module",
                 "tool",
-                source,
-                Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))),
-                Map.of("module", new ModularJarResolver(true))), "manifests");
+                source)
+                .repositories(Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))))
+                .resolvers(Map.of("module", new ModularJarResolver(true))), "manifests");
 
         assertThatThrownBy(() -> buildExecutor.execute())
                 .rootCause()
@@ -442,9 +442,9 @@ public class InternalModuleTest {
         buildExecutor.addModule("internal", new InternalModule(
                 "module",
                 null,
-                source,
-                Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))),
-                Map.of("module", new ModularJarResolver(true))), "manifests");
+                source)
+                .repositories(Map.of("module", versionInsensitive(Map.of("build.jenesis", jenesisJar))))
+                .resolvers(Map.of("module", new ModularJarResolver(true))), "manifests");
 
         assertThatThrownBy(() -> buildExecutor.execute())
                 .rootCause()

--- a/tests/build/jenesis/test/project/JavaMultiProjectAssemblerTest.java
+++ b/tests/build/jenesis/test/project/JavaMultiProjectAssemblerTest.java
@@ -10,7 +10,7 @@ import build.jenesis.BuildStepHashFunction;
 import build.jenesis.BuildExecutorModule;
 import build.jenesis.HashDigestFunction;
 import build.jenesis.SequencedProperties;
-import build.jenesis.project.DependencyScope;
+import build.jenesis.DependencyScope;
 import build.jenesis.project.JavaMultiProjectAssembler;
 import build.jenesis.project.ProjectModule;
 import build.jenesis.project.ProjectModuleDescriptor;

--- a/tests/build/jenesis/test/project/KotlinCompilerModuleTest.java
+++ b/tests/build/jenesis/test/project/KotlinCompilerModuleTest.java
@@ -223,7 +223,7 @@ public class KotlinCompilerModuleTest {
                 "kotlin",
                 new KotlinCompilerModule(
                         Map.of(),
-                        Map.of("module", (_, _, _, _, _, _) -> new LinkedHashMap<>())),
+                        Map.of("module", (_, _, _, _, _, _, _) -> new LinkedHashMap<>())),
                 "project");
         executor.execute("kotlin/" + "required");
 
@@ -242,7 +242,7 @@ public class KotlinCompilerModuleTest {
                 "kotlin",
                 new KotlinCompilerModule(
                         Map.of(),
-                        Map.of("maven", (_, _, _, _, _, _) -> new LinkedHashMap<>())),
+                        Map.of("maven", (_, _, _, _, _, _, _) -> new LinkedHashMap<>())),
                 "project");
         executor.execute("kotlin/" + "required");
 
@@ -262,8 +262,8 @@ public class KotlinCompilerModuleTest {
                 new KotlinCompilerModule(
                         Map.of(),
                         Map.of(
-                                "module", (_, _, _, _, _, _) -> new LinkedHashMap<>(),
-                                "maven", (_, _, _, _, _, _) -> new LinkedHashMap<>())),
+                                "module", (_, _, _, _, _, _, _) -> new LinkedHashMap<>(),
+                                "maven", (_, _, _, _, _, _, _) -> new LinkedHashMap<>())),
                 "project");
         executor.execute("kotlin/" + "required");
 
@@ -282,7 +282,7 @@ public class KotlinCompilerModuleTest {
                 "kotlin",
                 new KotlinCompilerModule(
                         Map.of(),
-                        Map.of("vendor", (_, _, _, _, _, _) -> new LinkedHashMap<>())),
+                        Map.of("vendor", (_, _, _, _, _, _, _) -> new LinkedHashMap<>())),
                 "project");
 
         assertThatThrownBy(() -> executor.execute("kotlin/" + "required"))
@@ -316,7 +316,7 @@ public class KotlinCompilerModuleTest {
                 "kotlin",
                 new KotlinCompilerModule(
                         Map.of(),
-                        Map.of("maven", (_, _, _, _, _, _) -> new LinkedHashMap<>())),
+                        Map.of("maven", (_, _, _, _, _, _, _) -> new LinkedHashMap<>())),
                 "project");
         SequencedMap<String, Path> outputs = executor.execute();
 

--- a/tests/build/jenesis/test/project/MultiProjectDependenciesTest.java
+++ b/tests/build/jenesis/test/project/MultiProjectDependenciesTest.java
@@ -10,7 +10,7 @@ import build.jenesis.ChecksumStatus;
 import build.jenesis.HashDigestFunction;
 import build.jenesis.SequencedProperties;
 import build.jenesis.project.MultiProjectDependencies;
-import build.jenesis.project.DependencyScope;
+import build.jenesis.DependencyScope;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/tests/build/jenesis/test/project/ProjectModuleDescriptorTest.java
+++ b/tests/build/jenesis/test/project/ProjectModuleDescriptorTest.java
@@ -4,7 +4,7 @@ import module java.base;
 import module org.junit.jupiter.api;
 import build.jenesis.PathPlacement;
 import build.jenesis.maven.MavenProject.MavenModuleDescriptor;
-import build.jenesis.project.DependencyScope;
+import build.jenesis.DependencyScope;
 import build.jenesis.project.ProjectModule;
 import build.jenesis.project.ProjectModuleDescriptor;
 

--- a/tests/build/jenesis/test/project/ScalaCompilerModuleTest.java
+++ b/tests/build/jenesis/test/project/ScalaCompilerModuleTest.java
@@ -263,7 +263,7 @@ public class ScalaCompilerModuleTest {
                 "scala",
                 new ScalaCompilerModule(
                         Map.of(),
-                        Map.of("module", (_, _, _, _, _, _) -> new LinkedHashMap<>())),
+                        Map.of("module", (_, _, _, _, _, _, _) -> new LinkedHashMap<>())),
                 "project");
         executor.execute("scala/" + "required");
 
@@ -282,7 +282,7 @@ public class ScalaCompilerModuleTest {
                 "scala",
                 new ScalaCompilerModule(
                         Map.of(),
-                        Map.of("maven", (_, _, _, _, _, _) -> new LinkedHashMap<>())),
+                        Map.of("maven", (_, _, _, _, _, _, _) -> new LinkedHashMap<>())),
                 "project");
         executor.execute("scala/" + "required");
 
@@ -302,8 +302,8 @@ public class ScalaCompilerModuleTest {
                 new ScalaCompilerModule(
                         Map.of(),
                         Map.of(
-                                "module", (_, _, _, _, _, _) -> new LinkedHashMap<>(),
-                                "maven", (_, _, _, _, _, _) -> new LinkedHashMap<>())),
+                                "module", (_, _, _, _, _, _, _) -> new LinkedHashMap<>(),
+                                "maven", (_, _, _, _, _, _, _) -> new LinkedHashMap<>())),
                 "project");
         executor.execute("scala/" + "required");
 
@@ -322,7 +322,7 @@ public class ScalaCompilerModuleTest {
                 "scala",
                 new ScalaCompilerModule(
                         Map.of(),
-                        Map.of("vendor", (_, _, _, _, _, _) -> new LinkedHashMap<>())),
+                        Map.of("vendor", (_, _, _, _, _, _, _) -> new LinkedHashMap<>())),
                 "project");
 
         assertThatThrownBy(() -> executor.execute("scala/" + "required"))
@@ -339,7 +339,7 @@ public class ScalaCompilerModuleTest {
                 "scala",
                 new ScalaCompilerModule(
                         Map.of(),
-                        Map.of("maven", (_, _, _, _, _, _) -> new LinkedHashMap<>())),
+                        Map.of("maven", (_, _, _, _, _, _, _) -> new LinkedHashMap<>())),
                 "project");
         SequencedMap<String, Path> outputs = executor.execute();
 

--- a/tests/build/jenesis/test/project/TestModuleTest.java
+++ b/tests/build/jenesis/test/project/TestModuleTest.java
@@ -380,7 +380,7 @@ public class TestModuleTest {
         executor.addSource("classes", classes);
         executor.addModule(
                 "test",
-                new TestModule(Map.of(), Map.of("maven", (_, _, _, _, _, _) -> new LinkedHashMap<>()))
+                new TestModule(Map.of(), Map.of("maven", (_, _, _, _, _, _, _) -> new LinkedHashMap<>()))
                         .engine(new JUnitPlatform())
                         .isTest(candidate -> candidate.endsWith("TestSample"))
                         .jarsOnly(false),
@@ -401,7 +401,7 @@ public class TestModuleTest {
         executor.addSource("classes", classes);
         executor.addModule(
                 "test",
-                new TestModule(Map.of(), Map.of("module", (_, _, _, _, _, _) -> new LinkedHashMap<>()))
+                new TestModule(Map.of(), Map.of("module", (_, _, _, _, _, _, _) -> new LinkedHashMap<>()))
                         .engine(new JUnitPlatform())
                         .isTest(candidate -> candidate.endsWith("TestSample"))
                         .jarsOnly(false),
@@ -506,7 +506,7 @@ public class TestModuleTest {
         executor.addSource("classes", classes);
         executor.addModule(
                 "test",
-                new TestModule(Map.of(), Map.of("module", (_, _, _, _, _, _) -> new LinkedHashMap<>()))
+                new TestModule(Map.of(), Map.of("module", (_, _, _, _, _, _, _) -> new LinkedHashMap<>()))
                         .engine(new JUnitPlatform())
                         .jarsOnly(false),
                 "dependencies", "classes");
@@ -531,7 +531,7 @@ public class TestModuleTest {
         executor.addSource("classes", classes);
         executor.addModule(
                 "test",
-                new TestModule(Map.of(), Map.of("module", (_, _, _, _, _, _) -> new LinkedHashMap<>()))
+                new TestModule(Map.of(), Map.of("module", (_, _, _, _, _, _, _) -> new LinkedHashMap<>()))
                         .engine(new JUnitPlatform())
                         .jarsOnly(false),
                 "dependencies", "classes");
@@ -549,7 +549,7 @@ public class TestModuleTest {
         executor.addSource("classes", classes);
         executor.addModule(
                 "test",
-                new TestModule(Map.of(), Map.of("maven", (_, _, _, _, _, _) -> new LinkedHashMap<>()))
+                new TestModule(Map.of(), Map.of("maven", (_, _, _, _, _, _, _) -> new LinkedHashMap<>()))
                         .engine(new MultiRunnerEngine())
                         .jarsOnly(false),
                 "dependencies", "classes");

--- a/tests/build/jenesis/test/step/AssignTest.java
+++ b/tests/build/jenesis/test/step/AssignTest.java
@@ -89,7 +89,7 @@ public class AssignTest {
         properties.setProperty("bar", argument.relativize(passthroughArtifact).toString());
         properties.store(argument.resolve(BuildStep.IDENTITY));
         Files.writeString(Files.createDirectory(argument.resolve(BuildStep.ARTIFACTS)).resolve("artifact"), "baz");
-        BuildStepResult result = new Assign((coordinates, files) -> {
+        BuildStepResult result = new Assign().assigner((coordinates, files) -> {
             assertThat(coordinates).containsExactly("foo");
             assertThat(files).containsExactly(argument.resolve(BuildStep.ARTIFACTS).resolve("artifact"));
             return Map.of(

--- a/tests/build/jenesis/test/step/DownloadTest.java
+++ b/tests/build/jenesis/test/step/DownloadTest.java
@@ -107,7 +107,7 @@ public class DownloadTest {
         BuildStepResult result = new Download(Map.of(
                 "foo",
                 (_, bar) -> Optional.of(() -> new ByteArrayInputStream(bar.getBytes(StandardCharsets.UTF_8)))
-        ), Pinning.IGNORE).apply(
+        )).pinning(Pinning.IGNORE).apply(
                 Runnable::run,
                 new BuildStepContext(previous, next, supplement),
                 new LinkedHashMap<>(Map.of("dependencies", new BuildStepArgument(
@@ -220,7 +220,7 @@ public class DownloadTest {
         assertThatThrownBy(() -> new Download(Map.of(
                 "foo",
                 (_, bar) -> Optional.of(() -> new ByteArrayInputStream(bar.getBytes(StandardCharsets.UTF_8)))
-        ), Pinning.STRICT).apply(
+        )).pinning(Pinning.STRICT).apply(
                 Runnable::run,
                 new BuildStepContext(previous, next, supplement),
                 new LinkedHashMap<>(Map.of("dependencies", new BuildStepArgument(
@@ -240,7 +240,7 @@ public class DownloadTest {
         BuildStepResult result = new Download(Map.of(
                 "foo",
                 (_, bar) -> Optional.of(() -> new ByteArrayInputStream(bar.getBytes(StandardCharsets.UTF_8)))
-        ), null).apply(
+        )).apply(
                 Runnable::run,
                 new BuildStepContext(previous, next, supplement),
                 new LinkedHashMap<>(Map.of("dependencies", new BuildStepArgument(

--- a/tests/build/jenesis/test/step/ResolveTest.java
+++ b/tests/build/jenesis/test/step/ResolveTest.java
@@ -1,6 +1,7 @@
 package build.jenesis.test.step;
 
 import module java.base;
+import build.jenesis.DependencyScope;
 import module org.junit.jupiter.api;
 import build.jenesis.BuildStep;
 import build.jenesis.BuildStepArgument;
@@ -40,7 +41,7 @@ public class ResolveTest {
                         resolved.put(prefix + "/transitive/" + descriptor, "");
                     });
                     return resolved;
-                }), true).apply(
+                }), DependencyScope.COMPILE).apply(
                 Runnable::run,
                 new BuildStepContext(previous, next, supplement),
                 new LinkedHashMap<>(Map.of("dependencies", new BuildStepArgument(
@@ -68,7 +69,7 @@ public class ResolveTest {
                     SequencedMap<String, String> resolved = new LinkedHashMap<>();
                     descriptors.sequencedKeySet().forEach(descriptor -> resolved.put(prefix + "/" + descriptor, ""));
                     return resolved;
-                }), true).apply(
+                }), DependencyScope.COMPILE).apply(
                 Runnable::run,
                 new BuildStepContext(previous, next, supplement),
                 new LinkedHashMap<>(Map.of("dependencies", new BuildStepArgument(
@@ -94,7 +95,7 @@ public class ResolveTest {
                 resolved.put(prefix + "/transitive/" + descriptor, "");
             });
             return resolved;
-        }), true).apply(
+        }), DependencyScope.COMPILE).apply(
                 Runnable::run,
                 new BuildStepContext(previous, next, supplement),
                 new LinkedHashMap<>(Map.of("dependencies", new BuildStepArgument(
@@ -127,7 +128,7 @@ public class ResolveTest {
                 resolved.put(prefix + "/" + "transitive/" + descriptor, "baz/" + descriptor);
             });
             return resolved;
-        }), true).apply(
+        }), DependencyScope.COMPILE).apply(
                 Runnable::run,
                 new BuildStepContext(previous, next, supplement),
                 new LinkedHashMap<>(Map.of("dependencies", new BuildStepArgument(

--- a/tests/build/jenesis/test/step/ResolveTest.java
+++ b/tests/build/jenesis/test/step/ResolveTest.java
@@ -33,7 +33,7 @@ public class ResolveTest {
         properties.setProperty("foo/qux", "");
         properties.setProperty("foo/baz", "");
         properties.store(dependencies.resolve(BuildStep.REQUIRES));
-        BuildStepResult result = new Resolve(Map.of("foo", Repository.empty()), Map.of("foo", (_, prefix, _, descriptors, _, _) -> {
+        BuildStepResult result = new Resolve(Map.of("foo", Repository.empty()), Map.of("foo", (_, prefix, _, descriptors, _, _, _) -> {
                     SequencedMap<String, String> resolved = new LinkedHashMap<>();
                     descriptors.sequencedKeySet().forEach(descriptor -> {
                         resolved.put(prefix + "/" +descriptor, "");
@@ -64,7 +64,7 @@ public class ResolveTest {
         SequencedProperties properties = new SequencedProperties();
         properties.setProperty("maven@kotlin/org.jetbrains/something", "");
         properties.store(dependencies.resolve(BuildStep.REQUIRES));
-        BuildStepResult result = new Resolve(Map.of("maven", Repository.empty()), Map.of("maven", (_, prefix, _, descriptors, _, _) -> {
+        BuildStepResult result = new Resolve(Map.of("maven", Repository.empty()), Map.of("maven", (_, prefix, _, descriptors, _, _, _) -> {
                     SequencedMap<String, String> resolved = new LinkedHashMap<>();
                     descriptors.sequencedKeySet().forEach(descriptor -> resolved.put(prefix + "/" + descriptor, ""));
                     return resolved;
@@ -87,7 +87,7 @@ public class ResolveTest {
         properties.setProperty("foo/qux", "bar");
         properties.setProperty("foo/baz", "");
         properties.store(dependencies.resolve(BuildStep.REQUIRES));
-        BuildStepResult result = new Resolve(Map.of("foo", Repository.empty()), Map.of("foo", (_, prefix, _, descriptors, _, _) -> {
+        BuildStepResult result = new Resolve(Map.of("foo", Repository.empty()), Map.of("foo", (_, prefix, _, descriptors, _, _, _) -> {
             SequencedMap<String, String> resolved = new LinkedHashMap<>();
             descriptors.sequencedKeySet().forEach(descriptor -> {
                 resolved.put(prefix + "/" + descriptor, "");
@@ -120,7 +120,7 @@ public class ResolveTest {
         properties.setProperty("foo/qux", "bar");
         properties.setProperty("foo/baz", "");
         properties.store(dependencies.resolve(BuildStep.REQUIRES));
-        BuildStepResult result = new Resolve(Map.of("foo", Repository.empty()), Map.of("foo", (_, prefix, _, descriptors, _, _) -> {
+        BuildStepResult result = new Resolve(Map.of("foo", Repository.empty()), Map.of("foo", (_, prefix, _, descriptors, _, _, _) -> {
             SequencedMap<String, String> resolved = new LinkedHashMap<>();
             descriptors.sequencedKeySet().forEach(descriptor -> {
                 resolved.put(prefix + "/" + descriptor, "qux/" + descriptor);


### PR DESCRIPTION
Adds a `mvn dependency:tree` / `gradle dependencies` equivalent as a reporting flag that captures the **real** build resolution, with zero impact when off.

## Design
- An optional `ResolutionListener` is passed as an **argument** to `Resolver.dependencies(...)`; the old 6-arg signature is kept as a **no-op default overload**, so existing consumers are unchanged and a normal build is byte-identical.
- The resolver reports each discovered parent→child edge (property-file key, resolved version, scope, and a `followed` flag that is `false` on a dedup re-encounter), plus a lazy `ResolutionContext` supplier for non-obvious context (no I/O, nothing read/downloaded that the build did not already fetch).
- A `Supplier<ResolutionListener>` factory is threaded via a `DependenciesModule` wither to the `Resolve` step (held transient, so a null listener leaves the cache key unchanged); when set, the step is **forced to re-run** so the tree always prints.
- The resolution tree is **never persisted or hashed** - only the flat closure remains the build's product.
- `DependencyTreeReport` collects edges from the per-resolve listeners and prints a **deduplicated** box-drawing tree.

## Coverage
Edge capture in all three layouts:
- **MAVEN** - `maven/...` keys with `[compile]`/`[runtime]` scopes.
- **MODULAR** - `module/...` keys with the module graph.
- **MODULAR_TO_MAVEN** - each module's resolved maven coordinate (e.g. `org.slf4j` → `maven/org.slf4j/slf4j-api/2.0.16`).

## Validation
Full self-build + test suite green; verified live on demo-03 (maven), demo-04 (modular_to_maven and forced modular). Documented in the help blocks and README.

## Follow-ups (optional)
- Merge a module's compile/runtime resolves into a single scope-annotated tree (needs module identity at resolve time).
- Populate the `ResolutionContext` for the automatic-module flag and the modular→maven module-name annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)