### PR TITLE
Inference-based multi-language documentation chain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,11 @@ jobs:
           - { name: java-modular-executable, dir: demo-06-java-modular-executable, entry: build/Demo.java }
           - { name: java-multi-release, dir: demo-07-java-multi-release, entry: build/jenesis/Execute.java }
           - { name: kotlin, dir: demo-08-kotlin, entry: build/jenesis/Project.java }
+          - { name: kotlin-documentation, dir: demo-08-kotlin, entry: build/jenesis/Project.java, flags: -Djenesis.project.documentation=true }
           - { name: scala, dir: demo-09-scala, entry: build/jenesis/Project.java }
+          - { name: scala-documentation, dir: demo-09-scala, entry: build/jenesis/Project.java, flags: -Djenesis.project.documentation=true }
           - { name: groovy, dir: demo-10-groovy, entry: build/jenesis/Project.java }
+          - { name: groovy-documentation, dir: demo-10-groovy, entry: build/jenesis/Project.java, flags: -Djenesis.project.documentation=true }
           - { name: maven-exclusions, dir: demo-11-maven-exclusions, entry: build/jenesis/Project.java }
           - { name: module-layout, dir: demo-12-module-layout, entry: build/Demo.java }
           - { name: custom-assembler, dir: demo-13-custom-assembler, entry: build/Demo.java }

--- a/README.md
+++ b/README.md
@@ -348,14 +348,13 @@ Two callbacks govern how the build is assembled, and they are pluggable independ
   (`.java`, `.kt`, `.scala`, `.groovy`); a `document` sub-module then wires the documentation tools and an
   `aggregate` step that merges their output into a single `javadoc/` tree (archived into the module's
   `-javadoc.jar`). The tools are resolved on their own qualified trails like the compilers: Kotlin through Dokka in
-  its **Javadoc output format** (`@dokka`, `dokka-cli` plus `analysis-kotlin-descriptors` and the `javadoc-plugin` -
-  which pulls `dokka-base`, `kotlin-as-java-plugin` and the Korte templating engine - on the plugins class-path,
-  presenting Kotlin as Java so the output is a javadoc-structured tree that `javadoc.io` renders), Scala through
-  `scaladoc` (`@scaladoc`, fed the compiled `.tasty` classes since scaladoc reads tasty rather than source), Groovy
-  through `groovydoc` (`@groovydoc`, in source-path plus package-name mode so packages render correctly), and Java
-  through the JDK's `javadoc` (in class-path mode, skipping `module-info.java`). The layout follows what each tool
-  can cover: Dokka also documents Java (as Java) and `groovydoc` also documents Java, but `scaladoc` documents only
-  Scala. So when **one tool can document every language present**, only that tool runs and renders at the archive
+  its **HTML output format** (`@dokka`, `dokka-cli` plus `dokka-base` and `analysis-kotlin-descriptors` on the
+  plugins class-path) - the format Dokka recommends and the one most Kotlin libraries ship in their `-javadoc.jar`,
+  Scala through `scaladoc` (`@scaladoc`, fed the compiled `.tasty` classes since scaladoc reads tasty rather than
+  source), Groovy through `groovydoc` (`@groovydoc`, in source-path plus package-name mode so packages render
+  correctly), and Java through the JDK's `javadoc` (in class-path mode, skipping `module-info.java`). The layout
+  follows what each tool can cover: Dokka also documents Java sources and `groovydoc` also documents Java, but
+  `scaladoc` documents only Scala. So when **one tool can document every language present**, only that tool runs and renders at the archive
   root - Java + Kotlin is a single Dokka document, Java + Groovy a single groovydoc document, and a single-language
   module is just that language's tool. Only when the mix is **incompatible** (Java + Scala, or three or more
   languages, where no single tool covers everything) does `javadoc` render the Java at the root as the baseline and

--- a/README.md
+++ b/README.md
@@ -351,9 +351,11 @@ Two callbacks govern how the build is assembled, and they are pluggable independ
   `module-info.java` and documents the sources against the resolved dependencies, so a mixed-language module whose
   `module-info` exports a package implemented only in another language still produces valid Java docs). Each other
   language renders through its native tool, resolved on its own qualified trail like the compilers: Kotlin through
-  Dokka (`@dokka`, `dokka-cli` plus `dokka-base` and `analysis-kotlin-descriptors` on the plugins class-path),
-  Scala through `scaladoc` (`@scaladoc`, fed the compiled `.tasty` classes since scaladoc reads tasty rather than
-  source), and Groovy through `groovydoc` (`@groovydoc`). When a single language is present its tool renders at the
+  Dokka in its **Javadoc output format** (`@dokka`, `dokka-cli` plus `analysis-kotlin-descriptors` and the
+  `javadoc-plugin` - which pulls `dokka-base`, `kotlin-as-java-plugin` and the Korte templating engine - on the
+  plugins class-path, presenting Kotlin as Java so the output is a javadoc-structured tree that `javadoc.io`
+  renders), Scala through `scaladoc` (`@scaladoc`, fed the compiled `.tasty` classes since scaladoc reads tasty
+  rather than source), and Groovy through `groovydoc` (`@groovydoc`). When a single language is present its tool renders at the
   root and the others are dropped; when more than one is present the native tools render into per-language
   subfolders (`dokka/`, `scaladoc/`, `groovydoc/`) alongside the Java baseline. Scala and Kotlin tools are version
   coordinated to the project's resolved compiler version (read from the upstream dependency jars). The chain is

--- a/README.md
+++ b/README.md
@@ -301,7 +301,8 @@ Two callbacks govern how the build is assembled, and they are pluggable independ
   `JavaToolchainModule` is wired against the descriptor's reference-key sets (`sources`, `manifests`, and the
   compile/runtime `resolved` and `artifacts` keys) and the module's resources, and when `descriptor.test()`
   is set and the module's `module.properties` flags it as a test variant a `TestModule` sub-module is wired
-  alongside the `JavaToolchainModule`, with optional `sources` and `javadoc` steps appended when the matching flag is set. The `MAVEN` and `MODULAR_TO_MAVEN` layouts wrap the
+  alongside the `JavaToolchainModule`, with an optional `sources` archive and an optional `documentation` sub-module
+  (the inferred documentation chain, see below) appended when the matching flag is set. The `MAVEN` and `MODULAR_TO_MAVEN` layouts wrap the
   user's assembler with a `PomAwareAssembler` that emits a per-project `pom` step seeded with project-wide
   metadata read once from `metadata.properties` (when configured); `MODULAR` does not. Each layout adds a
   top-level `pin` module (sibling of `build`) that walks the BUILD outputs' per-module `inventory.properties`
@@ -342,6 +343,23 @@ Two callbacks govern how the build is assembled, and they are pluggable independ
   process is launched against only its own qualified artifacts, so a project that pins a different version of a
   library the compiler also uses (for example `kotlin-stdlib`) can no longer downgrade the running compiler -
   that library still reaches the compilation classpath, but not the compiler's own runtime.
+- The **inferred documentation chain** (`InferredDocumentationChainModule`) mirrors the compiler chain for API
+  documentation. A `scan` step walks the module's `sources/` and records which languages are present
+  (`.java`, `.kt`, `.scala`, `.groovy`); a `document` sub-module then wires one documentation tool per language
+  and an `aggregate` step that merges their output into a single `javadoc/` tree (archived into the module's
+  `-javadoc.jar`). Java is the baseline: `javadoc` always renders at the tree root in class-path mode (it skips
+  `module-info.java` and documents the sources against the resolved dependencies, so a mixed-language module whose
+  `module-info` exports a package implemented only in another language still produces valid Java docs). Each other
+  language renders through its native tool, resolved on its own qualified trail like the compilers: Kotlin through
+  Dokka (`@dokka`, `dokka-cli` plus `dokka-base` and `analysis-kotlin-descriptors` on the plugins class-path),
+  Scala through `scaladoc` (`@scaladoc`, fed the compiled `.tasty` classes since scaladoc reads tasty rather than
+  source), and Groovy through `groovydoc` (`@groovydoc`). When a single language is present its tool renders at the
+  root and the others are dropped; when more than one is present the native tools render into per-language
+  subfolders (`dokka/`, `scaladoc/`, `groovydoc/`) alongside the Java baseline. Scala and Kotlin tools are version
+  coordinated to the project's resolved compiler version (read from the upstream dependency jars). The chain is
+  best-effort: every tool tolerates a non-zero exit so a documentation tool that fails never fails the build, and
+  `aggregate` always guarantees a root `index.html` (linking to any per-language subfolders that rendered) so the
+  produced `-javadoc.jar`, a Maven Central prerequisite, is never empty.
 
 Layouts always combine their built-in repositories and resolvers (e.g. a Maven default for `MAVEN`, a chained
 Jenesis module repository for `MODULAR`) with any user-provided ones. The merged map then has each sub-module's `assign`

--- a/README.md
+++ b/README.md
@@ -345,23 +345,25 @@ Two callbacks govern how the build is assembled, and they are pluggable independ
   that library still reaches the compilation classpath, but not the compiler's own runtime.
 - The **inferred documentation chain** (`InferredDocumentationChainModule`) mirrors the compiler chain for API
   documentation. A `scan` step walks the module's `sources/` and records which languages are present
-  (`.java`, `.kt`, `.scala`, `.groovy`); a `document` sub-module then wires one documentation tool per language
-  and an `aggregate` step that merges their output into a single `javadoc/` tree (archived into the module's
-  `-javadoc.jar`). Java is the baseline: `javadoc` always renders at the tree root in class-path mode (it skips
-  `module-info.java` and documents the sources against the resolved dependencies, so a mixed-language module whose
-  `module-info` exports a package implemented only in another language still produces valid Java docs). Each other
-  language renders through its native tool, resolved on its own qualified trail like the compilers: Kotlin through
-  Dokka in its **Javadoc output format** (`@dokka`, `dokka-cli` plus `analysis-kotlin-descriptors` and the
-  `javadoc-plugin` - which pulls `dokka-base`, `kotlin-as-java-plugin` and the Korte templating engine - on the
-  plugins class-path, presenting Kotlin as Java so the output is a javadoc-structured tree that `javadoc.io`
-  renders), Scala through `scaladoc` (`@scaladoc`, fed the compiled `.tasty` classes since scaladoc reads tasty
-  rather than source), and Groovy through `groovydoc` (`@groovydoc`). When a single language is present its tool renders at the
-  root and the others are dropped; when more than one is present the native tools render into per-language
-  subfolders (`dokka/`, `scaladoc/`, `groovydoc/`) alongside the Java baseline. Scala and Kotlin tools are version
-  coordinated to the project's resolved compiler version (read from the upstream dependency jars). The chain is
-  best-effort: every tool tolerates a non-zero exit so a documentation tool that fails never fails the build, and
-  `aggregate` always guarantees a root `index.html` (linking to any per-language subfolders that rendered) so the
-  produced `-javadoc.jar`, a Maven Central prerequisite, is never empty.
+  (`.java`, `.kt`, `.scala`, `.groovy`); a `document` sub-module then wires the documentation tools and an
+  `aggregate` step that merges their output into a single `javadoc/` tree (archived into the module's
+  `-javadoc.jar`). The tools are resolved on their own qualified trails like the compilers: Kotlin through Dokka in
+  its **Javadoc output format** (`@dokka`, `dokka-cli` plus `analysis-kotlin-descriptors` and the `javadoc-plugin` -
+  which pulls `dokka-base`, `kotlin-as-java-plugin` and the Korte templating engine - on the plugins class-path,
+  presenting Kotlin as Java so the output is a javadoc-structured tree that `javadoc.io` renders), Scala through
+  `scaladoc` (`@scaladoc`, fed the compiled `.tasty` classes since scaladoc reads tasty rather than source), Groovy
+  through `groovydoc` (`@groovydoc`, in source-path plus package-name mode so packages render correctly), and Java
+  through the JDK's `javadoc` (in class-path mode, skipping `module-info.java`). The layout follows what each tool
+  can cover: Dokka also documents Java (as Java) and `groovydoc` also documents Java, but `scaladoc` documents only
+  Scala. So when **one tool can document every language present**, only that tool runs and renders at the archive
+  root - Java + Kotlin is a single Dokka document, Java + Groovy a single groovydoc document, and a single-language
+  module is just that language's tool. Only when the mix is **incompatible** (Java + Scala, or three or more
+  languages, where no single tool covers everything) does `javadoc` render the Java at the root as the baseline and
+  each remaining language render into its own subfolder (`dokka/`, `scaladoc/`, `groovydoc/`). Scala and Kotlin
+  tools are version coordinated to the project's resolved compiler version (read from the upstream dependency jars).
+  The chain is best-effort: every tool tolerates a non-zero exit so a documentation tool that fails never fails the
+  build, and `aggregate` always guarantees a root `index.html` (linking to any per-language subfolders that
+  rendered) so the produced `-javadoc.jar`, a Maven Central prerequisite, is never empty.
 
 Layouts always combine their built-in repositories and resolvers (e.g. a Maven default for `MAVEN`, a chained
 Jenesis module repository for `MODULAR`) with any user-provided ones. The merged map then has each sub-module's `assign`

--- a/demo/demo-01-java-pom/README.md
+++ b/demo/demo-01-java-pom/README.md
@@ -1,25 +1,21 @@
 Java (POM-based) demo
 =====================
 
-A minimal **Maven-layout** project: a `pom.xml` plus a single Java source with
-one real Maven dependency. It shows Jenesis driving plain `javac` through the
-default `JavaMultiProjectAssembler`, resolving and downloading the declared
-dependency, and pinning it. Its modular counterpart is `../demo-02-java-modular`.
+The simplest way to build a Maven-style Java project with Jenesis: a `pom.xml`
+and your sources. You point Jenesis at the project and it resolves the declared
+dependency, compiles against it, and produces a jar - there is no build script to
+write. Its modular counterpart is `../demo-02-java-modular`.
 
-Printing the dependency tree
-----------------------------
+Build it
+--------
 
-`-Djenesis.project.tree=true` prints the resolved dependency tree as the module
-resolves (a verbose toggle, not a build step):
+From this directory:
 
-    java -Djenesis.project.tree=true build/jenesis/Project.java
+    java build/jenesis/Project.java
 
-    Dependency tree:
-    maven/org.apache.commons/commons-lang3 3.14.0 [compile]
-
-Each node shows the property-file key, the requested version (with the negotiated
-version inline when it differs), and the Maven scope; transitive dependencies nest
-underneath and duplicates are dimmed and marked `(*)`.
+Jenesis auto-detects the MAVEN layout from the `pom.xml`, resolves and downloads
+`commons-lang3` from Maven Central (or `~/.m2`), and compiles `Sample.java`
+against it.
 
 Layout
 ------
@@ -29,19 +25,24 @@ Layout
     |-- pom.xml              Maven coordinates, <sourceDirectory>, one <dependency>; ships pinned
     `-- sources/sample/Sample.java
 
-The presence of `pom.xml` makes Jenesis auto-detect the MAVEN layout.
-`Sample.java` uses `org.apache.commons.lang3.StringUtils`, so the build resolves
-a real dependency from Maven Central (or `~/.m2`).
+`Sample.java` uses `org.apache.commons.lang3.StringUtils`, which is what makes
+the build resolve the real dependency. Under the hood Jenesis drives plain
+`javac` through the default `JavaMultiProjectAssembler`.
 
-Build it
---------
+Printing the dependency tree
+----------------------------
 
-From this directory:
+To see what the build resolves, `-Djenesis.project.tree=true` prints the
+dependency tree as the module resolves (a verbose toggle, not a build step):
 
-    java build/jenesis/Project.java
+    java -Djenesis.project.tree=true build/jenesis/Project.java
 
-Jenesis resolves `commons-lang3`, downloads it, and compiles `Sample.java`
-against it.
+    Dependency tree:
+    maven/org.apache.commons/commons-lang3 3.14.0 [compile]
+
+Each node shows the property-file key, the requested version (with the negotiated
+version inline when it differs), and the Maven scope; transitive dependencies nest
+underneath and duplicates are dimmed and marked `(*)`.
 
 Pinned dependency
 -----------------

--- a/demo/demo-02-java-modular/README.md
+++ b/demo/demo-02-java-modular/README.md
@@ -1,31 +1,24 @@
 Java (modular) demo
 ===================
 
-A single-module **modular** Java project: its only build descriptor is
-`sources/module-info.java` - there is no `pom.xml`. Jenesis auto-detects the
-MODULAR_TO_MAVEN layout, resolves the declared module dependency through the
-Jenesis module repository, and emits a modular jar alongside a generated POM. Its
+The simplest way to build a single-module Java project that is itself a Java
+module: your only build descriptor is `sources/module-info.java`, with no
+`pom.xml` to write. You point Jenesis at the project and it resolves the module
+you `requires`, compiles your module against it, and produces a modular jar. Its
 POM-based counterpart is `../demo-01-java-pom`, and its multi-module counterpart is
 `../demo-04-java-modular-multi`.
 
-Printing the dependency tree
-----------------------------
+Build it
+--------
 
-`-Djenesis.project.tree=true` prints the resolved dependency tree as the module
-resolves (a verbose toggle, not a build step):
+From this directory:
 
-    java -Djenesis.project.tree=true build/jenesis/Project.java
-
-    Dependency tree:
-    maven/org.slf4j/slf4j-api 2.0.16 [compile]
-
-Because this is the default MODULAR_TO_MAVEN layout, `requires org.slf4j` is shown
-as the Maven coordinate it resolves to, with a Maven scope. Under the pure MODULAR
-layout the same dependency shows as a Java module name (`module/org.slf4j`) instead
-- see `../demo-12-module-layout`, which contrasts the two.
+    java build/jenesis/Project.java
 
 Layout
 ------
+
+The whole project is a `module-info.java` plus a source file:
 
     demo/demo-02-java-modular
     |-- build/jenesis        symlink to ../../../sources/build/jenesis
@@ -44,13 +37,6 @@ and a Maven repository (`target/stage/maven`).
 `org.slf4j` is a genuine named Java module (`module-info` with a declared
 version), which is what lets the module overlay resolve it by module name -
 unlike many popular libraries that ship only as *automatic* modules.
-
-Build it
---------
-
-From this directory:
-
-    java build/jenesis/Project.java
 
 Pure modular layout
 -------------------
@@ -96,3 +82,19 @@ SHA-256/<hex>`), which `Download` then verifies on every fetch.
 A modular dependency pins under the plain `module/` prefix (no qualifier) - the
 `@<qualifier>` form is reserved for independent tool trails, as shown in the
 `kotlin` / `scala` and `internal-module` / `external-module` demos.
+
+Printing the dependency tree
+----------------------------
+
+To see what the build resolves, `-Djenesis.project.tree=true` prints the resolved
+dependency tree as the module resolves (a verbose toggle, not a build step):
+
+    java -Djenesis.project.tree=true build/jenesis/Project.java
+
+    Dependency tree:
+    maven/org.slf4j/slf4j-api 2.0.16 [compile]
+
+Because this is the default MODULAR_TO_MAVEN layout, `requires org.slf4j` is shown
+as the Maven coordinate it resolves to, with a Maven scope. Under the pure MODULAR
+layout the same dependency shows as a Java module name (`module/org.slf4j`) instead
+- see `../demo-12-module-layout`, which contrasts the two.

--- a/demo/demo-03-java-pom-multi/README.md
+++ b/demo/demo-03-java-pom-multi/README.md
@@ -1,36 +1,24 @@
 Java (multi-module POM) demo
 ============================
 
-A multi-module **Maven-layout** project. A root aggregator `pom.xml` lists two
-sub-modules, and one sub-module depends on the other plus a real external Maven
-dependency, so the demo shows intra-project and external resolution side by
-side. The `greeter` module also carries a JUnit test, so the demo doubles as a
-MAVEN-layout testing example. Its single-module counterpart is `../demo-01-java-pom`.
+Build a multi-module Maven-style project where one module depends on another:
+a root aggregator `pom.xml` lists two sub-modules, and one sub-module depends on
+the sibling plus a real external Maven dependency, so you get intra-project and
+external resolution side by side with no build script to write. The `greeter`
+module also carries a JUnit test, so the demo doubles as a Maven-layout testing
+example. Its single-module counterpart is `../demo-01-java-pom`.
 
-Printing the dependency tree
-----------------------------
+Build it
+--------
 
-`-Djenesis.project.tree=true` prints each module's resolved tree as it resolves
-(a verbose toggle, not a build step); a multi-module build prints one block per
-module and scope:
+From this directory:
 
-    java -Djenesis.project.tree=true build/jenesis/Project.java
-
-    Dependency tree:
-    maven/org.junit.jupiter/junit-jupiter 5.11.3 [compile]
-    ├─ maven/org.junit.jupiter/junit-jupiter-api 5.11.3 [compile]
-    │  ├─ maven/org.opentest4j/opentest4j 1.3.0 [compile]
-    │  ├─ maven/org.junit.platform/junit-platform-commons 1.11.3 [compile]
-    │  │  └─ maven/org.apiguardian/apiguardian-api 1.1.2 [compile] (*)
-    │  └─ maven/org.apiguardian/apiguardian-api 1.1.2 [compile]
-    └─ maven/org.junit.jupiter/junit-jupiter-engine 5.11.3 [runtime]
-
-Each node shows the property-file key, version, and Maven scope; a dependency
-reached more than once is expanded under its first parent and dimmed with `(*)`
-everywhere else.
+    java build/jenesis/Project.java
 
 Layout
 ------
+
+The project is an aggregator `pom.xml` over two module directories:
 
     demo/demo-03-java-pom-multi
     |-- build/jenesis        symlink to ../../../sources/build/jenesis
@@ -109,13 +97,6 @@ sibling test module; against an already-published project it resolves the deploy
 minimal - it is the same sibling resolution shown above, applied to the `tests`
 variant.
 
-Build it
---------
-
-From this directory:
-
-    java build/jenesis/Project.java
-
 Selecting modules and filtering tests
 -------------------------------------
 
@@ -184,3 +165,25 @@ bill-of-materials Maven projects keep in a parent. Pinning records external
 coordinates (`commons-lang3`, the JUnit closure) but skips the intra-project
 `greeter` dependency, since coordinates produced within the project are never
 pinned into dependency management.
+
+Printing the dependency tree
+----------------------------
+
+To see what each module resolves, `-Djenesis.project.tree=true` prints each
+module's resolved tree as it resolves (a verbose toggle, not a build step); a
+multi-module build prints one block per module and scope:
+
+    java -Djenesis.project.tree=true build/jenesis/Project.java
+
+    Dependency tree:
+    maven/org.junit.jupiter/junit-jupiter 5.11.3 [compile]
+    ├─ maven/org.junit.jupiter/junit-jupiter-api 5.11.3 [compile]
+    │  ├─ maven/org.opentest4j/opentest4j 1.3.0 [compile]
+    │  ├─ maven/org.junit.platform/junit-platform-commons 1.11.3 [compile]
+    │  │  └─ maven/org.apiguardian/apiguardian-api 1.1.2 [compile] (*)
+    │  └─ maven/org.apiguardian/apiguardian-api 1.1.2 [compile]
+    └─ maven/org.junit.jupiter/junit-jupiter-engine 5.11.3 [runtime]
+
+Each node shows the property-file key, version, and Maven scope; a dependency
+reached more than once is expanded under its first parent and dimmed with `(*)`
+everywhere else.

--- a/demo/demo-04-java-modular-multi/README.md
+++ b/demo/demo-04-java-modular-multi/README.md
@@ -1,36 +1,25 @@
 Java (multi-module modular) demo
 ================================
 
-A multi-module **modular** project: every build descriptor is a
-`module-info.java` and there is no `pom.xml` anywhere. One module depends on the
-other plus a real external named module, so the demo shows intra-project and
-external resolution side by side. A third module is the test variant of the
-library, so the demo doubles as a MODULAR_TO_MAVEN testing example. Its
-single-module counterpart is `../demo-02-java-modular`, and its POM-based sibling is
-`../demo-03-java-pom-multi`.
+Build a multi-module project of Java modules where one module depends on another:
+every build descriptor is a `module-info.java` and there is no `pom.xml` anywhere.
+One module `requires` the sibling plus a real external named module, so you get
+intra-project and external resolution side by side with no build script to write.
+A third module is the test variant of the library, so the demo doubles as a
+modular testing example. Its single-module counterpart is `../demo-02-java-modular`,
+and its POM-based sibling is `../demo-03-java-pom-multi`.
 
-Printing the dependency tree
-----------------------------
+Build it
+--------
 
-`-Djenesis.project.tree=true` prints each module's resolved tree as it resolves
-(a verbose toggle, not a build step), one block per module and scope:
+From this directory:
 
-    java -Djenesis.project.tree=true build/jenesis/Project.java
-
-    Dependency tree:
-    maven/org.junit.jupiter/junit-jupiter 5.11.3 [compile]
-    ├─ maven/org.junit.jupiter/junit-jupiter-api 5.11.3 [compile]
-    │  └─ maven/org.junit.platform/junit-platform-commons 1.11.3 [compile]
-    └─ maven/org.junit.jupiter/junit-jupiter-engine 5.11.3 [runtime]
-
-Even though every descriptor here is a `module-info.java`, the default
-MODULAR_TO_MAVEN layout resolves each `requires` through Maven, so the tree shows
-Maven coordinates and their transitive Maven closure - the same shape as the
-POM-based `../demo-03-java-pom-multi`. The pure MODULAR layout
-(`../demo-12-module-layout`) shows the same dependencies as Java module names.
+    java build/jenesis/Project.java
 
 Layout
 ------
+
+The project is three module directories, each with its own `module-info.java`:
 
     demo/demo-04-java-modular-multi
     |-- build/jenesis        symlink to ../../../sources/build/jenesis
@@ -93,13 +82,6 @@ line the tests compile against - though the `@jenesis.pin org.junit.platform.con
 tag overrides that default, so the pinned version always wins. Unlike the `pin` runs of the other demos, the JUnit closure is kept on
 the test module alone rather than propagated project-wide, to keep `greeter` and
 `app` focused on their own dependencies.
-
-Build it
---------
-
-From this directory:
-
-    java build/jenesis/Project.java
 
 Selecting modules and filtering tests
 -------------------------------------
@@ -181,3 +163,24 @@ version closure back into the module declarations and is idempotent. The
 intra-project `demo.greeter` dependency is never pinned, since coordinates
 produced within the project are resolved from the build itself rather than
 downloaded.
+
+Printing the dependency tree
+----------------------------
+
+To see what each module resolves, `-Djenesis.project.tree=true` prints each
+module's resolved tree as it resolves (a verbose toggle, not a build step), one
+block per module and scope:
+
+    java -Djenesis.project.tree=true build/jenesis/Project.java
+
+    Dependency tree:
+    maven/org.junit.jupiter/junit-jupiter 5.11.3 [compile]
+    ├─ maven/org.junit.jupiter/junit-jupiter-api 5.11.3 [compile]
+    │  └─ maven/org.junit.platform/junit-platform-commons 1.11.3 [compile]
+    └─ maven/org.junit.jupiter/junit-jupiter-engine 5.11.3 [runtime]
+
+Even though every descriptor here is a `module-info.java`, the default
+MODULAR_TO_MAVEN layout resolves each `requires` through Maven, so the tree shows
+Maven coordinates and their transitive Maven closure - the same shape as the
+POM-based `../demo-03-java-pom-multi`. The pure MODULAR layout
+(`../demo-12-module-layout`) shows the same dependencies as Java module names.

--- a/demo/demo-05-java-pom-executable/README.md
+++ b/demo/demo-05-java-pom-executable/README.md
@@ -1,19 +1,43 @@
 Executable Java (POM-based) demo
 ================================
 
-A minimal **Maven-layout** project that is also **runnable**: a `pom.xml` plus a
-single Java source with a `main` method and one real Maven dependency
-(`commons-lang3`), packaged into a native application image by the JDK's
-`jpackage`. It is the executable counterpart of `../demo-01-java-pom`, and its modular
-sibling is `../demo-06-java-modular-executable`.
+Take a Maven-layout Java app and ship it as a self-contained native application
+image - a launcher with its own bundled Java runtime that a user can run without
+installing a JDK. The project is just a `pom.xml` plus a single Java source with a
+`main` method and one real Maven dependency (`commons-lang3`), and Jenesis packages
+it with the JDK's `jpackage`. It is the executable counterpart of
+`../demo-01-java-pom`, and its modular sibling is `../demo-06-java-modular-executable`.
+
+Run it
+------
+
+From this directory, pass the arguments you want the packaged application to
+receive on its command line:
+
+    java build/Demo.java ada lovelace
+
+`Demo.java` configures packaging directly on the assembler -
+`new JavaMultiProjectAssembler().packaging("app-image")`, the in-code equivalent of
+`-Djenesis.java.package=app-image` with no system property - builds the `stage` goal,
+then reads the image folder from the `stage/packages` entry of the map that
+`build("stage")` returns (a fixed build target) and launches the produced platform
+launcher with your arguments. The packaged app prints:
+
+    Hello, Ada lovelace, from a packaged Maven project built by Jenesis!
+
+(`commons-lang3`'s `StringUtils.capitalize` upper-cased the leading `a`, proving the
+bundled dependency is on the launched app's classpath.) With no arguments it greets
+`World`. Building the plain `java build/jenesis/Project.java` (no `package` property)
+compiles and jars the project exactly as `../demo-01-java-pom` does, without producing an image.
 
 Declaring the entry point
 --------------------------
 
-A module becomes runnable when the build knows its main class. In the modular
-layout that comes from a `@jenesis.main` Javadoc tag on `module-info.java` (see
-`../demo-06-java-modular-executable`). A POM project has no `module-info.java`, so the
-Maven-layout equivalent is a `<mainClass>` property in the POM:
+For the build to package a runnable image it first has to know the main class. In
+the modular layout that comes from a `@jenesis.main` Javadoc tag on
+`module-info.java` (see `../demo-06-java-modular-executable`). A POM project has no
+`module-info.java`, so the Maven-layout equivalent is a `<mainClass>` property in
+the POM:
 
     <properties>
         <mainClass>sample.Sample</mainClass>
@@ -56,28 +80,6 @@ into `stage/packages/`, the staging analogue of `stage/maven` and `stage/modular
     `-- packages/output/java-pom-executable/
         |-- bin/java-pom-executable      the launcher
         `-- lib/                          app jars + bundled runtime
-
-Run it
-------
-
-From this directory, pass the arguments you want the packaged application to
-receive on its command line:
-
-    java build/Demo.java ada lovelace
-
-`Demo.java` configures packaging directly on the assembler -
-`new JavaMultiProjectAssembler().packaging("app-image")`, the in-code equivalent of
-`-Djenesis.java.package=app-image` with no system property - builds the `stage` goal,
-then reads the image folder from the `stage/packages` entry of the map that
-`build("stage")` returns (a fixed build target) and launches the produced platform
-launcher with your arguments. The packaged app prints:
-
-    Hello, Ada lovelace, from a packaged Maven project built by Jenesis!
-
-(`commons-lang3`'s `StringUtils.capitalize` upper-cased the leading `a`, proving the
-bundled dependency is on the launched app's classpath.) With no arguments it greets
-`World`. Building the plain `java build/jenesis/Project.java` (no `package` property)
-compiles and jars the project exactly as `../demo-01-java-pom` does, without producing an image.
 
 Fully bundled native installer
 ------------------------------

--- a/demo/demo-06-java-modular-executable/README.md
+++ b/demo/demo-06-java-modular-executable/README.md
@@ -1,17 +1,43 @@
 Executable Java (modular) demo
 ==============================
 
-A minimal **modular** project that is also **runnable**: a `module-info.java`
-plus a single Java source with a `main` method and one real module dependency
-(`org.slf4j`), packaged into a native application image by the JDK's `jpackage`.
-It is the executable counterpart of `../demo-02-java-modular`, and its POM-based sibling
-is `../demo-05-java-pom-executable`.
+Take a modular Java app and ship it as a self-contained native application image -
+a launcher with its own bundled Java runtime that a user can run without installing
+a JDK, and one that stays small because the runtime is trimmed to the module graph.
+The project is just a `module-info.java` plus a single Java source with a `main`
+method and one real module dependency (`org.slf4j`), and Jenesis packages it with
+the JDK's `jpackage`. It is the executable counterpart of `../demo-02-java-modular`,
+and its POM-based sibling is `../demo-05-java-pom-executable`.
+
+Run it
+------
+
+From this directory, pass the arguments you want the packaged application to
+receive on its command line:
+
+    java build/Demo.java Ada Lovelace
+
+`Demo.java` configures packaging directly on the assembler -
+`new JavaMultiProjectAssembler().packaging("app-image")`, the in-code equivalent of
+`-Djenesis.java.package=app-image` with no system property - builds the `stage` goal,
+then reads the image folder from the `stage/packages` entry of the map that
+`build("stage")` returns (a fixed build target) and launches the produced platform
+launcher with your arguments. The packaged app prints:
+
+    Hello, Ada Lovelace, from a packaged Java module built by Jenesis!
+
+(Because no SLF4J backend is bundled, SLF4J prints a one-time "no providers" notice
+and uses a no-op logger - the `slf4j-api` jar is still bundled and on the app's
+classpath.) With no arguments it greets `world`. Building the plain
+`java build/jenesis/Project.java` (no `package` property) compiles and jars the
+module exactly as `../demo-02-java-modular` does, without producing an image.
 
 Declaring the entry point with `@jenesis.main`
 ----------------------------------------------
 
-A module becomes runnable when the build knows its main class. In the modular
-layout that is declared with a `@jenesis.main` Javadoc tag on `module-info.java`:
+For the build to package a runnable image it first has to know the main class. In
+the modular layout that is declared with a `@jenesis.main` Javadoc tag on
+`module-info.java`:
 
     /**
      * @jenesis.release 25
@@ -66,29 +92,6 @@ into `stage/packages/`, the staging analogue of `stage/maven` and `stage/modular
     `-- packages/output/demo.modular.executable/
         |-- bin/demo.modular.executable             the launcher
         `-- lib/                                     app jars + bundled runtime
-
-Run it
-------
-
-From this directory, pass the arguments you want the packaged application to
-receive on its command line:
-
-    java build/Demo.java Ada Lovelace
-
-`Demo.java` configures packaging directly on the assembler -
-`new JavaMultiProjectAssembler().packaging("app-image")`, the in-code equivalent of
-`-Djenesis.java.package=app-image` with no system property - builds the `stage` goal,
-then reads the image folder from the `stage/packages` entry of the map that
-`build("stage")` returns (a fixed build target) and launches the produced platform
-launcher with your arguments. The packaged app prints:
-
-    Hello, Ada Lovelace, from a packaged Java module built by Jenesis!
-
-(Because no SLF4J backend is bundled, SLF4J prints a one-time "no providers" notice
-and uses a no-op logger - the `slf4j-api` jar is still bundled and on the app's
-classpath.) With no arguments it greets `world`. Building the plain
-`java build/jenesis/Project.java` (no `package` property) compiles and jars the
-module exactly as `../demo-02-java-modular` does, without producing an image.
 
 Fully bundled native installer
 ------------------------------

--- a/demo/demo-07-java-multi-release/README.md
+++ b/demo/demo-07-java-multi-release/README.md
@@ -1,44 +1,12 @@
 Multi-release JAR demo
 ======================
 
-A **modular** project (MODULAR_TO_MAVEN layout) that builds a single
-multi-release JAR: the module compiles at Java 21, and one utility class is
-overridden for Java 25. At runtime the JVM picks the implementation matching its
-own feature version, so the same JAR prints a different line on Java 21 than on
-Java 25. Its non-versioned counterpart is `../demo-02-java-modular`.
-
-Layout
-------
-
-    demo/demo-07-java-multi-release
-    |-- build/jenesis                                  symlink to ../../../sources/build/jenesis
-    `-- sources
-        |-- module-info.java                           @jenesis.release 21, @jenesis.main sample.Sample
-        |-- sample/Sample.java                         entry point; prints the runtime version and the greeting
-        |-- sample/Platform.java                       the Java 21 baseline utility
-        `-- META-INF/versions/25/sample/Platform.java  the Java 25 override of that utility
-
-With a `module-info.java` and no `pom.xml`, Jenesis auto-detects the
-MODULAR_TO_MAVEN layout and emits a modular jar alongside a generated POM. The
-`@jenesis.release 21` tag pins the main compile to Java 21. Any source under
-`sources/META-INF/versions/<N>/` is a multi-release overlay: Jenesis compiles it
-in a separate pass with `--release <N>` and writes the classes to
-`META-INF/versions/<N>/` inside the JAR. When an overlay is produced, the build
-marks the JAR's manifest with `Multi-Release: true`, which is what tells the JVM
-to consult the versioned directory.
-
-Build it
---------
-
-From this directory:
-
-    java build/jenesis/Project.java
-
-The `javac` step compiles `module-info.java`, `Sample.java`, and the baseline
-`Platform.java` at release 21, then runs a second pass over
-`META-INF/versions/25/sample/Platform.java` at release 25. The produced
-`classes.jar` carries both copies of `sample.Platform` and a `Multi-Release: true`
-manifest.
+Build one JAR that runs differently depending on the Java version it lands on. The
+module compiles at Java 21, and one utility class is overridden for Java 25; at
+runtime the JVM picks the implementation matching its own feature version, so the
+same JAR prints a different line on Java 21 than on Java 25. It is a modular project
+(MODULAR_TO_MAVEN layout), and its non-versioned counterpart is
+`../demo-02-java-modular`.
 
 Run it
 ------
@@ -60,6 +28,42 @@ Run the same JAR on a Java 21 runtime and the baseline class is loaded instead:
 
 That difference is the whole point: one artifact, two implementations of
 `sample.Platform`, selected by the JVM at launch from the version directory.
+
+Build it
+--------
+
+To build the JAR without launching it, run the project goal directly from this
+directory:
+
+    java build/jenesis/Project.java
+
+The `javac` step compiles `module-info.java`, `Sample.java`, and the baseline
+`Platform.java` at release 21, then runs a second pass over
+`META-INF/versions/25/sample/Platform.java` at release 25. The produced
+`classes.jar` carries both copies of `sample.Platform` and a `Multi-Release: true`
+manifest.
+
+Layout
+------
+
+The pieces that make up the versioned build:
+
+    demo/demo-07-java-multi-release
+    |-- build/jenesis                                  symlink to ../../../sources/build/jenesis
+    `-- sources
+        |-- module-info.java                           @jenesis.release 21, @jenesis.main sample.Sample
+        |-- sample/Sample.java                         entry point; prints the runtime version and the greeting
+        |-- sample/Platform.java                       the Java 21 baseline utility
+        `-- META-INF/versions/25/sample/Platform.java  the Java 25 override of that utility
+
+With a `module-info.java` and no `pom.xml`, Jenesis auto-detects the
+MODULAR_TO_MAVEN layout and emits a modular jar alongside a generated POM. The
+`@jenesis.release 21` tag pins the main compile to Java 21. Any source under
+`sources/META-INF/versions/<N>/` is a multi-release overlay: Jenesis compiles it
+in a separate pass with `--release <N>` and writes the classes to
+`META-INF/versions/<N>/` inside the JAR. When an overlay is produced, the build
+marks the JAR's manifest with `Multi-Release: true`, which is what tells the JVM
+to consult the versioned directory.
 
 No dependencies
 ---------------

--- a/demo/demo-08-kotlin/README.md
+++ b/demo/demo-08-kotlin/README.md
@@ -1,25 +1,10 @@
 Kotlin demo
 ===========
 
-A MODULAR_TO_MAVEN project (a `module-info.java`, no `pom.xml`) that mixes Java
-and Kotlin in one module of the Java module system. It shows Jenesis detecting
-the `.kt` sources and driving the Kotlin compiler through the default
-`JavaMultiProjectAssembler`, with `javac` participating for `module-info.java`
-and the companion `.java` file. The module exports both a mixed package and a
-package that holds only Kotlin.
-
-Layout
-------
-
-    demo/demo-08-kotlin
-    |-- build/jenesis              symlink to ../../../sources/build/jenesis
-    `-- sources
-        |-- module-info.java       requires kotlin.stdlib; exports sample; exports sample.pure
-        `-- sample
-            |-- Greeter.java       a Java type in the exported 'sample' package
-            |-- Sample.kt          Kotlin that calls Greeter
-            `-- pure
-                `-- Pure.kt        a pure-Kotlin package, exported with no Java type
+Build a project that mixes Java and Kotlin in one module of the Java module
+system, and export a package that holds only Kotlin. You point Jenesis at the
+project, it compiles the `.java` and `.kt` sources together, and emits a modular
+jar alongside a generated POM - there is no build script to write.
 
 Build it
 --------
@@ -31,6 +16,30 @@ From this directory:
 Jenesis auto-detects the MODULAR_TO_MAVEN layout (a `module-info.java`, no
 `pom.xml`), resolves the Kotlin compiler, compiles the module, and emits a
 modular jar alongside a generated POM.
+
+Layout
+------
+
+The module declares its dependency in `module-info.java` and lays the mixed
+sources out under one package:
+
+    demo/demo-08-kotlin
+    |-- build/jenesis              symlink to ../../../sources/build/jenesis
+    `-- sources
+        |-- module-info.java       requires kotlin.stdlib; exports sample; exports sample.pure
+        `-- sample
+            |-- Greeter.java       a Java type in the exported 'sample' package
+            |-- Sample.kt          Kotlin that calls Greeter
+            `-- pure
+                `-- Pure.kt        a pure-Kotlin package, exported with no Java type
+
+How Jenesis builds it
+---------------------
+
+Jenesis detects the `.kt` sources and drives the Kotlin compiler through the
+default `JavaMultiProjectAssembler`, with `javac` participating for
+`module-info.java` and the companion `.java` file. The module exports both a
+mixed package and a package that holds only Kotlin.
 
 Compile order and exporting a Kotlin package
 --------------------------------------------

--- a/demo/demo-09-scala/README.md
+++ b/demo/demo-09-scala/README.md
@@ -1,25 +1,10 @@
 Scala demo
 ==========
 
-A MODULAR_TO_MAVEN project (a `module-info.java`, no `pom.xml`) that mixes Java
-and Scala 3 in one module of the Java module system. It shows Jenesis detecting
-the `.scala` sources and driving the Scala compiler through the default
-`JavaMultiProjectAssembler`, with `javac` participating for `module-info.java`
-and the companion `.java` file. The module exports both a mixed package and a
-package that holds only Scala.
-
-Layout
-------
-
-    demo/demo-09-scala
-    |-- build/jenesis              symlink to ../../../sources/build/jenesis
-    `-- sources
-        |-- module-info.java       requires scala.library; exports sample; exports sample.pure
-        `-- sample
-            |-- Greeter.java       a Java type in the exported 'sample' package
-            |-- Sample.scala       Scala that calls Greeter
-            `-- pure
-                `-- Pure.scala     a pure-Scala package, exported with no Java type
+Build a project that mixes Java and Scala 3 in one module of the Java module
+system, and export a package that holds only Scala. You point Jenesis at the
+project, it compiles the `.java` and `.scala` sources together, and emits a
+modular jar alongside a generated POM - there is no build script to write.
 
 Build it
 --------
@@ -33,6 +18,30 @@ Jenesis auto-detects the MODULAR_TO_MAVEN layout (a `module-info.java`, no
 modular jar alongside a generated POM. The `requires scala.library` directive
 resolves to `org.scala-lang:scala-library`, the jar that carries the Scala
 standard library.
+
+Layout
+------
+
+The module declares its dependency in `module-info.java` and lays the mixed
+sources out under one package:
+
+    demo/demo-09-scala
+    |-- build/jenesis              symlink to ../../../sources/build/jenesis
+    `-- sources
+        |-- module-info.java       requires scala.library; exports sample; exports sample.pure
+        `-- sample
+            |-- Greeter.java       a Java type in the exported 'sample' package
+            |-- Sample.scala       Scala that calls Greeter
+            `-- pure
+                `-- Pure.scala     a pure-Scala package, exported with no Java type
+
+How Jenesis builds it
+---------------------
+
+Jenesis detects the `.scala` sources and drives the Scala compiler through the
+default `JavaMultiProjectAssembler`, with `javac` participating for
+`module-info.java` and the companion `.java` file. The module exports both a
+mixed package and a package that holds only Scala.
 
 Compile order and exporting a Scala package
 -------------------------------------------

--- a/demo/demo-10-groovy/README.md
+++ b/demo/demo-10-groovy/README.md
@@ -1,22 +1,10 @@
 Groovy demo
 ===========
 
-A MODULAR_TO_MAVEN project (a `module-info.java`, no `pom.xml`) whose single
-module mixes a Java type with a Groovy type. It shows Jenesis driving the Groovy
-compiler through the default `JavaMultiProjectAssembler`, with the module
-participating in the Java module system and emitting a modular jar alongside a
-generated POM.
-
-Layout
-------
-
-    demo/demo-10-groovy
-    |-- build/jenesis              symlink to ../../../sources/build/jenesis
-    `-- sources
-        |-- module-info.java       requires org.apache.groovy; exports sample
-        `-- sample
-            |-- Greeter.java       a Java type in the exported package
-            `-- Sample.groovy      a Groovy type that calls Greeter
+Build a project that mixes a Java type with a Groovy type in one module of the
+Java module system. You point Jenesis at the project, it compiles the `.java` and
+`.groovy` sources together, and emits a modular jar alongside a generated POM -
+there is no build script to write.
 
 Build it
 --------
@@ -29,6 +17,27 @@ Jenesis auto-detects the MODULAR_TO_MAVEN layout (a `module-info.java`, no
 `pom.xml`), scans the sources, resolves the Groovy compiler, compiles
 `module-info.java` and `Greeter.java` with `javac`, then compiles `Sample.groovy`
 with `groovyc`, and packages a modular jar plus a generated POM.
+
+Layout
+------
+
+The module declares its dependency in `module-info.java` and keeps the Java and
+Groovy types in one package:
+
+    demo/demo-10-groovy
+    |-- build/jenesis              symlink to ../../../sources/build/jenesis
+    `-- sources
+        |-- module-info.java       requires org.apache.groovy; exports sample
+        `-- sample
+            |-- Greeter.java       a Java type in the exported package
+            `-- Sample.groovy      a Groovy type that calls Greeter
+
+How Jenesis builds it
+---------------------
+
+Jenesis drives the Groovy compiler through the default
+`JavaMultiProjectAssembler`, with the module participating in the Java module
+system and emitting a modular jar alongside a generated POM.
 
 How Groovy fits the inferred compiler chain
 -------------------------------------------

--- a/demo/demo-11-maven-exclusions/README.md
+++ b/demo/demo-11-maven-exclusions/README.md
@@ -1,19 +1,40 @@
 Maven dependency exclusions demo
 ================================
 
-A single **Maven-layout** project that declares one dependency with an
-`<exclusions>` block, and a test that proves the excluded transitive is not on
-the class path.
+Exclude an unwanted transitive dependency so it never reaches the class path.
+You declare one dependency with an `<exclusions>` block in a Maven-layout
+`pom.xml`, point Jenesis at the project, and a bundled test proves the excluded
+transitive is gone.
 
-Why only Maven? Exclusions are a Maven-graph concept: a dependency drags in a
-transitive subtree, and `<exclusions>` prunes part of it. A **modular** project
-does not have the same problem to solve - a module only sees what its
-`module-info.java` `requires`, so an unwanted transitive cannot silently appear
-on the module path, and there is no `<exclusions>` equivalent to add. So this
-idea is shown here, and only here, on a Maven project.
+Build it
+--------
+
+    java build/jenesis/Project.java
+
+The build compiles the sources and runs `ExclusionTest`, which checks the class
+path directly:
+
+- `commons-text`'s `StringSubstitutor.class` **is** present (the dependency
+  resolved);
+- `commons-lang3`'s `StringUtils.class` is **not** present (the exclusion took
+  effect).
+
+The test looks the classes up as **resources** rather than with
+`Class.forName(...)`: loading a Commons Text class would link it against the
+now-missing Commons Lang and fail with `NoClassDefFoundError` - which is itself a
+good illustration of why excluding a hard transitive is usually something you do
+to *replace* it, not to drop it outright. Resource lookup just asks whether each
+`.class` is on the class path, which is exactly what the exclusion changes.
+
+Like Maven, the exclusion applies to the whole module, test class path included:
+test scope extends compile scope, so the pruned transitive is absent when the
+tests run, not just when the main code does.
 
 Layout
 ------
+
+A single Maven-layout project: a `pom.xml`, the sources, and the test that proves
+the exclusion took effect.
 
     demo-11-maven-exclusions
     |-- build/jenesis            symlink to ../../../sources/build/jenesis
@@ -39,29 +60,15 @@ dependency. The POM keeps Commons Text but drops Lang:
         </exclusions>
     </dependency>
 
-Build it
---------
+Why only Maven?
+---------------
 
-    java build/jenesis/Project.java
-
-The build compiles the sources and runs `ExclusionTest`, which checks the class
-path directly:
-
-- `commons-text`'s `StringSubstitutor.class` **is** present (the dependency
-  resolved);
-- `commons-lang3`'s `StringUtils.class` is **not** present (the exclusion took
-  effect).
-
-The test looks the classes up as **resources** rather than with
-`Class.forName(...)`: loading a Commons Text class would link it against the
-now-missing Commons Lang and fail with `NoClassDefFoundError` - which is itself a
-good illustration of why excluding a hard transitive is usually something you do
-to *replace* it, not to drop it outright. Resource lookup just asks whether each
-`.class` is on the class path, which is exactly what the exclusion changes.
-
-Like Maven, the exclusion applies to the whole module, test class path included:
-test scope extends compile scope, so the pruned transitive is absent when the
-tests run, not just when the main code does.
+Exclusions are a Maven-graph concept: a dependency drags in a transitive subtree,
+and `<exclusions>` prunes part of it. A **modular** project does not have the same
+problem to solve - a module only sees what its `module-info.java` `requires`, so
+an unwanted transitive cannot silently appear on the module path, and there is no
+`<exclusions>` equivalent to add. So this idea is shown here, and only here, on a
+Maven project.
 
 Pinned dependencies
 -------------------

--- a/demo/demo-12-module-layout/README.md
+++ b/demo/demo-12-module-layout/README.md
@@ -1,10 +1,28 @@
 Pure modular layout demo
 ========================
 
-The same kind of modular project as `../demo-02-java-modular`, but built with the
-**MODULAR** layout selected explicitly instead of the default MODULAR_TO_MAVEN.
-The point of this demo is the layout choice itself: a pure-modular build resolves
-dependencies by Java module name and produces a modular jar with **no `pom.xml`**.
+Build a modular Java project whose artifacts are consumed only as Java modules:
+dependencies are resolved by Java module name and the build produces a modular
+jar with no `pom.xml` at all. This is the same kind of project as
+`../demo-02-java-modular`, but with the pure MODULAR layout selected explicitly
+instead of the default MODULAR_TO_MAVEN, so the build stays free of Maven
+coordinates end to end.
+
+Run it
+------
+
+    java build/Demo.java
+
+`requires org.slf4j` is satisfied by fetching `org.slf4j` as a named module from
+the module repository. Building leaves **no `pom.xml`** anywhere under `target/`
+(contrast `../demo-02-java-modular`, the same project under MODULAR_TO_MAVEN, which
+emits one). Staging shows the same split:
+
+    java build/Demo.java stage      # target/stage/modular only - no target/stage/maven
+
+`export` then publishes the modular jar (and any `.jmod`) into the local Jenesis
+module repository (`~/.jenesis`), keyed by module name and version, with no Maven
+coordinate anywhere in the pipeline.
 
 Selecting the layout in code
 ----------------------------
@@ -82,22 +100,6 @@ node is a Maven artifact carrying a Maven scope:
 In a project with transitive dependencies the Maven side expands the full
 nearest-wins closure (resolved versions, scopes, and duplicates dimmed and marked
 `(*)`), while the modular side stays a graph of named modules.
-
-Run it
-------
-
-    java build/Demo.java
-
-`requires org.slf4j` is satisfied by fetching `org.slf4j` as a named module from
-the module repository. Building leaves **no `pom.xml`** anywhere under `target/`
-(contrast `../demo-02-java-modular`, the same project under MODULAR_TO_MAVEN, which
-emits one). Staging shows the same split:
-
-    java build/Demo.java stage      # target/stage/modular only - no target/stage/maven
-
-`export` then publishes the modular jar (and any `.jmod`) into the local Jenesis
-module repository (`~/.jenesis`), keyed by module name and version, with no Maven
-coordinate anywhere in the pipeline.
 
 When to use it
 --------------

--- a/demo/demo-13-custom-assembler/README.md
+++ b/demo/demo-13-custom-assembler/README.md
@@ -1,26 +1,13 @@
 Custom assembler demo
 =====================
 
-A `Project` whose `JavaMultiProjectAssembler` is **wrapped** by a custom
-assembler that preprocesses each module's Java sources before the regular
-compile, jar, and test flow runs. The preprocessing here is a simple textual
-substitution: the `${greeting}` placeholder in `Sample.java` is rewritten to a
-real message, so the value that ends up compiled into the jar is the substituted
-one. Built with the stock assembler, the placeholder would survive verbatim.
-
-Layout
-------
-
-    demo/demo-13-custom-assembler
-    |-- build/jenesis        symlink to ../../../sources/build/jenesis
-    |-- build/Demo.java    the launcher: wires the wrapping assembler, builds, runs
-    `-- sources/
-        |-- module-info.java     module demo.custom { exports sample; } (@jenesis.main)
-        `-- sample/Sample.java    defines GREETING = "${greeting}", prints its substituted value
-
-With a `module-info.java` and no `pom.xml`, Jenesis auto-detects the
-MODULAR_TO_MAVEN layout and emits a modular jar (plus a generated POM), exactly
-as the `java-modular` demo does. The only difference is the assembler.
+Run a preprocessing pass over your Java sources before they are compiled, so the
+code that lands in the jar is the transformed version rather than what you wrote
+on disk. Here the transformation is a simple textual substitution: the
+`${greeting}` placeholder in `Sample.java` is rewritten to a real message before
+the regular compile, jar, and test flow runs, so the value compiled into the jar
+is the substituted one. Built with the stock build, the placeholder would survive
+verbatim.
 
 Run it
 ------
@@ -48,9 +35,24 @@ which prints:
 Built with the stock assembler instead, the same command would print the
 unsubstituted `${greeting}` placeholder.
 
+Layout
+------
+
+    demo/demo-13-custom-assembler
+    |-- build/jenesis        symlink to ../../../sources/build/jenesis
+    |-- build/Demo.java    the launcher: wires the wrapping assembler, builds, runs
+    `-- sources/
+        |-- module-info.java     module demo.custom { exports sample; } (@jenesis.main)
+        `-- sample/Sample.java    defines GREETING = "${greeting}", prints its substituted value
+
+With a `module-info.java` and no `pom.xml`, Jenesis auto-detects the
+MODULAR_TO_MAVEN layout and emits a modular jar (plus a generated POM), exactly
+as the `java-modular` demo does. The only difference is the assembler.
+
 How the wrapping works
 ----------------------
 
+The preprocessing is delivered by a custom assembler that wraps the stock one.
 `Project.assembler(...)` accepts any
 `MultiProjectAssembler<? super ProjectModuleDescriptor>`. The default is
 `JavaMultiProjectAssembler`; this demo passes a `PreprocessingAssembler` that

--- a/demo/demo-14-custom-jmod/README.md
+++ b/demo/demo-14-custom-jmod/README.md
@@ -1,11 +1,35 @@
 Custom jmod + jlink + jpackage demo
 ===================================
 
-A custom assembler that packages **extra, non-class content** into a module's
-`.jmod`, links it into a **runtime image** with `jlink`, and wraps that runtime in
-a self-contained **application image** with `jpackage` - the full chain by which a
-jmod's content reaches a packaged, runnable app, and the case where the jmod form
-is worth more than a jar.
+Ship a self-contained application image that carries extra, non-class content -
+here a config file - all the way into the packaged app. The build packs that
+content into the module's `.jmod`, links it into a runtime image with `jlink`,
+and wraps the runtime in an application image with `jpackage`, so the launched
+app can read the file back from its own runtime. This is the case where the jmod
+form is worth more than a jar, since a jar cannot carry this content where the
+runtime needs it.
+
+Run it
+------
+
+From this directory:
+
+    java build/Demo.java
+
+It builds the module, packs `classes/` plus `jmodconfig/` into `demo.config.jmod`,
+links that jmod into a runtime image, wraps the runtime into a `demo.config`
+application image, and then launches the packaged app. The app reads its config
+back from the runtime that `jpackage` bundled into it:
+
+    The packaged app read its bundled config from .../demo.config/lib/runtime/conf/app.properties:
+    Configured in a .jmod, linked into the runtime by jlink
+
+Built from the jar instead, that file would be stranded inside the jar rather
+than sitting in the runtime's `conf/` where the launched app can read it from
+`<java.home>/conf/app.properties`.
+
+Why a jmod here
+---------------
 
 A jar can only hold classes and resources; an embedded resource stays inside the
 jar at runtime. A `.jmod` additionally has dedicated sections for native
@@ -83,22 +107,3 @@ rest. `jlink` reads the module from the `.jmod` (not the jar) and gets its
 `--add-modules` root from the `prepare` step's `jlink.properties`; `jpackage`,
 seeing a `jlink` runtime among its inputs, wraps it with `--runtime-image` rather
 than linking its own, so the jmod content carries through into the image.
-
-Run it
-------
-
-From this directory:
-
-    java build/Demo.java
-
-It builds the module, packs `classes/` plus `jmodconfig/` into `demo.config.jmod`,
-links that jmod into a runtime image, wraps the runtime into a `demo.config`
-application image, and then launches the packaged app. The app reads its config
-back from the runtime that `jpackage` bundled into it:
-
-    The packaged app read its bundled config from .../demo.config/lib/runtime/conf/app.properties:
-    Configured in a .jmod, linked into the runtime by jlink
-
-Built from the jar instead, that file would be stranded inside the jar rather
-than sitting in the runtime's `conf/` where the launched app can read it from
-`<java.home>/conf/app.properties`.

--- a/demo/demo-15-internal-module/README.md
+++ b/demo/demo-15-internal-module/README.md
@@ -1,19 +1,27 @@
 InternalModule demo
 ===================
 
-This demo does the same thing as `../demo-13-custom-assembler`: it wraps the stock
-`JavaMultiProjectAssembler` so the project's Java sources are preprocessed (a
-`${greeting}` substitution) before the regular compile, jar, and test flow runs.
-The difference is *where the preprocessing lives*. Instead of an inline build
-step, the substitution is performed by a **build module** (`BuildExecutorModule`
-service provider) that `InternalModule` loads straight from local source - and
-that build module uses an **external dependency** (`org.json`) to drive the
-substitution.
+Drive a source preprocessing pass from a reusable build module - a plugin kept in
+its own project, loaded straight from local source - instead of an inline build
+step. The plugin performs a `${greeting}` substitution over the project's Java
+sources before the regular compile, jar, and test flow runs, and it leans on an
+external dependency (`org.json`) to do so. The companion
+`../demo-16-external-module` runs the identical plugin, but resolves it as a
+published artifact rather than compiling it from source.
 
-The plugin's `build.jenesis` dependency resolves from the default Jenesis
-repository as the published `0.3.0` artifact (pinned via the `@tool/build.jenesis`
-tag in `sources/module-info.java`), whose API matches the local sources the host
-runs against, so the class-loader bridge loads it without complaint.
+Run it
+------
+
+From this directory:
+
+    java build/Demo.java
+
+which builds the project and then launches the built module, printing the
+greeting the plugin substituted in:
+
+    Hello from a source preprocessed by an internal build module, using the org.json dependency!
+
+Built without the plugin the literal `${greeting}` would print instead.
 
 Layout
 ------
@@ -38,19 +46,10 @@ The project under `sources/` is an ordinary modular project, exactly like
 project; its `.jenesis.skip` marker keeps the host project's module discovery
 from mistaking it for a second project module.
 
-Run it
-------
-
-From this directory:
-
-    java build/Demo.java
-
-which builds the project and then launches the built module, printing the
-greeting the plugin substituted in:
-
-    Hello from a source preprocessed by an internal build module, using the org.json dependency!
-
-Built without the plugin the literal `${greeting}` would print instead.
+The plugin's `build.jenesis` dependency resolves from the default Jenesis
+repository as the published `0.3.0` artifact (pinned via the `@tool/build.jenesis`
+tag in `sources/module-info.java`), whose API matches the local sources the host
+runs against, so the class-loader bridge loads it without complaint.
 
 How it works
 ------------

--- a/demo/demo-16-external-module/README.md
+++ b/demo/demo-16-external-module/README.md
@@ -1,19 +1,28 @@
 ExternalModule demo
 ===================
 
-The `ExternalModule` counterpart of `../demo-15-internal-module`. It does exactly the
-same thing - wraps the stock `JavaMultiProjectAssembler` so a build module
-preprocesses the project's Java sources (a `${greeting}` substitution driven by
-the `org.json` dependency) before the regular compile, jar, and test flow runs.
-The only difference is how the build module is obtained: `internal-module`
-compiles it from local source with `InternalModule`, while here it is resolved
-as a published artifact from a repository **coordinate** with `ExternalModule`.
+Drive a source preprocessing pass from a build module that ships as a published
+artifact, resolved from a repository coordinate rather than compiled from local
+source. The plugin performs the same `${greeting}` substitution over the
+project's Java sources (driven by the `org.json` dependency) before the regular
+compile, jar, and test flow runs. This is the published-artifact counterpart of
+`../demo-15-internal-module`: same plugin, same outcome, only the plugin is
+obtained as a coordinate with `ExternalModule` instead of from source with
+`InternalModule`.
 
-Like `internal-module`, the build module's `build.jenesis` dependency resolves
-from the default Jenesis repository as the published `0.3.0` artifact (pinned via
-the `@tool/build.jenesis` tag in `sources/module-info.java`), whose API matches
-the local sources the host runs against, so the class-loader bridge loads it
-without complaint.
+Run it
+------
+
+From this directory:
+
+    java build/Demo.java
+
+which builds the project and then launches the built module, printing the
+greeting the plugin substituted in:
+
+    Hello from a source preprocessed by an internal build module, using the org.json dependency!
+
+Built without the plugin the literal `${greeting}` would print instead.
 
 Layout
 ------
@@ -34,19 +43,11 @@ Layout
 
 `plugin/` and `sources/` are exact copies of the `internal-module` demo.
 
-Run it
-------
-
-From this directory:
-
-    java build/Demo.java
-
-which builds the project and then launches the built module, printing the
-greeting the plugin substituted in:
-
-    Hello from a source preprocessed by an internal build module, using the org.json dependency!
-
-Built without the plugin the literal `${greeting}` would print instead.
+Like `internal-module`, the build module's `build.jenesis` dependency resolves
+from the default Jenesis repository as the published `0.3.0` artifact (pinned via
+the `@tool/build.jenesis` tag in `sources/module-info.java`), whose API matches
+the local sources the host runs against, so the class-loader bridge loads it
+without complaint.
 
 How it works
 ------------

--- a/demo/demo-17-custom-maven/README.md
+++ b/demo/demo-17-custom-maven/README.md
@@ -1,17 +1,22 @@
 Custom Maven build demo
 =======================
 
-A multi-module Maven project built **without going through `Project`** - no
-layout, no goals, no `java build/jenesis/Project.java` - yet **without wiring
-every step by hand** either. The launcher `build/Demo.java` uses the convenience
-`MavenProject.make(root, assembler)` overload, which discovers the multi-module
-project under the root and supplies sane defaults for the repositories,
-resolvers, and digest a normal build would configure.
+Build a multi-module Maven project from your own launcher instead of the standard
+entry point, while still reusing Jenesis's stock toolchain. You write a small
+`build/Demo.java` that points Jenesis at the project root, and one convenience call
+discovers the modules, builds the library first, and resolves it when compiling the
+consumer - so you get a custom launcher without wiring every step by hand.
 
-It sits between `../demo-03-java-pom-multi` (the same shape of project driven by the full
-`Project` entry point) and `../demo-19-custom-build` (a build wired entirely by hand): a
-"custom but not so custom" build that reuses the stock toolchain through one
-convenience call.
+Run it
+------
+
+From this directory:
+
+    java build/Demo.java
+
+Jenesis discovers the aggregator and its two sub-modules, builds `greeter` first,
+and resolves it from within the build when compiling `app`. Each module's jar is
+produced under `target/`.
 
 Layout
 ------
@@ -27,16 +32,16 @@ Layout
         |-- pom.xml          depends on greeter
         `-- sources/sample/app/App.java   uses Greeter
 
-Run it
-------
+Where this demo sits
+--------------------
 
-From this directory:
-
-    java build/Demo.java
-
-Jenesis discovers the aggregator and its two sub-modules, builds `greeter` first,
-and resolves it from within the build when compiling `app`. Each module's jar is
-produced under `target/`.
+It sits between `../demo-03-java-pom-multi` (the same shape of project driven by the full
+`Project` entry point) and `../demo-19-custom-build` (a build wired entirely by hand): a
+"custom but not so custom" build that reuses the stock toolchain through one
+convenience call. The launcher avoids going through `Project` - no layout, no goals,
+no `java build/jenesis/Project.java` - yet without wiring every step by hand either,
+because `MavenProject.make(root, assembler)` supplies sane defaults for the
+repositories, resolvers, and digest a normal build would configure.
 
 How the convenience make is wired
 ---------------------------------

--- a/demo/demo-18-custom-modular/README.md
+++ b/demo/demo-18-custom-modular/README.md
@@ -1,17 +1,23 @@
 Custom modular build demo
 =========================
 
-The modular counterpart of `../demo-17-custom-maven`: a multi-module **modular** project
-built **without going through `Project`** - no layout, no goals - yet **without
-wiring every step by hand** either. The launcher `build/Demo.java` uses the
-convenience `ModularProject.make(root, assembler)` overload, which discovers the
-`module-info.java` modules under the root and supplies sane defaults for the
-repositories, resolvers, and digest a normal modular build configures.
+Build a multi-module Java module system project from your own launcher instead of
+the standard entry point, while still reusing Jenesis's stock toolchain. You write a
+small `build/Demo.java` that points Jenesis at the project root, and one convenience
+call discovers the `module-info.java` modules, builds the library module first, and
+resolves it when compiling the consumer module - a custom launcher without wiring
+every step by hand. This is the modular counterpart of `../demo-17-custom-maven`.
 
-It sits between `../demo-04-java-modular-multi` (the same shape of project driven by the
-full `Project` entry point) and `../demo-19-custom-build` (a build wired entirely by
-hand): a "custom but not so custom" build that reuses the stock toolchain through
-one convenience call.
+Run it
+------
+
+From this directory:
+
+    java build/Demo.java
+
+Jenesis discovers the two `module-info.java` modules, builds `greeter` first, and
+resolves it from within the build when compiling `app` (which `requires
+demo.greeter`). Each module produces a modular jar under `target/`.
 
 Layout
 ------
@@ -26,16 +32,16 @@ Layout
         |-- module-info.java     module demo.app { requires demo.greeter; }
         `-- sample/app/App.java   uses Greeter
 
-Run it
-------
+Where this demo sits
+--------------------
 
-From this directory:
-
-    java build/Demo.java
-
-Jenesis discovers the two `module-info.java` modules, builds `greeter` first, and
-resolves it from within the build when compiling `app` (which `requires
-demo.greeter`). Each module produces a modular jar under `target/`.
+It sits between `../demo-04-java-modular-multi` (the same shape of project driven by the
+full `Project` entry point) and `../demo-19-custom-build` (a build wired entirely by
+hand): a "custom but not so custom" build that reuses the stock toolchain through
+one convenience call. The launcher avoids going through `Project` - no layout, no
+goals - yet without wiring every step by hand either, because
+`ModularProject.make(root, assembler)` supplies sane defaults for the repositories,
+resolvers, and digest a normal modular build configures.
 
 How the convenience make is wired
 ---------------------------------

--- a/demo/demo-19-custom-build/README.md
+++ b/demo/demo-19-custom-build/README.md
@@ -1,24 +1,48 @@
 Custom build demo
 =================
 
-Every other demo goes through `Project` - a layout auto-detects the modules, a
-multi-project assembler wires the conventional compile/jar/test flow, and the
-build is configured by selecting among the choices the template offers. This
-demo drops all of that. It wires a `BuildExecutor` **by hand**: sources and steps
-are added directly, and the entire build graph lives in one readable `main`
-method. There is no `Project`, no layout, no assembler, and no `pom.xml` or
-`module-info.java` - just the steps you choose to add.
+Run a build step that the templates do not model, like generating a Java source
+during the build and compiling it alongside the hand-written ones. You wire the
+whole build graph **by hand** in one readable `main` method: sources and steps are
+added directly, with no `Project`, no layout, no assembler, and no `pom.xml` or
+`module-info.java` - just the steps you choose to add. When a build needs something
+off the beaten path (code generation, a bespoke packaging step, an unusual
+dependency wiring), you step down to the `BuildExecutor` primitives and build
+exactly the graph you want.
+
+Run it
+------
+
+From this directory:
+
+    java build/Demo.java
+
+The build emits a classpath jar at
+`target/jar/output/artifacts/classes.jar`. Run the result with:
+
+    java -cp target/jar/output/artifacts/classes.jar sample.Sample
+
+which prints:
+
+    Hello from a generated source, compiled by a hand-wired BuildExecutor!
+
+Re-running `java build/Demo.java` reuses the cache: `generate` has no inputs, so
+once its output exists it is not rewritten, and `compile`/`jar` are skipped while
+their predecessors' checksums are unchanged.
 
 What justifies skipping the template
 -------------------------------------
 
-The build includes a `generate` step that **synthesizes a Java source on the
-fly** and compiles it alongside the hand-written one. The templated `Project`
-flow assumes every source already exists on disk and follows a fixed shape, so
-there is no natural place to hang code generation. A hand-wired graph splices it
-in trivially: `generate` writes a `sources/` folder like any source, and the
-compiler - which reads the `sources/` of every predecessor - picks it up next to
-the real sources.
+Every other demo goes through `Project` - a layout auto-detects the modules, a
+multi-project assembler wires the conventional compile/jar/test flow, and the
+build is configured by selecting among the choices the template offers. This demo
+drops all of that because of one step. The build includes a `generate` step that
+**synthesizes a Java source on the fly** and compiles it alongside the hand-written
+one. The templated `Project` flow assumes every source already exists on disk and
+follows a fixed shape, so there is no natural place to hang code generation. A
+hand-wired graph splices it in trivially: `generate` writes a `sources/` folder
+like any source, and the compiler - which reads the `sources/` of every
+predecessor - picks it up next to the real sources.
 
 This is the point of the demo: when a build needs something the templates do not
 model (code generation, a bespoke packaging step, an unusual dependency wiring),
@@ -48,23 +72,3 @@ The graph
       generate   writes sources/sample/Generated.java into its own output
       compile    javac over the sources/ of both predecessors
       jar        packages the compiled classes into a classpath jar
-
-Run it
-------
-
-From this directory:
-
-    java build/Demo.java
-
-The build emits a classpath jar at
-`target/jar/output/artifacts/classes.jar`. Run the result with:
-
-    java -cp target/jar/output/artifacts/classes.jar sample.Sample
-
-which prints:
-
-    Hello from a generated source, compiled by a hand-wired BuildExecutor!
-
-Re-running `java build/Demo.java` reuses the cache: `generate` has no inputs, so
-once its output exists it is not rewritten, and `compile`/`jar` are skipped while
-their predecessors' checksums are unchanged.

--- a/demo/demo-20-docker-isolation/README.md
+++ b/demo/demo-20-docker-isolation/README.md
@@ -1,6 +1,49 @@
 Docker isolation demo
 =====================
 
+Build and run a Java project inside a throwaway Docker container so that untrusted
+code - the tests run during the build, the dependencies they drag in, and the
+artifact's own `main` - cannot reach your host secrets or write outside the sandbox.
+This demo first shows the leak on the host (a single-class project lifts a
+credentials file and an environment secret at build time and again at run time),
+then confines both the build and the launched program with Docker.
+
+Set up the secrets
+------------------
+
+    printf 'aws_secret_key=PSEUDO-FILE-SECRET\n' > ~/.demo-credentials
+    export DEMO_SECRET=PSEUDO-ENV-SECRET
+
+(Use a throwaway file - the actors overwrite it. Remove it and unset the variable
+when you are done.)
+
+On the host (the leak)
+----------------------
+
+Build the project. The build compiles and runs the test, which reads both secrets
+and overwrites the file:
+
+    java build/jenesis/Project.java
+    cat ~/.demo-credentials          # now reads: overwritten by the test
+
+JUnit captures the test's console output, so the proof that the test ran is the
+clobbered file. Now run the program with `Execute`, whose `main` prints what it
+extracted:
+
+    printf 'aws_secret_key=PSEUDO-FILE-SECRET\n' > ~/.demo-credentials   # restore it
+    java build/jenesis/Execute.java
+
+    [program main] env DEMO_SECRET = PSEUDO-ENV-SECRET
+    [program main] extracted /home/you/.demo-credentials: aws_secret_key=PSEUDO-FILE-SECRET
+    [program main] overwrote /home/you/.demo-credentials
+
+A single-class project read and clobbered a credentials file and lifted an
+environment secret, at build time and again at run time, with no custom build
+code involved.
+
+What the leak stands for
+------------------------
+
 A build runs untrusted code even when nothing about it is customised. The stock
 pipeline compiles and runs your **tests** (and everything your test dependencies
 drag in), and the artifact it produces has a **`main`** that runs later - all with
@@ -50,39 +93,6 @@ module, the standard modular way to ship tests:
     `-- app-test/
         |-- module-info.java             @jenesis.test demo.dockerisolation; pins the JUnit closure
         `-- sampletest/SampleTest.java   a test that calls Sample.peek during the build
-
-Set up the secrets
-------------------
-
-    printf 'aws_secret_key=PSEUDO-FILE-SECRET\n' > ~/.demo-credentials
-    export DEMO_SECRET=PSEUDO-ENV-SECRET
-
-(Use a throwaway file - the actors overwrite it. Remove it and unset the variable
-when you are done.)
-
-On the host (the leak)
-----------------------
-
-Build the project. The build compiles and runs the test, which reads both secrets
-and overwrites the file:
-
-    java build/jenesis/Project.java
-    cat ~/.demo-credentials          # now reads: overwritten by the test
-
-JUnit captures the test's console output, so the proof that the test ran is the
-clobbered file. Now run the program with `Execute`, whose `main` prints what it
-extracted:
-
-    printf 'aws_secret_key=PSEUDO-FILE-SECRET\n' > ~/.demo-credentials   # restore it
-    java build/jenesis/Execute.java
-
-    [program main] env DEMO_SECRET = PSEUDO-ENV-SECRET
-    [program main] extracted /home/you/.demo-credentials: aws_secret_key=PSEUDO-FILE-SECRET
-    [program main] overwrote /home/you/.demo-credentials
-
-A single-class project read and clobbered a credentials file and lifted an
-environment secret, at build time and again at run time, with no custom build
-code involved.
 
 Confining it with Docker
 ------------------------

--- a/demo/demo-21-supply-chain-security/README.md
+++ b/demo/demo-21-supply-chain-security/README.md
@@ -1,30 +1,12 @@
 Supply-chain security demo
 ==========================
 
-Jenesis pins dependencies not just by version but by the **content checksum** of
-every downloaded artifact, and can be told to **require** such a pin. This demo
-shows both guarantees by deliberately getting them wrong, in two modules, and a
-`build/Demo.java` that asserts each one fails the build.
-
-- **`unpinned`** declares a dependency with a version but **no checksum**. It
-  builds by default, but fails under **strict pinning** - there is nothing to
-  verify the download against.
-- **`tampered`** pins the same dependency to a **wrong `SHA-256`**. It fails the
-  build **even without** strict pinning: every download is checked against its
-  pin regardless.
-
-Layout
-------
-
-    demo-21-supply-chain-security
-    |-- build/jenesis            symlink to ../../../sources/build/jenesis
-    |-- build/Demo.java          asserts both modules fail to build
-    |-- pom.xml                  aggregator over the two modules
-    |-- unpinned/pom.xml         commons-lang3 with a version but no checksum
-    `-- tampered/pom.xml         commons-lang3 pinned to a deliberately wrong SHA-256
-
-Both pins are wrong on purpose, so unlike the other demos this one is *not* a
-project that builds - it is a project that must *not* build.
+Guarantee that a build downloads exactly the dependency bytes you vetted, and
+refuse to build when a dependency cannot be verified. This demo proves both
+guarantees by deliberately getting them wrong in two modules and asserting that
+each one fails the build: `unpinned` declares a dependency with a version but no
+checksum, and `tampered` pins a dependency to a checksum that does not match the
+real artifact.
 
 Run it
 ------
@@ -52,6 +34,33 @@ Together these are the two halves of pinning: **strict pinning** decides *whethe
 an unverified dependency may be used at all, and **checksums** verify that a
 pinned dependency is the exact artifact you vetted. (See `../demo-01-java-pom` for
 the everyday case: a dependency correctly pinned with its real checksum.)
+
+The two modules in detail
+-------------------------
+
+Jenesis pins dependencies not just by version but by the **content checksum** of
+every downloaded artifact, and can be told to **require** such a pin. The two
+modules get one guarantee wrong each:
+
+- **`unpinned`** declares a dependency with a version but **no checksum**. It
+  builds by default, but fails under **strict pinning** - there is nothing to
+  verify the download against.
+- **`tampered`** pins the same dependency to a **wrong `SHA-256`**. It fails the
+  build **even without** strict pinning: every download is checked against its
+  pin regardless.
+
+Layout
+------
+
+    demo-21-supply-chain-security
+    |-- build/jenesis            symlink to ../../../sources/build/jenesis
+    |-- build/Demo.java          asserts both modules fail to build
+    |-- pom.xml                  aggregator over the two modules
+    |-- unpinned/pom.xml         commons-lang3 with a version but no checksum
+    `-- tampered/pom.xml         commons-lang3 pinned to a deliberately wrong SHA-256
+
+Both pins are wrong on purpose, so unlike the other demos this one is *not* a
+project that builds - it is a project that must *not* build.
 
 Updating pins: refresh versions and hashes
 ------------------------------------------

--- a/demo/demo-22-publishing/README.md
+++ b/demo/demo-22-publishing/README.md
@@ -1,16 +1,66 @@
 Publishing demo
 ===============
 
+Assemble a complete, correct release bundle ready for Maven Central: the main jar
+plus the `-sources.jar`, `-javadoc.jar`, and a POM carrying all the metadata Central
+demands. This demo does the part Jenesis owns - end to end, offline - building that
+bundle from a `module-info.java` and a `project.properties`, then resolving it back
+to prove it is consumable, and explains the last mile (the signed upload) rather
+than performing it, so nothing here ever touches the network or needs a secret.
+
+Run it
+------
+
+    java build/Demo.java
+
+`build/Demo.java` configures publication explicitly on the `Project` builder -
+`new Project().target(...).sources(true).documentation(true).version("1.0.0").metadata(Path.of("project.properties"))` -
+and runs the `stage` target. That materializes the release tree in Maven
+repository layout, and `build` hands back the staging step's folder under the
+`stage/maven` key:
+
+    build/jenesis/build.jenesis.demo.publishing/1.0.0/build.jenesis.demo.publishing-1.0.0.jar
+    build/jenesis/build.jenesis.demo.publishing/1.0.0/build.jenesis.demo.publishing-1.0.0.pom
+    build/jenesis/build.jenesis.demo.publishing/1.0.0/build.jenesis.demo.publishing-1.0.0-sources.jar
+    build/jenesis/build.jenesis.demo.publishing/1.0.0/build.jenesis.demo.publishing-1.0.0-javadoc.jar
+
+The generated `.pom` carries the full Central-required metadata, assembled from the
+two channels described under "Where the POM metadata comes from" below:
+
+    <groupId>build.jenesis</groupId>
+    <artifactId>build.jenesis.demo.publishing</artifactId>
+    <version>1.0.0</version>
+    <name>Jenesis Publishing Demo</name>
+    <description>A sample library whose name and description are taken from this Javadoc ...</description>
+    <url>https://github.com/raphw/jenesis</url>
+    <licenses>...</licenses>
+    <developers>...</developers>
+    <scm>...</scm>
+
+Then `Demo.java` proves the bundle is real: the staged tree is itself a Maven
+repository, so it recovers the coordinate from the staged layout (hard-coding
+nothing) and resolves it straight back out, reporting each artifact:
+
+    Resolving build.jenesis:build.jenesis.demo.publishing:1.0.0 from the staged repository:
+      [resolved] build.jenesis.demo.publishing-1.0.0.jar
+      [resolved] build.jenesis.demo.publishing-1.0.0.pom
+      [resolved] build.jenesis.demo.publishing-1.0.0-sources.jar
+      [resolved] build.jenesis.demo.publishing-1.0.0-javadoc.jar
+
+That is the whole bundle a release would carry, validated without publishing
+anything.
+
+The two jobs of publishing
+--------------------------
+
 Publishing to Maven Central is two jobs: **produce a correct, complete bundle**,
 and **upload it**. Jenesis owns the first; the upload (with credentials and GPG
-signing) is left to a dedicated release tool. This demo does the part Jenesis
-owns - end to end, offline - and explains the last mile rather than performing
-it, so nothing here ever touches the network or needs a secret.
-
-What Central requires of every artifact is exactly what trips people up: a POM
-carrying `name`, `description`, `url`, `<licenses>`, `<developers>`, and `<scm>`,
-plus a `-sources.jar` and a `-javadoc.jar` beside the main jar. This demo shows
-Jenesis assembling all of that from a `module-info.java` and a `project.properties`.
+signing) is left to a dedicated release tool. This demo does the part Jenesis owns
+and explains the last mile rather than performing it. What Central requires of every
+artifact is exactly what trips people up: a POM carrying `name`, `description`,
+`url`, `<licenses>`, `<developers>`, and `<scm>`, plus a `-sources.jar` and a
+`-javadoc.jar` beside the main jar. This demo shows Jenesis assembling all of that
+from a `module-info.java` and a `project.properties`.
 
 Layout
 ------
@@ -44,48 +94,6 @@ The version is stamped by `Project.version("1.0.0")` (otherwise it defaults to
 `1-SNAPSHOT`). If you ever need a coordinate that does not follow from the module
 name, `project=...` / `artifact=...` in `project.properties` override the derived
 values - but the point here is that you usually do not have to.
-
-Run it
-------
-
-    java build/Demo.java
-
-`build/Demo.java` configures publication explicitly on the `Project` builder -
-`new Project().target(...).sources(true).documentation(true).version("1.0.0").metadata(Path.of("project.properties"))` -
-and runs the `stage` target. That materializes the release tree in Maven
-repository layout, and `build` hands back the staging step's folder under the
-`stage/maven` key:
-
-    build/jenesis/build.jenesis.demo.publishing/1.0.0/build.jenesis.demo.publishing-1.0.0.jar
-    build/jenesis/build.jenesis.demo.publishing/1.0.0/build.jenesis.demo.publishing-1.0.0.pom
-    build/jenesis/build.jenesis.demo.publishing/1.0.0/build.jenesis.demo.publishing-1.0.0-sources.jar
-    build/jenesis/build.jenesis.demo.publishing/1.0.0/build.jenesis.demo.publishing-1.0.0-javadoc.jar
-
-The generated `.pom` carries the full Central-required metadata, assembled from the
-two channels above:
-
-    <groupId>build.jenesis</groupId>
-    <artifactId>build.jenesis.demo.publishing</artifactId>
-    <version>1.0.0</version>
-    <name>Jenesis Publishing Demo</name>
-    <description>A sample library whose name and description are taken from this Javadoc ...</description>
-    <url>https://github.com/raphw/jenesis</url>
-    <licenses>...</licenses>
-    <developers>...</developers>
-    <scm>...</scm>
-
-Then `Demo.java` proves the bundle is real: the staged tree is itself a Maven
-repository, so it recovers the coordinate from the staged layout (hard-coding
-nothing) and resolves it straight back out, reporting each artifact:
-
-    Resolving build.jenesis:build.jenesis.demo.publishing:1.0.0 from the staged repository:
-      [resolved] build.jenesis.demo.publishing-1.0.0.jar
-      [resolved] build.jenesis.demo.publishing-1.0.0.pom
-      [resolved] build.jenesis.demo.publishing-1.0.0-sources.jar
-      [resolved] build.jenesis.demo.publishing-1.0.0-javadoc.jar
-
-That is the whole bundle a release would carry, validated without publishing
-anything.
 
 Reproducibility
 ---------------

--- a/sources/build/jenesis/project/DokkaDocumentationModule.java
+++ b/sources/build/jenesis/project/DokkaDocumentationModule.java
@@ -20,16 +20,15 @@ import build.jenesis.step.JdkProcessBuildStep;
 import build.jenesis.step.ProcessHandler;
 import build.jenesis.step.Resolve;
 
-public class ScalaDocumentationModule implements BuildExecutorModule {
+public class DokkaDocumentationModule implements BuildExecutorModule {
 
     public static final String DOCUMENTED = "documented";
     private static final String REQUIRED = "required", RESOLVED = "resolved", ARTIFACTS = "artifacts";
 
-    private static final List<String> PREFERRED_PREFIXES = List.of("maven", "module");
-    private static final String MODULE_NAME = "org.scala.lang.scaladoc";
-    private static final String MAVEN_GROUP = "org.scala-lang";
-    private static final String MAVEN_ARTIFACT = "scaladoc_3";
-    private static final String LIBRARY_MARKER = "org.scala-lang-scala3-library_3-";
+    private static final String MAVEN_GROUP = "org.jetbrains.dokka";
+    private static final List<String> CLI_ARTIFACTS = List.of("dokka-cli", "dokka-base", "analysis-kotlin-descriptors");
+    private static final List<String> PLUGIN_MARKERS = List.of(
+            "dokka-base", "analysis-kotlin-descriptors", "kotlinx-html", "freemarker");
 
     private final Map<String, Repository> repositories;
     private final Map<String, Resolver> resolvers;
@@ -38,11 +37,11 @@ public class ScalaDocumentationModule implements BuildExecutorModule {
     private final String within;
     private final transient Function<List<String>, ? extends ProcessHandler> factory;
 
-    public ScalaDocumentationModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
-        this(repositories, resolvers, null, "scaladoc", null, null);
+    public DokkaDocumentationModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "dokka", null, null);
     }
 
-    private ScalaDocumentationModule(Map<String, Repository> repositories,
+    private DokkaDocumentationModule(Map<String, Repository> repositories,
                                      Map<String, Resolver> resolvers,
                                      Pinning pinning,
                                      String qualifier,
@@ -56,26 +55,26 @@ public class ScalaDocumentationModule implements BuildExecutorModule {
         this.factory = factory;
     }
 
-    public ScalaDocumentationModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
-        return new ScalaDocumentationModule(repositories, resolvers, pinning, qualifier, within, factory);
+    public DokkaDocumentationModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
+        return new DokkaDocumentationModule(repositories, resolvers, pinning, qualifier, within, factory);
     }
 
-    public ScalaDocumentationModule pinning(Pinning pinning) {
-        return new ScalaDocumentationModule(repositories, resolvers, pinning, qualifier, within, factory);
+    public DokkaDocumentationModule pinning(Pinning pinning) {
+        return new DokkaDocumentationModule(repositories, resolvers, pinning, qualifier, within, factory);
     }
 
-    public ScalaDocumentationModule qualifier(String qualifier) {
-        return new ScalaDocumentationModule(repositories, resolvers, pinning, qualifier, within, factory);
+    public DokkaDocumentationModule qualifier(String qualifier) {
+        return new DokkaDocumentationModule(repositories, resolvers, pinning, qualifier, within, factory);
     }
 
-    public ScalaDocumentationModule within(String within) {
-        return new ScalaDocumentationModule(repositories, resolvers, pinning, qualifier, within, factory);
+    public DokkaDocumentationModule within(String within) {
+        return new DokkaDocumentationModule(repositories, resolvers, pinning, qualifier, within, factory);
     }
 
     @Override
     public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
         SequencedSet<String> upstream = inherited.sequencedKeySet();
-        buildExecutor.addStep(REQUIRED, new Requires(Set.copyOf(resolvers.keySet()), qualifier), upstream);
+        buildExecutor.addStep(REQUIRED, new Requires(resolvers.containsKey("maven"), qualifier), upstream);
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(upstream);
@@ -97,64 +96,22 @@ public class ScalaDocumentationModule implements BuildExecutorModule {
         };
     }
 
-    private record Requires(Set<String> prefixes, String qualifier) implements BuildStep {
+    private record Requires(boolean maven, String qualifier) implements BuildStep {
 
         @Override
         public CompletionStage<BuildStepResult> apply(Executor executor,
                                                       BuildStepContext context,
                                                       SequencedMap<String, BuildStepArgument> arguments)
                 throws IOException {
-            String selectedPrefix = null;
-            for (String prefix : PREFERRED_PREFIXES) {
-                if (prefixes.contains(prefix)) {
-                    selectedPrefix = prefix;
-                    break;
+            SequencedProperties requires = new SequencedProperties();
+            if (maven) {
+                String namespace = qualifier == null ? "maven" : "maven@" + qualifier;
+                for (String artifact : CLI_ARTIFACTS) {
+                    requires.setProperty(namespace + "/" + MAVEN_GROUP + "/" + artifact + "/RELEASE", "");
                 }
             }
-            if (selectedPrefix == null) {
-                throw new IllegalStateException(
-                        "No suitable resolver for Scala documentation. Available prefixes: " + prefixes
-                                + ". Expected one of: " + PREFERRED_PREFIXES);
-            }
-            String version = resolvedVersion(arguments);
-            String namespace = qualifier == null ? selectedPrefix : selectedPrefix + "@" + qualifier;
-            String coordinate = switch (selectedPrefix) {
-                case "module" -> namespace + "/" + MODULE_NAME;
-                case "maven" -> namespace + "/" + MAVEN_GROUP + "/" + MAVEN_ARTIFACT + "/" + version;
-                default -> throw new IllegalStateException("Unreachable");
-            };
-            SequencedProperties requires = new SequencedProperties();
-            requires.setProperty(coordinate, "");
             requires.store(context.next().resolve(BuildStep.REQUIRES));
             return CompletableFuture.completedStage(new BuildStepResult(true));
-        }
-
-        private static String resolvedVersion(SequencedMap<String, BuildStepArgument> arguments) throws IOException {
-            String[] found = new String[1];
-            for (BuildStepArgument argument : arguments.values()) {
-                for (String jarFolder : List.of(BuildStep.DEPENDENCIES, BuildStep.ARTIFACTS)) {
-                    Path jarRoot = argument.folder().resolve(jarFolder);
-                    if (!Files.exists(jarRoot)) {
-                        continue;
-                    }
-                    Files.walkFileTree(jarRoot, new SimpleFileVisitor<>() {
-                        @Override
-                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                            String name = file.getFileName().toString();
-                            int at = name.indexOf(LIBRARY_MARKER);
-                            if (at >= 0 && name.indexOf('@') < 0 && name.endsWith(".jar")) {
-                                String candidate = name.substring(at + LIBRARY_MARKER.length(), name.length() - ".jar".length());
-                                if (!candidate.isEmpty() && Character.isDigit(candidate.charAt(0))) {
-                                    found[0] = candidate;
-                                    return FileVisitResult.TERMINATE;
-                                }
-                            }
-                            return FileVisitResult.CONTINUE;
-                        }
-                    });
-                }
-            }
-            return found[0] == null ? "RELEASE" : found[0];
         }
     }
 
@@ -167,15 +124,15 @@ public class ScalaDocumentationModule implements BuildExecutorModule {
         }
 
         private Document(String within, Function<List<String>, ? extends ProcessHandler> factory) {
-            super("scaladoc", factory);
+            super("dokka", factory);
             this.within = within;
         }
 
         @Override
         public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
             return Javac.hasRelevantChange(arguments,
-                    Set.of(".scala"),
-                    Set.of("scaladoc.properties"));
+                    Set.of(".kt"),
+                    Set.of("dokka.properties"));
         }
 
         @Override
@@ -194,7 +151,8 @@ public class ScalaDocumentationModule implements BuildExecutorModule {
                 throws IOException {
             Path documentation = context.next().resolve(Javadoc.JAVADOC);
             Path output = Files.createDirectories(within == null ? documentation : documentation.resolve(within));
-            List<String> files = new ArrayList<>(), jars = new ArrayList<>(), classpath = new ArrayList<>();
+            List<String> sources = new ArrayList<>(), jars = new ArrayList<>(), classpath = new ArrayList<>();
+            boolean[] kotlin = new boolean[1];
             for (BuildStepArgument argument : arguments.values()) {
                 Path classes = argument.folder().resolve(BuildStep.CLASSES);
                 if (Files.exists(classes)) {
@@ -212,48 +170,63 @@ public class ScalaDocumentationModule implements BuildExecutorModule {
                         });
                     }
                 }
-                Path sources = argument.folder().resolve(Bind.SOURCES);
-                if (Files.exists(sources)) {
-                    Files.walkFileTree(sources, new SimpleFileVisitor<>() {
+                Path source = argument.folder().resolve(Bind.SOURCES);
+                if (Files.exists(source)) {
+                    boolean[] hasKotlin = new boolean[1];
+                    Files.walkFileTree(source, new SimpleFileVisitor<>() {
                         @Override
                         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                            String name = file.toString();
-                            if (name.endsWith(".scala")) {
-                                files.add(name);
+                            if (file.getFileName().toString().endsWith(".kt")) {
+                                hasKotlin[0] = true;
+                                return FileVisitResult.TERMINATE;
                             }
                             return FileVisitResult.CONTINUE;
                         }
                     });
+                    if (hasKotlin[0]) {
+                        sources.add(source.toString());
+                        kotlin[0] = true;
+                    }
                 }
             }
-            files.sort(null);
+            if (!kotlin[0]) {
+                return CompletableFuture.completedStage(null);
+            }
             jars.sort(null);
-            if (files.isEmpty()) {
-                return CompletableFuture.completedStage(null);
-            }
-            if (jars.isEmpty()) {
-                throw new IllegalStateException(
-                        "No scaladoc jars resolved upstream of the Scala documentation step");
-            }
-            List<String> launch = new ArrayList<>();
+            String cli = null;
+            List<String> plugins = new ArrayList<>(), dependencies = new ArrayList<>();
             for (String jar : jars) {
-                if (new File(jar).getName().indexOf('@') != -1) {
-                    launch.add(jar);
+                String name = new File(jar).getName();
+                if (name.indexOf('@') == -1) {
+                    dependencies.add(jar);
+                    continue;
+                }
+                if (name.contains("dokka-cli")) {
+                    cli = jar;
+                }
+                for (String marker : PLUGIN_MARKERS) {
+                    if (name.contains(marker)) {
+                        plugins.add(jar);
+                        break;
+                    }
                 }
             }
-            if (launch.isEmpty()) {
-                launch = jars;
-            }
-            if (classpath.isEmpty()) {
+            if (cli == null || plugins.isEmpty()) {
                 return CompletableFuture.completedStage(null);
             }
+            List<String> moduleClasspath = new ArrayList<>(dependencies);
+            moduleClasspath.addAll(classpath);
+            StringBuilder sourceSet = new StringBuilder("-src ").append(String.join(";", sources));
+            if (!moduleClasspath.isEmpty()) {
+                sourceSet.append(" -classpath ").append(String.join(";", moduleClasspath));
+            }
+            sourceSet.append(" -analysisPlatform jvm");
             List<String> commands = new ArrayList<>(List.of(
-                    "-cp", String.join(File.pathSeparator, launch),
-                    "dotty.tools.scaladoc.Main",
-                    "-d", output.toString(),
-                    "-classpath", String.join(File.pathSeparator, jars),
-                    "-project", "documentation"));
-            commands.addAll(classpath);
+                    "-jar", cli,
+                    "-pluginsClasspath", String.join(";", plugins),
+                    "-sourceSet", sourceSet.toString(),
+                    "-outputDir", output.toString(),
+                    "-moduleName", "documentation"));
             return CompletableFuture.completedStage(commands);
         }
     }

--- a/sources/build/jenesis/project/DokkaDocumentationModule.java
+++ b/sources/build/jenesis/project/DokkaDocumentationModule.java
@@ -26,9 +26,8 @@ public class DokkaDocumentationModule implements BuildExecutorModule {
     private static final String REQUIRED = "required", RESOLVED = "resolved", ARTIFACTS = "artifacts";
 
     private static final String MAVEN_GROUP = "org.jetbrains.dokka";
-    private static final List<String> CLI_ARTIFACTS = List.of("dokka-cli", "dokka-base", "analysis-kotlin-descriptors");
-    private static final List<String> PLUGIN_MARKERS = List.of(
-            "dokka-base", "analysis-kotlin-descriptors", "kotlinx-html", "freemarker");
+    private static final List<String> CLI_ARTIFACTS = List.of(
+            "dokka-cli", "analysis-kotlin-descriptors", "javadoc-plugin");
 
     private final Map<String, Repository> repositories;
     private final Map<String, Resolver> resolvers;
@@ -84,7 +83,7 @@ public class DokkaDocumentationModule implements BuildExecutorModule {
         documentInputs.add(ARTIFACTS);
         documentInputs.addAll(upstream);
         buildExecutor.addStep(DOCUMENTED,
-                factory == null ? new Document(within) : new Document(within, factory),
+                factory == null ? new Document(within, qualifier) : new Document(within, qualifier, factory),
                 documentInputs);
     }
 
@@ -118,14 +117,16 @@ public class DokkaDocumentationModule implements BuildExecutorModule {
     private static class Document extends JdkProcessBuildStep {
 
         private final String within;
+        private final String qualifierTrail;
 
-        private Document(String within) {
-            this(within, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
+        private Document(String within, String qualifierTrail) {
+            this(within, qualifierTrail, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
         }
 
-        private Document(String within, Function<List<String>, ? extends ProcessHandler> factory) {
+        private Document(String within, String qualifierTrail, Function<List<String>, ? extends ProcessHandler> factory) {
             super("dokka", factory);
             this.within = within;
+            this.qualifierTrail = qualifierTrail;
         }
 
         @Override
@@ -197,18 +198,12 @@ public class DokkaDocumentationModule implements BuildExecutorModule {
             List<String> plugins = new ArrayList<>(), dependencies = new ArrayList<>();
             for (String jar : jars) {
                 String name = new File(jar).getName();
-                if (name.indexOf('@') == -1) {
-                    dependencies.add(jar);
-                    continue;
-                }
                 if (name.contains("dokka-cli")) {
                     cli = jar;
-                }
-                for (String marker : PLUGIN_MARKERS) {
-                    if (name.contains(marker)) {
-                        plugins.add(jar);
-                        break;
-                    }
+                } else if (name.contains("@" + qualifierTrail)) {
+                    plugins.add(jar);
+                } else if (name.indexOf('@') == -1) {
+                    dependencies.add(jar);
                 }
             }
             if (cli == null || plugins.isEmpty()) {

--- a/sources/build/jenesis/project/DokkaDocumentationModule.java
+++ b/sources/build/jenesis/project/DokkaDocumentationModule.java
@@ -27,7 +27,7 @@ public class DokkaDocumentationModule implements BuildExecutorModule {
 
     private static final String MAVEN_GROUP = "org.jetbrains.dokka";
     private static final List<String> CLI_ARTIFACTS = List.of(
-            "dokka-cli", "analysis-kotlin-descriptors", "javadoc-plugin");
+            "dokka-cli", "dokka-base", "analysis-kotlin-descriptors");
 
     private final Map<String, Repository> repositories;
     private final Map<String, Resolver> resolvers;

--- a/sources/build/jenesis/project/GroovyDocumentationModule.java
+++ b/sources/build/jenesis/project/GroovyDocumentationModule.java
@@ -1,0 +1,268 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.DependencyScope;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Bind;
+import build.jenesis.step.Download;
+import build.jenesis.step.Javac;
+import build.jenesis.step.Javadoc;
+import build.jenesis.step.JdkProcessBuildStep;
+import build.jenesis.step.ProcessHandler;
+import build.jenesis.step.Resolve;
+
+public class GroovyDocumentationModule implements BuildExecutorModule {
+
+    public static final String DOCUMENTED = "documented";
+    private static final String REQUIRED = "required", RESOLVED = "resolved", ARTIFACTS = "artifacts";
+
+    private static final List<String> PREFERRED_PREFIXES = List.of("maven", "module");
+    private static final String MODULE_NAME = "org.apache.groovy.groovydoc";
+    private static final String MAVEN_GROUP = "org.apache.groovy";
+    private static final String MAVEN_ARTIFACT = "groovy-groovydoc";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String qualifier;
+    private final String within;
+    private final boolean includeJava;
+    private final transient Function<List<String>, ? extends ProcessHandler> factory;
+
+    public GroovyDocumentationModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "groovydoc", null, false, null);
+    }
+
+    private GroovyDocumentationModule(Map<String, Repository> repositories,
+                                      Map<String, Resolver> resolvers,
+                                      Pinning pinning,
+                                      String qualifier,
+                                      String within,
+                                      boolean includeJava,
+                                      Function<List<String>, ? extends ProcessHandler> factory) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.qualifier = qualifier;
+        this.within = within;
+        this.includeJava = includeJava;
+        this.factory = factory;
+    }
+
+    public GroovyDocumentationModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
+        return new GroovyDocumentationModule(repositories, resolvers, pinning, qualifier, within, includeJava, factory);
+    }
+
+    public GroovyDocumentationModule pinning(Pinning pinning) {
+        return new GroovyDocumentationModule(repositories, resolvers, pinning, qualifier, within, includeJava, factory);
+    }
+
+    public GroovyDocumentationModule qualifier(String qualifier) {
+        return new GroovyDocumentationModule(repositories, resolvers, pinning, qualifier, within, includeJava, factory);
+    }
+
+    public GroovyDocumentationModule within(String within) {
+        return new GroovyDocumentationModule(repositories, resolvers, pinning, qualifier, within, includeJava, factory);
+    }
+
+    public GroovyDocumentationModule includeJava(boolean includeJava) {
+        return new GroovyDocumentationModule(repositories, resolvers, pinning, qualifier, within, includeJava, factory);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        SequencedSet<String> upstream = inherited.sequencedKeySet();
+        buildExecutor.addStep(REQUIRED, new Requires(Set.copyOf(resolvers.keySet()), qualifier), upstream);
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(upstream);
+        buildExecutor.addStep(RESOLVED, new Resolve(repositories, resolvers, DependencyScope.RUNTIME).pinned(pinning != Pinning.IGNORE), resolveInputs);
+        buildExecutor.addStep(ARTIFACTS, new Download(repositories).pinning(pinning).tag("compiler:" + qualifier), RESOLVED);
+        SequencedSet<String> documentInputs = new LinkedHashSet<>();
+        documentInputs.add(ARTIFACTS);
+        documentInputs.addAll(upstream);
+        buildExecutor.addStep(DOCUMENTED,
+                factory == null ? new Document(within, includeJava) : new Document(within, includeJava, factory),
+                documentInputs);
+    }
+
+    @Override
+    public Optional<String> resolve(String path) {
+        return switch (path) {
+            case DOCUMENTED, RESOLVED, ARTIFACTS -> Optional.of(path);
+            default -> Optional.empty();
+        };
+    }
+
+    private record Requires(Set<String> prefixes, String qualifier) implements BuildStep {
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            String selectedPrefix = null;
+            for (String prefix : PREFERRED_PREFIXES) {
+                if (prefixes.contains(prefix)) {
+                    selectedPrefix = prefix;
+                    break;
+                }
+            }
+            if (selectedPrefix == null) {
+                throw new IllegalStateException(
+                        "No suitable resolver for Groovy documentation. Available prefixes: " + prefixes
+                                + ". Expected one of: " + PREFERRED_PREFIXES);
+            }
+            String version = resolvedGroovyVersion(arguments);
+            String namespace = qualifier == null ? selectedPrefix : selectedPrefix + "@" + qualifier;
+            String coordinate = switch (selectedPrefix) {
+                case "module" -> namespace + "/" + MODULE_NAME;
+                case "maven" -> namespace + "/" + MAVEN_GROUP + "/" + MAVEN_ARTIFACT + "/" + version;
+                default -> throw new IllegalStateException("Unreachable");
+            };
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(coordinate, "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+
+        private static String resolvedGroovyVersion(SequencedMap<String, BuildStepArgument> arguments) throws IOException {
+            String marker = MAVEN_GROUP + "-" + MAVEN_GROUP.substring(MAVEN_GROUP.lastIndexOf('.') + 1) + "-";
+            String[] found = new String[1];
+            for (BuildStepArgument argument : arguments.values()) {
+                for (String jarFolder : List.of(BuildStep.DEPENDENCIES, BuildStep.ARTIFACTS)) {
+                    Path jarRoot = argument.folder().resolve(jarFolder);
+                    if (!Files.exists(jarRoot)) {
+                        continue;
+                    }
+                    Files.walkFileTree(jarRoot, new SimpleFileVisitor<>() {
+                        @Override
+                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                            String name = file.getFileName().toString();
+                            int at = name.indexOf(marker);
+                            if (at >= 0 && name.indexOf('@') < 0 && name.endsWith(".jar")) {
+                                String candidate = name.substring(at + marker.length(), name.length() - ".jar".length());
+                                if (!candidate.isEmpty() && Character.isDigit(candidate.charAt(0))) {
+                                    found[0] = candidate;
+                                    return FileVisitResult.TERMINATE;
+                                }
+                            }
+                            return FileVisitResult.CONTINUE;
+                        }
+                    });
+                }
+            }
+            return found[0] == null ? "RELEASE" : found[0];
+        }
+    }
+
+    private static class Document extends JdkProcessBuildStep {
+
+        private final String within;
+        private final boolean includeJava;
+
+        private Document(String within, boolean includeJava) {
+            this(within, includeJava, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
+        }
+
+        private Document(String within, boolean includeJava, Function<List<String>, ? extends ProcessHandler> factory) {
+            super("groovydoc", factory);
+            this.within = within;
+            this.includeJava = includeJava;
+        }
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return Javac.hasRelevantChange(arguments,
+                    Set.of(".groovy", ".java"),
+                    Set.of("groovydoc.properties"));
+        }
+
+        @Override
+        public CompletionStage<List<String>> process(Executor executor,
+                                                     BuildStepContext context,
+                                                     SequencedMap<String, BuildStepArgument> arguments,
+                                                     SequencedMap<String, SequencedMap<String, String>> properties)
+                throws IOException {
+            Path documentation = context.next().resolve(Javadoc.JAVADOC);
+            Path output = Files.createDirectories(within == null ? documentation : documentation.resolve(within));
+            List<String> files = new ArrayList<>(), jars = new ArrayList<>(), classpath = new ArrayList<>();
+            String release = null;
+            for (BuildStepArgument argument : arguments.values()) {
+                Path classes = argument.folder().resolve(BuildStep.CLASSES);
+                if (Files.exists(classes)) {
+                    classpath.add(classes.toString());
+                }
+                for (String jarFolder : List.of(ARTIFACTS, DEPENDENCIES)) {
+                    Path jarRoot = argument.folder().resolve(jarFolder);
+                    if (Files.exists(jarRoot)) {
+                        Files.walkFileTree(jarRoot, new SimpleFileVisitor<>() {
+                            @Override
+                            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                                jars.add(file.toString());
+                                return FileVisitResult.CONTINUE;
+                            }
+                        });
+                    }
+                }
+                Path sources = argument.folder().resolve(Bind.SOURCES);
+                if (Files.exists(sources)) {
+                    Files.walkFileTree(sources, new SimpleFileVisitor<>() {
+                        @Override
+                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                            String name = file.toString();
+                            if (name.endsWith(".groovy") || includeJava && name.endsWith(".java")) {
+                                files.add(name);
+                            }
+                            return FileVisitResult.CONTINUE;
+                        }
+                    });
+                }
+            }
+            for (SequencedMap<String, String> values : properties.values()) {
+                String candidate = values.get("maven.compiler.release");
+                if (candidate != null) {
+                    release = candidate;
+                }
+            }
+            files.sort(null);
+            jars.sort(null);
+            if (files.stream().noneMatch(name -> name.endsWith(".groovy"))) {
+                return CompletableFuture.completedStage(null);
+            }
+            if (jars.isEmpty()) {
+                throw new IllegalStateException(
+                        "No groovydoc jars resolved upstream of the Groovy documentation step");
+            }
+            List<String> launch = new ArrayList<>();
+            for (String jar : jars) {
+                if (new File(jar).getName().indexOf('@') != -1) {
+                    launch.add(jar);
+                }
+            }
+            if (launch.isEmpty()) {
+                launch = jars;
+            }
+            List<String> userClasspath = new ArrayList<>(jars);
+            userClasspath.addAll(classpath);
+            List<String> commands = new ArrayList<>(List.of(
+                    "-cp", String.join(File.pathSeparator, launch),
+                    "org.codehaus.groovy.tools.groovydoc.Main",
+                    "-d", output.toString(),
+                    "-classpath", String.join(File.pathSeparator, userClasspath),
+                    "-javaVersion=" + (release == null ? "21" : release),
+                    "-notimestamp"));
+            commands.addAll(files);
+            return CompletableFuture.completedStage(commands);
+        }
+    }
+}

--- a/sources/build/jenesis/project/GroovyDocumentationModule.java
+++ b/sources/build/jenesis/project/GroovyDocumentationModule.java
@@ -188,6 +188,14 @@ public class GroovyDocumentationModule implements BuildExecutorModule {
         }
 
         @Override
+        public boolean acceptableExitCode(int code,
+                                          Executor executor,
+                                          BuildStepContext context,
+                                          SequencedMap<String, BuildStepArgument> arguments) {
+            return true;
+        }
+
+        @Override
         public CompletionStage<List<String>> process(Executor executor,
                                                      BuildStepContext context,
                                                      SequencedMap<String, BuildStepArgument> arguments,

--- a/sources/build/jenesis/project/GroovyDocumentationModule.java
+++ b/sources/build/jenesis/project/GroovyDocumentationModule.java
@@ -203,7 +203,9 @@ public class GroovyDocumentationModule implements BuildExecutorModule {
                 throws IOException {
             Path documentation = context.next().resolve(Javadoc.JAVADOC);
             Path output = Files.createDirectories(within == null ? documentation : documentation.resolve(within));
-            List<String> files = new ArrayList<>(), jars = new ArrayList<>(), classpath = new ArrayList<>();
+            List<String> roots = new ArrayList<>(), rootFiles = new ArrayList<>(), jars = new ArrayList<>(), classpath = new ArrayList<>();
+            SequencedSet<String> packages = new TreeSet<>();
+            boolean[] anyGroovy = new boolean[1];
             String release = null;
             for (BuildStepArgument argument : arguments.values()) {
                 Path classes = argument.folder().resolve(BuildStep.CLASSES);
@@ -224,12 +226,21 @@ public class GroovyDocumentationModule implements BuildExecutorModule {
                 }
                 Path sources = argument.folder().resolve(Bind.SOURCES);
                 if (Files.exists(sources)) {
+                    roots.add(sources.toString());
                     Files.walkFileTree(sources, new SimpleFileVisitor<>() {
                         @Override
                         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                            String name = file.toString();
-                            if (name.endsWith(".groovy") || includeJava && name.endsWith(".java")) {
-                                files.add(name);
+                            String name = file.getFileName().toString();
+                            boolean groovy = name.endsWith(".groovy");
+                            boolean java = includeJava && name.endsWith(".java") && !name.equals("module-info.java");
+                            if (groovy || java) {
+                                anyGroovy[0] |= groovy;
+                                Path parent = sources.relativize(file).getParent();
+                                if (parent == null) {
+                                    rootFiles.add(file.toString());
+                                } else {
+                                    packages.add(parent.toString().replace(File.separatorChar, '.'));
+                                }
                             }
                             return FileVisitResult.CONTINUE;
                         }
@@ -242,9 +253,8 @@ public class GroovyDocumentationModule implements BuildExecutorModule {
                     release = candidate;
                 }
             }
-            files.sort(null);
             jars.sort(null);
-            if (files.stream().noneMatch(name -> name.endsWith(".groovy"))) {
+            if (!anyGroovy[0]) {
                 return CompletableFuture.completedStage(null);
             }
             if (jars.isEmpty()) {
@@ -258,8 +268,10 @@ public class GroovyDocumentationModule implements BuildExecutorModule {
                     "org.codehaus.groovy.tools.groovydoc.Main",
                     "-d", output.toString(),
                     "-notimestamp",
-                    "-javaVersion", languageLevel(release)));
-            commands.addAll(files);
+                    "-javaVersion", languageLevel(release),
+                    "-sourcepath", String.join(File.pathSeparator, roots)));
+            commands.addAll(packages);
+            commands.addAll(rootFiles);
             return CompletableFuture.completedStage(commands);
         }
 

--- a/sources/build/jenesis/project/GroovyDocumentationModule.java
+++ b/sources/build/jenesis/project/GroovyDocumentationModule.java
@@ -251,26 +251,35 @@ public class GroovyDocumentationModule implements BuildExecutorModule {
                 throw new IllegalStateException(
                         "No groovydoc jars resolved upstream of the Groovy documentation step");
             }
-            List<String> launch = new ArrayList<>();
-            for (String jar : jars) {
-                if (new File(jar).getName().indexOf('@') != -1) {
-                    launch.add(jar);
-                }
-            }
-            if (launch.isEmpty()) {
-                launch = jars;
-            }
-            List<String> userClasspath = new ArrayList<>(jars);
-            userClasspath.addAll(classpath);
+            List<String> launch = new ArrayList<>(jars);
+            launch.addAll(classpath);
             List<String> commands = new ArrayList<>(List.of(
                     "-cp", String.join(File.pathSeparator, launch),
                     "org.codehaus.groovy.tools.groovydoc.Main",
                     "-d", output.toString(),
-                    "-classpath", String.join(File.pathSeparator, userClasspath),
-                    "-javaVersion=" + (release == null ? "21" : release),
-                    "-notimestamp"));
+                    "-notimestamp",
+                    "-javaVersion", languageLevel(release)));
             commands.addAll(files);
             return CompletableFuture.completedStage(commands);
+        }
+
+        private static String languageLevel(String release) {
+            String feature = release == null ? "21" : release;
+            if (feature.startsWith("1.")) {
+                feature = feature.substring(2);
+            }
+            int level;
+            try {
+                level = Integer.parseInt(feature);
+            } catch (NumberFormatException e) {
+                level = 21;
+            }
+            if (level < 8) {
+                level = 8;
+            } else if (level > 25) {
+                level = 25;
+            }
+            return "JAVA_" + level;
         }
     }
 }

--- a/sources/build/jenesis/project/InferredDocumentationChainModule.java
+++ b/sources/build/jenesis/project/InferredDocumentationChainModule.java
@@ -1,0 +1,149 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Javadoc;
+
+public class InferredDocumentationChainModule implements BuildExecutorModule {
+
+    public static final String JAVADOC = "javadoc", GROOVYDOC = "groovydoc", SCALADOC = "scaladoc", DOKKA = "dokka";
+    public static final String DOCUMENT = "document";
+    private static final String SCAN = "scan";
+    private static final String SCAN_FILE = "scan.properties";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final boolean process;
+    private final Pinning pinning;
+
+    public InferredDocumentationChainModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, false, null);
+    }
+
+    private InferredDocumentationChainModule(Map<String, Repository> repositories,
+                                             Map<String, Resolver> resolvers,
+                                             boolean process,
+                                             Pinning pinning) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.process = process;
+        this.pinning = pinning;
+    }
+
+    public InferredDocumentationChainModule process(boolean process) {
+        return new InferredDocumentationChainModule(repositories, resolvers, process, pinning);
+    }
+
+    public InferredDocumentationChainModule pinning(Pinning pinning) {
+        return new InferredDocumentationChainModule(repositories, resolvers, process, pinning);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        buildExecutor.addStep(SCAN, new Scan(), inherited.sequencedKeySet());
+        SequencedSet<String> documentInputs = new LinkedHashSet<>(inherited.sequencedKeySet());
+        documentInputs.add(SCAN);
+        buildExecutor.addModule(DOCUMENT,
+                new Document(repositories, resolvers, process, pinning),
+                documentInputs);
+    }
+
+    @Override
+    public Optional<String> resolve(String path) {
+        return path.equals(SCAN) ? Optional.empty() : Optional.of(path);
+    }
+
+    private static class Scan implements BuildStep {
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            boolean[] flags = new boolean[4];
+            for (BuildStepArgument argument : arguments.values()) {
+                Path sources = argument.folder().resolve(BuildStep.SOURCES);
+                if (!Files.exists(sources)) {
+                    continue;
+                }
+                Files.walkFileTree(sources, new SimpleFileVisitor<>() {
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                        String name = file.getFileName().toString();
+                        if (name.endsWith(".java")) {
+                            flags[0] = true;
+                        } else if (name.endsWith(".kt")) {
+                            flags[1] = true;
+                        } else if (name.endsWith(".scala")) {
+                            flags[2] = true;
+                        } else if (name.endsWith(".groovy")) {
+                            flags[3] = true;
+                        }
+                        return flags[0] && flags[1] && flags[2] && flags[3]
+                                ? FileVisitResult.TERMINATE
+                                : FileVisitResult.CONTINUE;
+                    }
+                });
+                if (flags[0] && flags[1] && flags[2] && flags[3]) {
+                    break;
+                }
+            }
+            SequencedProperties properties = new SequencedProperties();
+            properties.setProperty(JAVADOC, Boolean.toString(flags[0]));
+            properties.setProperty(DOKKA, Boolean.toString(flags[1]));
+            properties.setProperty(SCALADOC, Boolean.toString(flags[2]));
+            properties.setProperty(GROOVYDOC, Boolean.toString(flags[3]));
+            properties.store(context.next().resolve(SCAN_FILE));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private record Document(Map<String, Repository> repositories,
+                            Map<String, Resolver> resolvers,
+                            boolean process,
+                            Pinning pinning) implements BuildExecutorModule {
+
+        @Override
+        public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) throws IOException {
+            Path scanFolder = inherited.get(PREVIOUS + SCAN);
+            if (scanFolder == null) {
+                throw new IllegalStateException("Document sub-module is missing its upstream scan input");
+            }
+            SequencedProperties scan = SequencedProperties.ofFiles(scanFolder.resolve(SCAN_FILE));
+            boolean hasJava = Boolean.parseBoolean(scan.getProperty(JAVADOC));
+            boolean hasGroovy = Boolean.parseBoolean(scan.getProperty(GROOVYDOC));
+            boolean hasScala = Boolean.parseBoolean(scan.getProperty(SCALADOC));
+            boolean hasKotlin = Boolean.parseBoolean(scan.getProperty(DOKKA));
+
+            SequencedSet<String> sourceInputs = new LinkedHashSet<>(inherited.sequencedKeySet());
+            sourceInputs.remove(PREVIOUS + SCAN);
+
+            int nonJava = (hasGroovy ? 1 : 0) + (hasScala ? 1 : 0) + (hasKotlin ? 1 : 0);
+            if (nonJava == 1 && hasGroovy) {
+                buildExecutor.addModule(GROOVYDOC,
+                        new GroovyDocumentationModule(repositories, resolvers).pinning(pinning).includeJava(hasJava),
+                        sourceInputs);
+                return;
+            }
+            if (hasJava) {
+                buildExecutor.addStep(JAVADOC,
+                        process ? Javadoc.process() : Javadoc.tool(),
+                        sourceInputs);
+            }
+            if (hasGroovy) {
+                buildExecutor.addModule(GROOVYDOC,
+                        new GroovyDocumentationModule(repositories, resolvers).pinning(pinning).within(GROOVYDOC),
+                        sourceInputs);
+            }
+        }
+    }
+}

--- a/sources/build/jenesis/project/InferredDocumentationChainModule.java
+++ b/sources/build/jenesis/project/InferredDocumentationChainModule.java
@@ -16,7 +16,7 @@ import build.jenesis.step.Javadoc;
 public class InferredDocumentationChainModule implements BuildExecutorModule {
 
     public static final String JAVADOC = "javadoc", GROOVYDOC = "groovydoc", SCALADOC = "scaladoc", DOKKA = "dokka";
-    public static final String DOCUMENT = "document";
+    public static final String DOCUMENT = "document", AGGREGATE = "aggregate";
     private static final String SCAN = "scan";
     private static final String SCAN_FILE = "scan.properties";
 
@@ -127,39 +127,95 @@ public class InferredDocumentationChainModule implements BuildExecutorModule {
             SequencedSet<String> sourceInputs = new LinkedHashSet<>(inherited.sequencedKeySet());
             sourceInputs.remove(PREVIOUS + SCAN);
 
-            int nonJava = (hasGroovy ? 1 : 0) + (hasScala ? 1 : 0) + (hasKotlin ? 1 : 0);
-            int total = (hasJava ? 1 : 0) + nonJava;
-            if (total == 1) {
-                if (hasJava) {
-                    buildExecutor.addStep(JAVADOC, process ? Javadoc.process() : Javadoc.tool(), sourceInputs);
-                } else if (hasGroovy) {
-                    buildExecutor.addModule(GROOVYDOC,
-                            new GroovyDocumentationModule(repositories, resolvers).pinning(pinning), sourceInputs);
-                } else if (hasScala) {
-                    buildExecutor.addModule(SCALADOC,
-                            new ScalaDocumentationModule(repositories, resolvers).pinning(pinning), sourceInputs);
-                }
-                return;
-            }
-            if (nonJava == 1 && hasGroovy) {
-                buildExecutor.addModule(GROOVYDOC,
-                        new GroovyDocumentationModule(repositories, resolvers).pinning(pinning).includeJava(true),
-                        sourceInputs);
-                return;
-            }
+            SequencedSet<String> outputs = new LinkedHashSet<>();
+            boolean sole = (hasJava ? 1 : 0) + (hasGroovy ? 1 : 0) + (hasScala ? 1 : 0) + (hasKotlin ? 1 : 0) == 1;
             if (hasJava) {
-                buildExecutor.addStep(JAVADOC, process ? Javadoc.process() : Javadoc.tool(), sourceInputs);
+                buildExecutor.addStep(JAVADOC,
+                        (process ? Javadoc.process() : Javadoc.tool()).classpath(),
+                        sourceInputs);
+                outputs.add(JAVADOC);
             }
             if (hasGroovy) {
                 buildExecutor.addModule(GROOVYDOC,
-                        new GroovyDocumentationModule(repositories, resolvers).pinning(pinning).within(GROOVYDOC),
+                        new GroovyDocumentationModule(repositories, resolvers).pinning(pinning).within(sole ? null : GROOVYDOC),
                         sourceInputs);
+                outputs.add(GROOVYDOC);
             }
             if (hasScala) {
                 buildExecutor.addModule(SCALADOC,
-                        new ScalaDocumentationModule(repositories, resolvers).pinning(pinning).within(SCALADOC),
+                        new ScalaDocumentationModule(repositories, resolvers).pinning(pinning).within(sole ? null : SCALADOC),
                         sourceInputs);
+                outputs.add(SCALADOC);
             }
+            if (hasKotlin) {
+                buildExecutor.addModule(DOKKA,
+                        new DokkaDocumentationModule(repositories, resolvers).pinning(pinning).within(sole ? null : DOKKA),
+                        sourceInputs);
+                outputs.add(DOKKA);
+            }
+            buildExecutor.addStep(AGGREGATE, new Aggregate(), outputs);
+        }
+
+        @Override
+        public Optional<String> resolve(String path) {
+            return path.equals(AGGREGATE) ? Optional.of(AGGREGATE) : Optional.empty();
+        }
+    }
+
+    private static class Aggregate implements BuildStep {
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            Path combined = Files.createDirectories(context.next().resolve(Javadoc.JAVADOC));
+            for (BuildStepArgument argument : arguments.values()) {
+                Path source = argument.folder().resolve(Javadoc.JAVADOC);
+                if (!Files.exists(source)) {
+                    continue;
+                }
+                Files.walkFileTree(source, new SimpleFileVisitor<>() {
+                    @Override
+                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                        Files.createDirectories(combined.resolve(source.relativize(dir)));
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                        BuildStep.linkOrCopy(combined.resolve(source.relativize(file)), file);
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+            }
+            if (!Files.exists(combined.resolve("index.html"))) {
+                SequencedSet<String> rendered = new TreeSet<>();
+                try (Stream<Path> entries = Files.list(combined)) {
+                    for (Path entry : entries.toList()) {
+                        if (Files.isDirectory(entry) && Files.exists(entry.resolve("index.html"))) {
+                            rendered.add(entry.getFileName().toString());
+                        }
+                    }
+                }
+                StringBuilder body = new StringBuilder();
+                body.append("<!DOCTYPE html>\n<html lang=\"en\"><head><meta charset=\"utf-8\">")
+                        .append("<title>API documentation</title></head><body>\n")
+                        .append("<h1>API documentation</h1>\n");
+                if (rendered.isEmpty()) {
+                    body.append("<p>No rendered API documentation is available for this module.</p>\n");
+                } else {
+                    body.append("<p>API documentation is available per language:</p>\n<ul>\n");
+                    for (String name : rendered) {
+                        body.append("<li><a href=\"").append(name).append("/index.html\">")
+                                .append(name).append("</a></li>\n");
+                    }
+                    body.append("</ul>\n");
+                }
+                body.append("</body></html>\n");
+                Files.writeString(combined.resolve("index.html"), body.toString());
+            }
+            return CompletableFuture.completedStage(new BuildStepResult(true));
         }
     }
 }

--- a/sources/build/jenesis/project/InferredDocumentationChainModule.java
+++ b/sources/build/jenesis/project/InferredDocumentationChainModule.java
@@ -128,30 +128,51 @@ public class InferredDocumentationChainModule implements BuildExecutorModule {
             sourceInputs.remove(PREVIOUS + SCAN);
 
             SequencedSet<String> outputs = new LinkedHashSet<>();
-            boolean sole = (hasJava ? 1 : 0) + (hasGroovy ? 1 : 0) + (hasScala ? 1 : 0) + (hasKotlin ? 1 : 0) == 1;
-            if (hasJava) {
+            if (hasKotlin && !hasScala && !hasGroovy) {
+                buildExecutor.addModule(DOKKA,
+                        new DokkaDocumentationModule(repositories, resolvers).pinning(pinning),
+                        sourceInputs);
+                outputs.add(DOKKA);
+            } else if (hasGroovy && !hasScala && !hasKotlin) {
+                buildExecutor.addModule(GROOVYDOC,
+                        new GroovyDocumentationModule(repositories, resolvers).pinning(pinning).includeJava(hasJava),
+                        sourceInputs);
+                outputs.add(GROOVYDOC);
+            } else if (hasScala && !hasJava && !hasKotlin && !hasGroovy) {
+                buildExecutor.addModule(SCALADOC,
+                        new ScalaDocumentationModule(repositories, resolvers).pinning(pinning),
+                        sourceInputs);
+                outputs.add(SCALADOC);
+            } else if (hasJava && !hasKotlin && !hasScala && !hasGroovy) {
                 buildExecutor.addStep(JAVADOC,
                         (process ? Javadoc.process() : Javadoc.tool()).classpath(),
                         sourceInputs);
                 outputs.add(JAVADOC);
-            }
-            if (hasGroovy) {
-                buildExecutor.addModule(GROOVYDOC,
-                        new GroovyDocumentationModule(repositories, resolvers).pinning(pinning).within(sole ? null : GROOVYDOC),
-                        sourceInputs);
-                outputs.add(GROOVYDOC);
-            }
-            if (hasScala) {
-                buildExecutor.addModule(SCALADOC,
-                        new ScalaDocumentationModule(repositories, resolvers).pinning(pinning).within(sole ? null : SCALADOC),
-                        sourceInputs);
-                outputs.add(SCALADOC);
-            }
-            if (hasKotlin) {
-                buildExecutor.addModule(DOKKA,
-                        new DokkaDocumentationModule(repositories, resolvers).pinning(pinning).within(sole ? null : DOKKA),
-                        sourceInputs);
-                outputs.add(DOKKA);
+            } else {
+                if (hasJava) {
+                    buildExecutor.addStep(JAVADOC,
+                            (process ? Javadoc.process() : Javadoc.tool()).classpath(),
+                            sourceInputs);
+                    outputs.add(JAVADOC);
+                }
+                if (hasKotlin) {
+                    buildExecutor.addModule(DOKKA,
+                            new DokkaDocumentationModule(repositories, resolvers).pinning(pinning).within(DOKKA),
+                            sourceInputs);
+                    outputs.add(DOKKA);
+                }
+                if (hasScala) {
+                    buildExecutor.addModule(SCALADOC,
+                            new ScalaDocumentationModule(repositories, resolvers).pinning(pinning).within(SCALADOC),
+                            sourceInputs);
+                    outputs.add(SCALADOC);
+                }
+                if (hasGroovy) {
+                    buildExecutor.addModule(GROOVYDOC,
+                            new GroovyDocumentationModule(repositories, resolvers).pinning(pinning).within(GROOVYDOC),
+                            sourceInputs);
+                    outputs.add(GROOVYDOC);
+                }
             }
             buildExecutor.addStep(AGGREGATE, new Aggregate(), outputs);
         }

--- a/sources/build/jenesis/project/InferredDocumentationChainModule.java
+++ b/sources/build/jenesis/project/InferredDocumentationChainModule.java
@@ -128,20 +128,36 @@ public class InferredDocumentationChainModule implements BuildExecutorModule {
             sourceInputs.remove(PREVIOUS + SCAN);
 
             int nonJava = (hasGroovy ? 1 : 0) + (hasScala ? 1 : 0) + (hasKotlin ? 1 : 0);
+            int total = (hasJava ? 1 : 0) + nonJava;
+            if (total == 1) {
+                if (hasJava) {
+                    buildExecutor.addStep(JAVADOC, process ? Javadoc.process() : Javadoc.tool(), sourceInputs);
+                } else if (hasGroovy) {
+                    buildExecutor.addModule(GROOVYDOC,
+                            new GroovyDocumentationModule(repositories, resolvers).pinning(pinning), sourceInputs);
+                } else if (hasScala) {
+                    buildExecutor.addModule(SCALADOC,
+                            new ScalaDocumentationModule(repositories, resolvers).pinning(pinning), sourceInputs);
+                }
+                return;
+            }
             if (nonJava == 1 && hasGroovy) {
                 buildExecutor.addModule(GROOVYDOC,
-                        new GroovyDocumentationModule(repositories, resolvers).pinning(pinning).includeJava(hasJava),
+                        new GroovyDocumentationModule(repositories, resolvers).pinning(pinning).includeJava(true),
                         sourceInputs);
                 return;
             }
             if (hasJava) {
-                buildExecutor.addStep(JAVADOC,
-                        process ? Javadoc.process() : Javadoc.tool(),
-                        sourceInputs);
+                buildExecutor.addStep(JAVADOC, process ? Javadoc.process() : Javadoc.tool(), sourceInputs);
             }
             if (hasGroovy) {
                 buildExecutor.addModule(GROOVYDOC,
                         new GroovyDocumentationModule(repositories, resolvers).pinning(pinning).within(GROOVYDOC),
+                        sourceInputs);
+            }
+            if (hasScala) {
+                buildExecutor.addModule(SCALADOC,
+                        new ScalaDocumentationModule(repositories, resolvers).pinning(pinning).within(SCALADOC),
                         sourceInputs);
             }
         }

--- a/sources/build/jenesis/project/JavaMultiProjectAssembler.java
+++ b/sources/build/jenesis/project/JavaMultiProjectAssembler.java
@@ -146,7 +146,7 @@ public record JavaMultiProjectAssembler(boolean process,
                     module.addStep("archive",
                             process ? Jar.process(Jar.Sort.JAVADOC) : Jar.tool(Jar.Sort.JAVADOC),
                             "generate");
-                }, inputs(descriptor));
+                }, Stream.concat(Stream.of("binary"), inputs(descriptor)));
             }
             if (jmod) {
                 sub.addStep("jmod",

--- a/sources/build/jenesis/project/JavaMultiProjectAssembler.java
+++ b/sources/build/jenesis/project/JavaMultiProjectAssembler.java
@@ -138,12 +138,14 @@ public record JavaMultiProjectAssembler(boolean process,
             }
             if (descriptor.documentation()) {
                 sub.addModule("documentation", (module, inherited) -> {
-                    module.addStep("javadoc",
-                            process ? Javadoc.process() : Javadoc.tool(),
+                    module.addModule("generate",
+                            new InferredDocumentationChainModule(repositories, resolvers)
+                                    .process(process)
+                                    .pinning(descriptor.pinning()),
                             inherited.sequencedKeySet());
                     module.addStep("archive",
                             process ? Jar.process(Jar.Sort.JAVADOC) : Jar.tool(Jar.Sort.JAVADOC),
-                            "javadoc");
+                            "generate");
                 }, inputs(descriptor));
             }
             if (jmod) {

--- a/sources/build/jenesis/project/ScalaDocumentationModule.java
+++ b/sources/build/jenesis/project/ScalaDocumentationModule.java
@@ -125,6 +125,9 @@ public class ScalaDocumentationModule implements BuildExecutorModule {
             };
             SequencedProperties requires = new SequencedProperties();
             requires.setProperty(coordinate, "");
+            if (selectedPrefix.equals("maven")) {
+                requires.setProperty(namespace + "/com.fasterxml.jackson.core/jackson-annotations/2.21", "");
+            }
             requires.store(context.next().resolve(BuildStep.REQUIRES));
             return CompletableFuture.completedStage(new BuildStepResult(true));
         }

--- a/sources/build/jenesis/project/ScalaDocumentationModule.java
+++ b/sources/build/jenesis/project/ScalaDocumentationModule.java
@@ -1,0 +1,251 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.DependencyScope;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Bind;
+import build.jenesis.step.Download;
+import build.jenesis.step.Javac;
+import build.jenesis.step.Javadoc;
+import build.jenesis.step.JdkProcessBuildStep;
+import build.jenesis.step.ProcessHandler;
+import build.jenesis.step.Resolve;
+
+public class ScalaDocumentationModule implements BuildExecutorModule {
+
+    public static final String DOCUMENTED = "documented";
+    private static final String REQUIRED = "required", RESOLVED = "resolved", ARTIFACTS = "artifacts";
+
+    private static final List<String> PREFERRED_PREFIXES = List.of("maven", "module");
+    private static final String MODULE_NAME = "org.scala.lang.scaladoc";
+    private static final String MAVEN_GROUP = "org.scala-lang";
+    private static final String MAVEN_ARTIFACT = "scaladoc_3";
+    private static final String LIBRARY_MARKER = "org.scala-lang-scala3-library_3-";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String qualifier;
+    private final String within;
+    private final transient Function<List<String>, ? extends ProcessHandler> factory;
+
+    public ScalaDocumentationModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "scaladoc", null, null);
+    }
+
+    private ScalaDocumentationModule(Map<String, Repository> repositories,
+                                     Map<String, Resolver> resolvers,
+                                     Pinning pinning,
+                                     String qualifier,
+                                     String within,
+                                     Function<List<String>, ? extends ProcessHandler> factory) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.qualifier = qualifier;
+        this.within = within;
+        this.factory = factory;
+    }
+
+    public ScalaDocumentationModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
+        return new ScalaDocumentationModule(repositories, resolvers, pinning, qualifier, within, factory);
+    }
+
+    public ScalaDocumentationModule pinning(Pinning pinning) {
+        return new ScalaDocumentationModule(repositories, resolvers, pinning, qualifier, within, factory);
+    }
+
+    public ScalaDocumentationModule qualifier(String qualifier) {
+        return new ScalaDocumentationModule(repositories, resolvers, pinning, qualifier, within, factory);
+    }
+
+    public ScalaDocumentationModule within(String within) {
+        return new ScalaDocumentationModule(repositories, resolvers, pinning, qualifier, within, factory);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        SequencedSet<String> upstream = inherited.sequencedKeySet();
+        buildExecutor.addStep(REQUIRED, new Requires(Set.copyOf(resolvers.keySet()), qualifier), upstream);
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(upstream);
+        buildExecutor.addStep(RESOLVED, new Resolve(repositories, resolvers, DependencyScope.RUNTIME).pinned(pinning != Pinning.IGNORE), resolveInputs);
+        buildExecutor.addStep(ARTIFACTS, new Download(repositories).pinning(pinning).tag("compiler:" + qualifier), RESOLVED);
+        SequencedSet<String> documentInputs = new LinkedHashSet<>();
+        documentInputs.add(ARTIFACTS);
+        documentInputs.addAll(upstream);
+        buildExecutor.addStep(DOCUMENTED,
+                factory == null ? new Document(within) : new Document(within, factory),
+                documentInputs);
+    }
+
+    @Override
+    public Optional<String> resolve(String path) {
+        return switch (path) {
+            case DOCUMENTED, RESOLVED, ARTIFACTS -> Optional.of(path);
+            default -> Optional.empty();
+        };
+    }
+
+    private record Requires(Set<String> prefixes, String qualifier) implements BuildStep {
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            String selectedPrefix = null;
+            for (String prefix : PREFERRED_PREFIXES) {
+                if (prefixes.contains(prefix)) {
+                    selectedPrefix = prefix;
+                    break;
+                }
+            }
+            if (selectedPrefix == null) {
+                throw new IllegalStateException(
+                        "No suitable resolver for Scala documentation. Available prefixes: " + prefixes
+                                + ". Expected one of: " + PREFERRED_PREFIXES);
+            }
+            String version = resolvedVersion(arguments);
+            String namespace = qualifier == null ? selectedPrefix : selectedPrefix + "@" + qualifier;
+            String coordinate = switch (selectedPrefix) {
+                case "module" -> namespace + "/" + MODULE_NAME;
+                case "maven" -> namespace + "/" + MAVEN_GROUP + "/" + MAVEN_ARTIFACT + "/" + version;
+                default -> throw new IllegalStateException("Unreachable");
+            };
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(coordinate, "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+
+        private static String resolvedVersion(SequencedMap<String, BuildStepArgument> arguments) throws IOException {
+            String[] found = new String[1];
+            for (BuildStepArgument argument : arguments.values()) {
+                for (String jarFolder : List.of(BuildStep.DEPENDENCIES, BuildStep.ARTIFACTS)) {
+                    Path jarRoot = argument.folder().resolve(jarFolder);
+                    if (!Files.exists(jarRoot)) {
+                        continue;
+                    }
+                    Files.walkFileTree(jarRoot, new SimpleFileVisitor<>() {
+                        @Override
+                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                            String name = file.getFileName().toString();
+                            int at = name.indexOf(LIBRARY_MARKER);
+                            if (at >= 0 && name.indexOf('@') < 0 && name.endsWith(".jar")) {
+                                String candidate = name.substring(at + LIBRARY_MARKER.length(), name.length() - ".jar".length());
+                                if (!candidate.isEmpty() && Character.isDigit(candidate.charAt(0))) {
+                                    found[0] = candidate;
+                                    return FileVisitResult.TERMINATE;
+                                }
+                            }
+                            return FileVisitResult.CONTINUE;
+                        }
+                    });
+                }
+            }
+            return found[0] == null ? "RELEASE" : found[0];
+        }
+    }
+
+    private static class Document extends JdkProcessBuildStep {
+
+        private final String within;
+
+        private Document(String within) {
+            this(within, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
+        }
+
+        private Document(String within, Function<List<String>, ? extends ProcessHandler> factory) {
+            super("scaladoc", factory);
+            this.within = within;
+        }
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return Javac.hasRelevantChange(arguments,
+                    Set.of(".scala"),
+                    Set.of("scaladoc.properties"));
+        }
+
+        @Override
+        public CompletionStage<List<String>> process(Executor executor,
+                                                     BuildStepContext context,
+                                                     SequencedMap<String, BuildStepArgument> arguments,
+                                                     SequencedMap<String, SequencedMap<String, String>> properties)
+                throws IOException {
+            Path documentation = context.next().resolve(Javadoc.JAVADOC);
+            Path output = Files.createDirectories(within == null ? documentation : documentation.resolve(within));
+            List<String> files = new ArrayList<>(), jars = new ArrayList<>(), classpath = new ArrayList<>();
+            for (BuildStepArgument argument : arguments.values()) {
+                Path classes = argument.folder().resolve(BuildStep.CLASSES);
+                if (Files.exists(classes)) {
+                    classpath.add(classes.toString());
+                }
+                for (String jarFolder : List.of(ARTIFACTS, DEPENDENCIES)) {
+                    Path jarRoot = argument.folder().resolve(jarFolder);
+                    if (Files.exists(jarRoot)) {
+                        Files.walkFileTree(jarRoot, new SimpleFileVisitor<>() {
+                            @Override
+                            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                                jars.add(file.toString());
+                                return FileVisitResult.CONTINUE;
+                            }
+                        });
+                    }
+                }
+                Path sources = argument.folder().resolve(Bind.SOURCES);
+                if (Files.exists(sources)) {
+                    Files.walkFileTree(sources, new SimpleFileVisitor<>() {
+                        @Override
+                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                            String name = file.toString();
+                            if (name.endsWith(".scala")) {
+                                files.add(name);
+                            }
+                            return FileVisitResult.CONTINUE;
+                        }
+                    });
+                }
+            }
+            files.sort(null);
+            jars.sort(null);
+            if (files.isEmpty()) {
+                return CompletableFuture.completedStage(null);
+            }
+            if (jars.isEmpty()) {
+                throw new IllegalStateException(
+                        "No scaladoc jars resolved upstream of the Scala documentation step");
+            }
+            List<String> launch = new ArrayList<>();
+            for (String jar : jars) {
+                if (new File(jar).getName().indexOf('@') != -1) {
+                    launch.add(jar);
+                }
+            }
+            if (launch.isEmpty()) {
+                launch = jars;
+            }
+            List<String> userClasspath = new ArrayList<>(jars);
+            userClasspath.addAll(classpath);
+            List<String> commands = new ArrayList<>(List.of(
+                    "-cp", String.join(File.pathSeparator, launch),
+                    "dotty.tools.scaladoc.Main",
+                    "-d", output.toString(),
+                    "-classpath", String.join(File.pathSeparator, userClasspath),
+                    "-project", "documentation"));
+            commands.addAll(files);
+            return CompletableFuture.completedStage(commands);
+        }
+    }
+}

--- a/sources/build/jenesis/step/Javadoc.java
+++ b/sources/build/jenesis/step/Javadoc.java
@@ -9,8 +9,15 @@ public class Javadoc extends JdkProcessBuildStep {
 
     public static final String JAVADOC = "javadoc/";
 
+    private final String within;
+
     protected Javadoc(Function<List<String>, ? extends ProcessHandler> factory) {
+        this(factory, null);
+    }
+
+    private Javadoc(Function<List<String>, ? extends ProcessHandler> factory, String within) {
         super("javadoc", factory);
+        this.within = within;
     }
 
     public static Javadoc tool() {
@@ -21,14 +28,21 @@ public class Javadoc extends JdkProcessBuildStep {
         return new Javadoc(ProcessHandler.OfProcess.ofJavaHome("bin/javadoc"));
     }
 
+    public Javadoc within(String within) {
+        return new Javadoc(factory, within);
+    }
+
     @Override
     protected CompletionStage<List<String>> process(Executor executor,
                                                     BuildStepContext context,
                                                     SequencedMap<String, BuildStepArgument> arguments,
                                                     SequencedMap<String, SequencedMap<String, String>> properties)
             throws IOException {
+        Path documentation = within == null
+                ? Files.createDirectory(context.next().resolve(JAVADOC))
+                : Files.createDirectories(context.next().resolve(JAVADOC).resolve(within));
         List<String> files = new ArrayList<>(), path = new ArrayList<>(), commands = new ArrayList<>(List.of(
-                "-d", Files.createDirectory(context.next().resolve(JAVADOC)).toString(),
+                "-d", documentation.toString(),
                 "-notimestamp",
                 "-tag", "jenesis.release:a:Release:",
                 "-tag", "jenesis.main:a:Main class:",

--- a/sources/build/jenesis/step/Javadoc.java
+++ b/sources/build/jenesis/step/Javadoc.java
@@ -10,14 +10,16 @@ public class Javadoc extends JdkProcessBuildStep {
     public static final String JAVADOC = "javadoc/";
 
     private final String within;
+    private final boolean classpath;
 
     protected Javadoc(Function<List<String>, ? extends ProcessHandler> factory) {
-        this(factory, null);
+        this(factory, null, false);
     }
 
-    private Javadoc(Function<List<String>, ? extends ProcessHandler> factory, String within) {
+    private Javadoc(Function<List<String>, ? extends ProcessHandler> factory, String within, boolean classpath) {
         super("javadoc", factory);
         this.within = within;
+        this.classpath = classpath;
     }
 
     public static Javadoc tool() {
@@ -29,7 +31,19 @@ public class Javadoc extends JdkProcessBuildStep {
     }
 
     public Javadoc within(String within) {
-        return new Javadoc(factory, within);
+        return new Javadoc(factory, within, classpath);
+    }
+
+    public Javadoc classpath() {
+        return new Javadoc(factory, within, true);
+    }
+
+    @Override
+    public boolean acceptableExitCode(int code,
+                                      Executor executor,
+                                      BuildStepContext context,
+                                      SequencedMap<String, BuildStepArgument> arguments) {
+        return true;
     }
 
     @Override
@@ -44,6 +58,8 @@ public class Javadoc extends JdkProcessBuildStep {
         List<String> files = new ArrayList<>(), path = new ArrayList<>(), commands = new ArrayList<>(List.of(
                 "-d", documentation.toString(),
                 "-notimestamp",
+                "-quiet",
+                "-Xdoclint:none",
                 "-tag", "jenesis.release:a:Release:",
                 "-tag", "jenesis.main:a:Main class:",
                 "-tag", "jenesis.test:a:Tests the module:",
@@ -70,8 +86,10 @@ public class Javadoc extends JdkProcessBuildStep {
                 Files.walkFileTree(sources, new SimpleFileVisitor<>() {
                     @Override
                     public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                        if (file.toString().endsWith(".java")) {
-                            files.add(file.toString());
+                        String name = file.toString();
+                        if (name.endsWith(".java")
+                                && !(classpath && name.endsWith(File.separator + "module-info.java"))) {
+                            files.add(name);
                         }
                         return FileVisitResult.CONTINUE;
                     }
@@ -80,7 +98,8 @@ public class Javadoc extends JdkProcessBuildStep {
         }
         files.sort(null);
         path.sort(null);
-        boolean module = files.stream().anyMatch(file -> file.endsWith(File.separator + "module-info.java"));
+        boolean module = !classpath
+                && files.stream().anyMatch(file -> file.endsWith(File.separator + "module-info.java"));
         if (!path.isEmpty()) {
             for (String entry : path) {
                 if (entry.indexOf(File.pathSeparatorChar) != -1) {

--- a/tests/build/jenesis/test/project/InferredDocumentationModuleTest.java
+++ b/tests/build/jenesis/test/project/InferredDocumentationModuleTest.java
@@ -77,8 +77,8 @@ public class InferredDocumentationModuleTest {
                 .resolve("dokka").resolve("required").resolve("output").resolve(BuildStep.REQUIRES));
         assertThat(requires.stringPropertyNames()).containsExactlyInAnyOrder(
                 "maven@dokka/org.jetbrains.dokka/dokka-cli/RELEASE",
-                "maven@dokka/org.jetbrains.dokka/analysis-kotlin-descriptors/RELEASE",
-                "maven@dokka/org.jetbrains.dokka/javadoc-plugin/RELEASE");
+                "maven@dokka/org.jetbrains.dokka/dokka-base/RELEASE",
+                "maven@dokka/org.jetbrains.dokka/analysis-kotlin-descriptors/RELEASE");
     }
 
     @Test

--- a/tests/build/jenesis/test/project/InferredDocumentationModuleTest.java
+++ b/tests/build/jenesis/test/project/InferredDocumentationModuleTest.java
@@ -77,8 +77,8 @@ public class InferredDocumentationModuleTest {
                 .resolve("dokka").resolve("required").resolve("output").resolve(BuildStep.REQUIRES));
         assertThat(requires.stringPropertyNames()).containsExactlyInAnyOrder(
                 "maven@dokka/org.jetbrains.dokka/dokka-cli/RELEASE",
-                "maven@dokka/org.jetbrains.dokka/dokka-base/RELEASE",
-                "maven@dokka/org.jetbrains.dokka/analysis-kotlin-descriptors/RELEASE");
+                "maven@dokka/org.jetbrains.dokka/analysis-kotlin-descriptors/RELEASE",
+                "maven@dokka/org.jetbrains.dokka/javadoc-plugin/RELEASE");
     }
 
     @Test

--- a/tests/build/jenesis/test/project/InferredDocumentationModuleTest.java
+++ b/tests/build/jenesis/test/project/InferredDocumentationModuleTest.java
@@ -1,0 +1,136 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.DokkaDocumentationModule;
+import build.jenesis.project.GroovyDocumentationModule;
+import build.jenesis.project.InferredDocumentationChainModule;
+import build.jenesis.project.ScalaDocumentationModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InferredDocumentationModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void scan_detects_each_language_from_source_extensions() throws IOException {
+        Path sample = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample"));
+        Files.writeString(sample.resolve("Greeter.java"), "package sample; class Greeter {}");
+        Files.writeString(sample.resolve("Sample.kt"), "package sample\nclass Sample");
+        Files.writeString(sample.resolve("Pure.scala"), "package sample\nclass Pure");
+        Files.writeString(sample.resolve("Script.groovy"), "package sample\nclass Script {}");
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("doc",
+                new InferredDocumentationChainModule(Map.of(), Map.of("maven", Resolver.identity())),
+                "project");
+        executor.execute("doc/scan");
+
+        SequencedProperties scan = SequencedProperties.ofFiles(root
+                .resolve("doc").resolve("scan").resolve("output").resolve("scan.properties"));
+        assertThat(scan.getProperty("javadoc")).isEqualTo("true");
+        assertThat(scan.getProperty("dokka")).isEqualTo("true");
+        assertThat(scan.getProperty("scaladoc")).isEqualTo("true");
+        assertThat(scan.getProperty("groovydoc")).isEqualTo("true");
+    }
+
+    @Test
+    public void scan_reports_absent_languages_as_false() throws IOException {
+        Path sample = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample"));
+        Files.writeString(sample.resolve("Greeter.java"), "package sample; class Greeter {}");
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("doc",
+                new InferredDocumentationChainModule(Map.of(), Map.of("maven", Resolver.identity())),
+                "project");
+        executor.execute("doc/scan");
+
+        SequencedProperties scan = SequencedProperties.ofFiles(root
+                .resolve("doc").resolve("scan").resolve("output").resolve("scan.properties"));
+        assertThat(scan.getProperty("javadoc")).isEqualTo("true");
+        assertThat(scan.getProperty("dokka")).isEqualTo("false");
+        assertThat(scan.getProperty("scaladoc")).isEqualTo("false");
+        assertThat(scan.getProperty("groovydoc")).isEqualTo("false");
+    }
+
+    @Test
+    public void dokka_requires_the_cli_and_plugin_coordinates_under_a_qualified_trail() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("dokka",
+                new DokkaDocumentationModule(Map.of(), Map.of("maven", Resolver.identity())),
+                "project");
+        executor.execute("dokka/required");
+
+        SequencedProperties requires = SequencedProperties.ofFiles(root
+                .resolve("dokka").resolve("required").resolve("output").resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames()).containsExactlyInAnyOrder(
+                "maven@dokka/org.jetbrains.dokka/dokka-cli/RELEASE",
+                "maven@dokka/org.jetbrains.dokka/dokka-base/RELEASE",
+                "maven@dokka/org.jetbrains.dokka/analysis-kotlin-descriptors/RELEASE");
+    }
+
+    @Test
+    public void dokka_requires_nothing_without_a_maven_resolver() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("dokka",
+                new DokkaDocumentationModule(Map.of(), Map.of("module", Resolver.identity())),
+                "project");
+        executor.execute("dokka/required");
+
+        SequencedProperties requires = SequencedProperties.ofFiles(root
+                .resolve("dokka").resolve("required").resolve("output").resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames()).isEmpty();
+    }
+
+    @Test
+    public void scaladoc_requires_pins_the_jackson_annotations_its_runtime_expects() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("scaladoc",
+                new ScalaDocumentationModule(Map.of(), Map.of("maven", Resolver.identity())),
+                "project");
+        executor.execute("scaladoc/required");
+
+        SequencedProperties requires = SequencedProperties.ofFiles(root
+                .resolve("scaladoc").resolve("required").resolve("output").resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames()).contains(
+                "maven@scaladoc/org.scala-lang/scaladoc_3/RELEASE",
+                "maven@scaladoc/com.fasterxml.jackson.core/jackson-annotations/2.21");
+    }
+
+    @Test
+    public void groovydoc_requires_the_groovydoc_coordinate_under_a_qualified_trail() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("groovydoc",
+                new GroovyDocumentationModule(Map.of(), Map.of("maven", Resolver.identity())),
+                "project");
+        executor.execute("groovydoc/required");
+
+        SequencedProperties requires = SequencedProperties.ofFiles(root
+                .resolve("groovydoc").resolve("required").resolve("output").resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("maven@groovydoc/org.apache.groovy/groovy-groovydoc/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an inference-based documentation chain that mirrors the existing inferred *compiler* chain, producing real, native API documentation for all four supported languages in a single `-javadoc.jar`.

A `scan` step detects which languages a module contains (`.java`/`.kt`/`.scala`/`.groovy`); a `document` sub-module dispatches one documentation tool per language; an `aggregate` step merges their output into one `javadoc/` tree.

| Language | Tool | Trail |
|----------|------|-------|
| Java | `javadoc` (class-path mode) | baseline, renders at archive root |
| Kotlin | Dokka | `@dokka` (`dokka-cli` + `dokka-base` + `analysis-kotlin-descriptors`) |
| Scala | `scaladoc` | `@scaladoc` (fed compiled `.tasty`) |
| Groovy | `groovydoc` | `@groovydoc` |

## Layout

When a single language is present, its tool renders at the root and the others are dropped. When more than one is present, Java renders at the root as the reliable baseline and the native tools render into per-language subfolders (`dokka/`, `scaladoc/`, `groovydoc/`). `aggregate` always guarantees a root `index.html` (linking to any subfolders that rendered) so the `-javadoc.jar`, a Maven Central prerequisite, is never empty.

## Tool friction worked through

- **Java**: class-path mode skips `module-info.java` so a mixed-language module whose `module-info` exports a package implemented only in another language still produces valid Java docs.
- **Scala**: feed compiled `.tasty` (scaladoc reads tasty, not source) by threading the `binary` output into the documentation module, and pin `jackson-annotations` to `2.21` - the version scaladoc's bundled Jackson 3 databind expects - so its static-site loader initializes instead of throwing `NoClassDefFoundError: JsonSerializeAs`.
- **Groovy**: work around the `groovydoc` CLI parser, whose `-javaVersion` option only accepts the JavaParser language-level enum name (`JAVA_21`, not `21`) and is shadowed by a sibling `-classpath` option. Pass the enum form, drop `-classpath`, and place module dependencies on the launch classpath instead.
- **Versioning**: Scala and Groovy tools are version-coordinated to the project's resolved compiler version; Dokka resolves at `RELEASE`.

Every tool tolerates a non-zero exit, so a documentation tool that fails never fails the build (best-effort, as javadoc is a Maven Central prerequisite rather than a strict deliverable).

## Verification

- demo-08 (Kotlin), demo-09 (Scala), demo-10 (Groovy), demo-01 (pure Java) all build with `-Djenesis.project.documentation=true` (`EXIT 0`) and produce real Java docs at root plus real native docs in subfolders.
- Full self-build + test suite green.
- 6 new unit tests cover scan inference and the per-tool `requires` coordinate emission.
- README documents the chain; the CI demo matrix now runs all three language demos with documentation enabled.