### PR TITLE
Fix high and medium severity findings from the scope-model review

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,11 @@ jobs:
           HEADER="$(printf '%s\n' "$MESSAGE" | head -n1)"
           VERSION="$(echo "$HEADER" | sed -nE 's/^\[release[[:space:]]+v?([0-9]+\.[0-9]+\.[0-9]+)\].*$/\1/p')"
           if [ -z "$VERSION" ]; then
+            STRAY="$(echo "$HEADER" | sed -nE 's/^\[release\][[:space:]]+v?([0-9]+\.[0-9]+\.[0-9]+).*$/\1/p')"
+            if [ -n "$STRAY" ]; then
+              echo "Version '$STRAY' must be inside the marker: use '[release $STRAY]', not '[release] $STRAY'." >&2
+              exit 1
+            fi
             LATEST="$(git tag --list --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 | sed 's/^v//')"
             if [ -z "$LATEST" ]; then
               VERSION="0.0.1"

--- a/README.md
+++ b/README.md
@@ -2310,7 +2310,7 @@ target/stage/maven/output/build/jenesis/build.jenesis/<version>/build.jenesis-<v
 `.github/workflows/release.yml` runs after the "Test Jenesis Tool" workflow completes on `main`, gated on the
 head commit's first line beginning with `[release]`. The release version is resolved as follows:
 
-- `[release] 1.2.3` (explicit version after the marker) - use `1.2.3`.
+- `[release 1.2.3]` or `[release v1.2.3]` (explicit version inside the marker) - use `1.2.3`.
 - `[release]` (marker alone) - take the highest `v?X.Y.Z` git tag, bump its minor by one, reset patch. So
   `v0.1.0 -> 0.2.0`, `v0.9.0 -> 0.10.0`, `v1.4.0 -> 1.5.0`.
 - `[release]` with no semver tags in the repo - bootstrap at `0.0.1`.

--- a/demo/demo-10-scala/README.md
+++ b/demo/demo-10-scala/README.md
@@ -67,7 +67,7 @@ A single `requires scala.library` pulls in the whole Scala standard library as o
 module: the library lives entirely in `scala-library`, and `scala3-library_3` is an
 empty aggregator, so nothing splits `package scala` across two modules and the
 Java module system accepts it on the module path. That is why this demo builds as a
-plain module with no `pom.xml`.
+plain module on the module path with no hand-written build script.
 
 Pinning
 -------

--- a/demo/demo-14-custom-assembler/README.md
+++ b/demo/demo-14-custom-assembler/README.md
@@ -25,7 +25,7 @@ To confirm the substituted value is what ended up compiled into the jar, run the
 produced modular jar yourself:
 
     java --module-path \
-        target/build/modules/compose/module/module-sources/produce/assemble/java/artifacts/jar/output/artifacts/classes.jar \
+        target/build/modules/compose/module/module-sources/produce/assemble/binary/artifacts/jar/output/artifacts/classes.jar \
         --module demo.custom
 
 which prints:

--- a/sdk/bin/jenesis-exec.bat
+++ b/sdk/bin/jenesis-exec.bat
@@ -24,7 +24,13 @@ if not defined JAVA_VERSION (
     exit /b 1
 )
 
+set "JAVA_MAJOR="
 for /f "tokens=1 delims=." %%m in ("!JAVA_VERSION!") do set "JAVA_MAJOR=%%m"
+echo !JAVA_MAJOR!| findstr /r "^[0-9][0-9]*$" >nul
+if errorlevel 1 (
+    echo jenesis-exec: Java 25 or newer required, but '!JAVA!' reports version '!JAVA_VERSION!' 1>&2
+    exit /b 1
+)
 if !JAVA_MAJOR! LSS 25 (
     echo jenesis-exec: Java 25 or newer required, but '!JAVA!' reports version '!JAVA_VERSION!' 1>&2
     exit /b 1

--- a/sdk/bin/jenesis-init
+++ b/sdk/bin/jenesis-init
@@ -41,7 +41,11 @@ fi
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 (cd "$TMPDIR" && "$JAR" xf "$SOURCES_JAR")
-rm -f "$TMPDIR/module-info.java"
+JAR_BUILD="$TMPDIR/build/jenesis"
+if [ ! -d "$JAR_BUILD" ]; then
+    echo "jenesis-init: extracted jar does not contain build/jenesis - artifact layout unexpected" >&2
+    exit 1
+fi
 
 for target in "${TARGETS[@]}"; do
     if [ ! -d "$target" ]; then
@@ -60,6 +64,7 @@ for target in "${TARGETS[@]}"; do
         fi
         rm -rf "$target/build/jenesis"
     fi
-    cp -R "$TMPDIR"/. "$target/"
+    mkdir -p "$target/build"
+    cp -R "$JAR_BUILD" "$target/build/jenesis"
     printf '%s' "$VERSION" > "$target/build/jenesis/jenesis.version"
 done

--- a/sdk/bin/jenesis-init.bat
+++ b/sdk/bin/jenesis-init.bat
@@ -41,7 +41,11 @@ if !EXTRACT_EXIT! NEQ 0 (
     rmdir /s /q "!TMPDIR!"
     exit /b !EXTRACT_EXIT!
 )
-if exist "!TMPDIR!\module-info.java" del /q "!TMPDIR!\module-info.java"
+if not exist "!TMPDIR!\build\jenesis\" (
+    echo jenesis-init: extracted jar does not contain build/jenesis - artifact layout unexpected 1>&2
+    rmdir /s /q "!TMPDIR!"
+    exit /b 1
+)
 
 set "LABELED=0"
 if not "%~1"=="" set "LABELED=1"
@@ -84,7 +88,8 @@ if exist "!TARGET!\build\jenesis" (
     )
     rmdir /s /q "!TARGET!\build\jenesis"
 )
-xcopy /s /e /y /i /q "!TMPDIR!\*" "!TARGET!\" >nul
+if not exist "!TARGET!\build\" mkdir "!TARGET!\build"
+xcopy /s /e /y /i /q "!TMPDIR!\build\jenesis\*" "!TARGET!\build\jenesis\" >nul
 if errorlevel 1 exit /b !ERRORLEVEL!
 <nul set /p =!VERSION!>"!TARGET!\build\jenesis\jenesis.version"
 exit /b 0

--- a/sdk/bin/jenesis.bat
+++ b/sdk/bin/jenesis.bat
@@ -24,7 +24,13 @@ if not defined JAVA_VERSION (
     exit /b 1
 )
 
+set "JAVA_MAJOR="
 for /f "tokens=1 delims=." %%m in ("!JAVA_VERSION!") do set "JAVA_MAJOR=%%m"
+echo !JAVA_MAJOR!| findstr /r "^[0-9][0-9]*$" >nul
+if errorlevel 1 (
+    echo jenesis: Java 25 or newer required, but '!JAVA!' reports version '!JAVA_VERSION!' 1>&2
+    exit /b 1
+)
 if !JAVA_MAJOR! LSS 25 (
     echo jenesis: Java 25 or newer required, but '!JAVA!' reports version '!JAVA_VERSION!' 1>&2
     exit /b 1

--- a/sources/build/jenesis/Project.java
+++ b/sources/build/jenesis/Project.java
@@ -404,7 +404,7 @@ public record Project(
                       %{name}@jenesis.release%{reset} <V>             Java release target
                       %{name}@jenesis.main%{reset} <class>            Main class for the module
                       %{name}@jenesis.test%{reset} [<module>]         Mark module as a test variant of <module>
-                      %{name}@jenesis.pin%{reset} <mod> <ver> [<algo>/<hex>]
+                      %{name}@jenesis.pin%{reset} <scope>/<repo>/<coord> <ver> [<algo>/<hex>]
                                                        Pin a dependency version and checksum
 
                     See README.md for the full reference.
@@ -544,11 +544,11 @@ public record Project(
 
                       1. Find the step folder under target/build/ (e.g.
                          `target/build/maven/compose/module/<m>/produce/
-                         assemble/java/artifacts/`).
+                         assemble/binary/artifacts/`).
                       2. Strip the `target/` prefix and any trailing `/output` or
                          `/supplement` segment.
                       3. Pass what remains to the launcher as a selector (e.g.
-                         `build/maven/compose/module/<m>/produce/assemble/java/
+                         `build/maven/compose/module/<m>/produce/assemble/binary/
                          artifacts`).
 
                     The executor walks that selector's subgraph and re-runs only
@@ -641,7 +641,7 @@ public record Project(
                       @jenesis.main <class>             Main class for the module.
                       @jenesis.test [<module>]          Mark this module as a test
                                                         variant of <module>.
-                      @jenesis.pin <mod> <ver> [<algo>/<hex>]
+                      @jenesis.pin <scope>/<repo>/<coord> <ver> [<algo>/<hex>]
                                                         Pin a dependency's version
                                                         and (optionally) its
                                                         content checksum.
@@ -766,7 +766,7 @@ public record Project(
                     It writes pom.xml (`<dependencyManagement>` versions with
                     `<!--Checksum/<algo>/<hex>-->`, and qualified compiler closures
                     in a `<!--jenesis.pin ... -->` comment) or module-info.java
-                    (`@jenesis.pin <mod> <ver> [<algo>/<hex>]` tags), per layout.
+                    (`@jenesis.pin <scope>/<repo>/<coord> <ver> [<algo>/<hex>]` tags), per layout.
                     The same pins can be written by hand. Enforce coverage with
                     `-Djenesis.dependency.pin=strict`, which fails the build on
                     any unpinned artifact, or refresh them with
@@ -1433,6 +1433,7 @@ public record Project(
             if (code != 0) {
                 System.exit(code);
             }
+            return new LinkedHashMap<>();
         }
         return this.build(selectors);
     }

--- a/sources/build/jenesis/Repository.java
+++ b/sources/build/jenesis/Repository.java
@@ -54,9 +54,14 @@ public interface Repository {
                         if (file != null) {
                             BuildStep.linkOrCopy(candidate, file);
                         } else {
+                            Path temporary = Files.createTempFile(candidate.getParent(), "fetch", ".jar");
                             try (InputStream inputStream = item.toInputStream()) {
-                                Files.copy(inputStream, candidate);
+                                Files.copy(inputStream, temporary, StandardCopyOption.REPLACE_EXISTING);
+                            } catch (Throwable t) {
+                                Files.deleteIfExists(temporary);
+                                throw t;
                             }
+                            Files.move(temporary, candidate, StandardCopyOption.ATOMIC_MOVE);
                         }
                         return candidate;
                     } catch (IOException e) {

--- a/sources/build/jenesis/SequencedProperties.java
+++ b/sources/build/jenesis/SequencedProperties.java
@@ -214,7 +214,7 @@ public class SequencedProperties extends Properties {
 
     private static class CommentSuppressingWriter extends BufferedWriter {
 
-        private boolean skipNextNewLine;
+        private boolean suppressLine;
 
         private CommentSuppressingWriter(Writer out) {
             super(out);
@@ -222,8 +222,11 @@ public class SequencedProperties extends Properties {
 
         @Override
         public void write(String str) throws IOException {
+            if (suppressLine) {
+                return;
+            }
             if (str.startsWith("#")) {
-                skipNextNewLine = true;
+                suppressLine = true;
             } else {
                 super.write(str);
             }
@@ -231,8 +234,8 @@ public class SequencedProperties extends Properties {
 
         @Override
         public void newLine() throws IOException {
-            if (skipNextNewLine) {
-                skipNextNewLine = false;
+            if (suppressLine) {
+                suppressLine = false;
             } else {
                 super.write('\n');
             }

--- a/sources/build/jenesis/docker/DockerizedJava.java
+++ b/sources/build/jenesis/docker/DockerizedJava.java
@@ -14,6 +14,7 @@ public class DockerizedJava {
     private final Map<Path, String> mounts;
     private final Map<String, String> environment;
     private final Boolean windowsDaemon;
+    private final boolean hardened;
 
     public DockerizedJava(Path workingDirectory) throws IOException, InterruptedException {
         boolean windows = isWindowsDaemon();
@@ -52,32 +53,43 @@ public class DockerizedJava {
         this.windowsDaemon = windows;
         this.mounts = Map.of();
         this.environment = Map.of();
+        this.hardened = true;
     }
 
     public DockerizedJava(Path workingDirectory, String image) {
-        this(workingDirectory, image, null, Map.of(), Map.of());
+        this(workingDirectory, image, null, Map.of(), Map.of(), false);
     }
 
     private DockerizedJava(Path workingDirectory,
                            String image,
                            Boolean windowsDaemon,
                            Map<Path, String> mounts,
-                           Map<String, String> environment) {
+                           Map<String, String> environment,
+                           boolean hardened) {
         this.image = image;
         this.workingDirectory = workingDirectory;
         this.windowsDaemon = windowsDaemon;
         this.mounts = mounts;
         this.environment = environment;
+        this.hardened = hardened;
     }
 
     public String image() {
         return image;
     }
 
+    public boolean hardened() {
+        return hardened;
+    }
+
+    public DockerizedJava harden(boolean hardened) {
+        return new DockerizedJava(workingDirectory, image, windowsDaemon, mounts, environment, hardened);
+    }
+
     public DockerizedJava mount(Path host, String container, boolean readOnly) {
         SequencedMap<Path, String> copy = new LinkedHashMap<>(mounts);
         copy.put(host.toAbsolutePath(), container + (readOnly ? ":ro" : ""));
-        return new DockerizedJava(workingDirectory, image, windowsDaemon, copy, environment);
+        return new DockerizedJava(workingDirectory, image, windowsDaemon, copy, environment, hardened);
     }
 
     public DockerizedJava mounts(String specification, Path base, boolean readOnly) {
@@ -102,7 +114,7 @@ public class DockerizedJava {
     public DockerizedJava env(String name, String value) {
         SequencedMap<String, String> copy = new LinkedHashMap<>(environment);
         copy.put(name, value);
-        return new DockerizedJava(workingDirectory, image, windowsDaemon, mounts, copy);
+        return new DockerizedJava(workingDirectory, image, windowsDaemon, mounts, copy, hardened);
     }
 
     public int execute(String main, Map<String, String> properties, String... args) throws IOException, InterruptedException {
@@ -116,6 +128,10 @@ public class DockerizedJava {
     }
 
     public int execute(List<String> javaArgs) throws IOException, InterruptedException {
+        return new ProcessBuilder(command(javaArgs)).inheritIO().start().waitFor();
+    }
+
+    public List<String> command(List<String> javaArgs) throws IOException, InterruptedException {
         String home = System.getProperty("java.home");
         if (home == null) {
             home = System.getenv("JAVA_HOME");
@@ -131,6 +147,12 @@ public class DockerizedJava {
         docker.add("run");
         docker.add("--rm");
         docker.add("-i");
+        if (hardened) {
+            docker.add("--cap-drop");
+            docker.add("ALL");
+            docker.add("--security-opt");
+            docker.add("no-new-privileges");
+        }
         if (!windows) {
             try {
                 Object uid = Files.getAttribute(workingDirectory, "unix:uid");
@@ -157,7 +179,7 @@ public class DockerizedJava {
         docker.add(image);
         docker.add(javaHomeMount + (windows ? "\\bin\\java.exe" : "/bin/java"));
         docker.addAll(javaArgs);
-        return new ProcessBuilder(docker).inheritIO().start().waitFor();
+        return docker;
     }
 
     private static boolean isWindowsDaemon() throws IOException, InterruptedException {

--- a/sources/build/jenesis/maven/MavenDefaultRepository.java
+++ b/sources/build/jenesis/maven/MavenDefaultRepository.java
@@ -32,7 +32,11 @@ public class MavenDefaultRepository implements MavenRepository {
         }
         this.writable = this.local != null && Files.isWritable(this.local);
         token = System.getenv("MAVEN_REPOSITORY_TOKEN");
-        validations = Map.of("SHA1", repository);
+        Map<String, URI> validations = new LinkedHashMap<>();
+        validations.put("SHA512", repository);
+        validations.put("SHA256", repository);
+        validations.put("SHA1", repository);
+        this.validations = Collections.unmodifiableMap(validations);
         boolean verbose = Boolean.getBoolean("jenesis.print.fetch");
         callback = verbose ? path -> System.out.printf("%s%-11s%s %s%n",
                 BuildExecutorCallback.YELLOW,
@@ -144,10 +148,14 @@ public class MavenDefaultRepository implements MavenRepository {
 
     private LazyRepositoryItem fetch(URI repository, String path, boolean validate) throws IOException {
         Path cached = local == null ? null : local.resolve(path);
+        if (cached != null && !cached.normalize().startsWith(local.normalize())) {
+            throw new IllegalStateException("Resolved path escapes the local repository root: " + path);
+        }
         if (cached != null) {
             if (Files.exists(cached)) {
                 boolean valid = true;
                 if (validate) {
+                    boolean verified = false;
                     Map<LazyRepositoryItem, byte[]> results = new HashMap<>();
                     for (Map.Entry<String, URI> entry : validations.entrySet()) {
                         LazyRepositoryItem item = fetch(
@@ -174,10 +182,14 @@ public class MavenDefaultRepository implements MavenRepository {
                                 valid = Arrays.equals(
                                         HexFormat.of().parseHex(new String(expected, StandardCharsets.UTF_8)),
                                         digest.digest());
+                                verified = true;
                             }
                         } else {
                             results.put(item, null);
                         }
+                    }
+                    if (!validations.isEmpty() && !verified) {
+                        throw new IllegalStateException("No checksum sidecar available to validate " + path);
                     }
                     if (valid) {
                         for (Map.Entry<LazyRepositoryItem, byte[]> entry : results.entrySet()) {
@@ -265,6 +277,7 @@ public class MavenDefaultRepository implements MavenRepository {
                 }
             }
             String invalid = null;
+            boolean verified = false;
             Map<LazyRepositoryItem, byte[]> results = new HashMap<>();
             for (Map.Entry<LazyRepositoryItem, MessageDigest> entry : digests.entrySet()) {
                 Optional<InputStream> candidate = entry.getKey().toLazyInputStream();
@@ -280,6 +293,7 @@ public class MavenDefaultRepository implements MavenRepository {
                         invalid = entry.getValue().getAlgorithm();
                         break;
                     }
+                    verified = true;
                 }
             }
             if (invalid != null) {
@@ -287,6 +301,12 @@ public class MavenDefaultRepository implements MavenRepository {
                     item.deleteIfPresent();
                 }
                 throw new IllegalStateException("Failed checksum validation for " + invalid);
+            }
+            if (!verified) {
+                for (LazyRepositoryItem item : digests.keySet()) {
+                    item.deleteIfPresent();
+                }
+                throw new IllegalStateException("No checksum sidecar available to validate " + uri);
             }
             for (Map.Entry<LazyRepositoryItem, byte[]> entry : results.entrySet()) {
                 entry.getKey().storeIfNotPresent(entry.getValue());

--- a/sources/build/jenesis/maven/MavenDefaultVersionNegotiator.java
+++ b/sources/build/jenesis/maven/MavenDefaultVersionNegotiator.java
@@ -213,12 +213,12 @@ public class MavenDefaultVersionNegotiator implements MavenVersionNegotiator {
                                     .filter(node -> Objects.equals(node.getLocalName(), "latest"))
                                     .findFirst()
                                     .map(Node::getTextContent)
-                                    .orElseThrow(missing("latest")),
+                                    .orElse(null),
                             toChildren(versioning)
                                     .filter(node -> Objects.equals(node.getLocalName(), "release"))
                                     .findFirst()
                                     .map(Node::getTextContent)
-                                    .orElseThrow(missing("release")),
+                                    .orElse(null),
                             toChildren(versioning)
                                     .filter(node -> Objects.equals(node.getLocalName(), "versions"))
                                     .findFirst()
@@ -418,5 +418,20 @@ public class MavenDefaultVersionNegotiator implements MavenVersionNegotiator {
     }
 
     private record Metadata(String latest, String release, List<String> versions) {
+        @Override
+        public String latest() {
+            if (latest == null) {
+                throw new IllegalStateException("Property not defined: latest");
+            }
+            return latest;
+        }
+
+        @Override
+        public String release() {
+            if (release == null) {
+                throw new IllegalStateException("Property not defined: release");
+            }
+            return release;
+        }
     }
 }

--- a/sources/build/jenesis/maven/MavenDependencyKey.java
+++ b/sources/build/jenesis/maven/MavenDependencyKey.java
@@ -2,6 +2,22 @@ package build.jenesis.maven;
 
 public record MavenDependencyKey(String groupId, String artifactId, String type, String classifier) {
 
+    public MavenDependencyKey {
+        validate("groupId", groupId);
+        validate("artifactId", artifactId);
+        validate("type", type);
+        validate("classifier", classifier);
+    }
+
+    static void validate(String role, String component) {
+        if (component != null && (component.contains("/")
+                || component.contains("\\")
+                || component.equals(".")
+                || component.equals(".."))) {
+            throw new IllegalArgumentException("Illegal Maven coordinate " + role + ": " + component);
+        }
+    }
+
     public String coordinate(String prefix, String version) {
         StringBuilder sb = new StringBuilder();
         if (prefix != null) {
@@ -53,5 +69,8 @@ public record MavenDependencyKey(String groupId, String artifactId, String type,
     }
 
     public record Versioned(MavenDependencyKey key, String version) {
+        public Versioned {
+            validate("version", version);
+        }
     }
 }

--- a/sources/build/jenesis/maven/MavenDependencyScope.java
+++ b/sources/build/jenesis/maven/MavenDependencyScope.java
@@ -9,15 +9,14 @@ public enum MavenDependencyScope {
     }
 
     static MavenDependencyScope of(String scope) {
-        return switch (scope) {
-            case "compile" -> COMPILE;
+        return switch (scope == null ? "" : scope.trim()) {
+            case "compile", "" -> COMPILE;
             case "provided" -> PROVIDED;
             case "runtime" -> RUNTIME;
             case "test" -> TEST;
             case "system" -> SYSTEM;
             case "import" -> IMPORT;
-            case null -> COMPILE;
-            default -> throw new IllegalArgumentException("");
+            default -> throw new IllegalArgumentException("Unknown Maven dependency scope: " + scope);
         };
     }
 }

--- a/sources/build/jenesis/maven/MavenPomResolver.java
+++ b/sources/build/jenesis/maven/MavenPomResolver.java
@@ -259,7 +259,7 @@ public class MavenPomResolver implements MavenResolver {
                     resolution.systemPath,
                     resolution.exclusions,
                     resolution.optional,
-                    resolution.checksum));
+                    selectChecksum(resolution)));
         });
         if (listener != null) {
             dependencies.clear();
@@ -334,6 +334,7 @@ public class MavenPomResolver implements MavenResolver {
                     continue;
                 }
                 String version;
+                bindChecksum(entry.getKey(), resolution, value.version(), value.checksum());
                 if (resolution.currentVersion == null) {
                     version = resolution.currentVersion = negotiator.resolve(executor,
                             repository,
@@ -347,7 +348,6 @@ public class MavenPomResolver implements MavenResolver {
                     resolution.systemPath = entry.getValue().systemPath();
                     resolution.exclusions = entry.getValue().exclusions();
                     resolution.optional = entry.getValue().optional();
-                    resolution.checksum = value.checksum();
                 } else {
                     version = resolution.currentVersion;
                     if (resolution.observedVersions.add(value.version()) || resolution.widestScope.reduces(scope)) {
@@ -385,6 +385,32 @@ public class MavenPomResolver implements MavenResolver {
             }
         } while ((current = queue.poll()) != null);
         return conflicting;
+    }
+
+    private static void bindChecksum(MavenDependencyKey key,
+                                     DependencyResolution resolution,
+                                     String version,
+                                     String checksum) {
+        if (checksum == null) {
+            return;
+        }
+        String existing = resolution.checksums.putIfAbsent(version, checksum);
+        if (existing != null && !existing.equals(checksum)) {
+            throw new IllegalStateException("Conflicting checksums for "
+                    + key.groupId() + ":" + key.artifactId() + ":" + version
+                    + " (" + existing + " and " + checksum + ")");
+        }
+    }
+
+    private static String selectChecksum(DependencyResolution resolution) {
+        String checksum = resolution.checksums.get(resolution.currentVersion);
+        if (checksum != null) {
+            return checksum;
+        }
+        if (resolution.checksums.size() == 1) {
+            return resolution.checksums.values().iterator().next();
+        }
+        return null;
     }
 
     public SequencedMap<Path, MavenLocalPom> local(Executor executor,
@@ -547,14 +573,15 @@ public class MavenPomResolver implements MavenResolver {
                 IMPLICITS.forEach(property -> toChildren400(document.getDocumentElement(), property)
                         .findFirst()
                         .ifPresent(node -> {
-                            properties.put(property, node.getTextContent());
-                            properties.put("project." + property, node.getTextContent());
+                            String value = node.getTextContent().trim();
+                            properties.put(property, value);
+                            properties.put("project." + property, value);
                         }));
                 toChildren400(document.getDocumentElement(), "properties")
                         .limit(1)
                         .flatMap(MavenPomResolver::toChildren)
                         .filter(node -> node.getNodeType() == Node.ELEMENT_NODE)
-                        .forEach(node -> properties.put(node.getLocalName(), node.getTextContent()));
+                        .forEach(node -> properties.put(node.getLocalName(), node.getTextContent().trim()));
                 toChildren400(document.getDocumentElement(), "dependencyManagement")
                         .limit(1)
                         .flatMap(node -> toChildren400(node, "dependencies"))
@@ -702,20 +729,15 @@ public class MavenPomResolver implements MavenResolver {
             MavenDependencyKey key = entry.getKey().resolve(pom.properties());
             MavenDependencyValue value = entry.getValue().resolveManaged(pom.properties());
             if (value.scope() == MavenDependencyScope.IMPORT) {
-                UnresolvedPom imported = assembleOrCached(executor,
+                flattenImport(executor,
                         repository,
                         key.groupId(),
                         key.artifactId(),
                         value.version(),
                         value.checksum(),
+                        managedDependencies,
                         new HashSet<>(),
                         unresolved);
-                imported.managedDependencies().forEach((importKey, importValue) -> {
-                    MavenDependencyValue resolved = importValue.resolveManaged(imported.properties());
-                    if (resolved.scope() != MavenDependencyScope.IMPORT) {
-                        managedDependencies.putIfAbsent(importKey.resolve(imported.properties()), resolved);
-                    }
-                });
             } else {
                 managedDependencies.put(key, value);
             }
@@ -724,6 +746,46 @@ public class MavenPomResolver implements MavenResolver {
                 key.resolve(pom.properties()),
                 value.resolve(pom.properties())));
         return new ResolvedPom(managedDependencies, dependencies);
+    }
+
+    private void flattenImport(Executor executor,
+                               MavenRepository repository,
+                               String groupId,
+                               String artifactId,
+                               String version,
+                               String checksum,
+                               Map<MavenDependencyKey, MavenDependencyValue> managedDependencies,
+                               Set<DependencyCoordinate> imports,
+                               Map<DependencyCoordinate, UnresolvedPom> unresolved) throws IOException {
+        if (!imports.add(new DependencyCoordinate(groupId, artifactId, version))) {
+            throw new IllegalStateException("Circular BOM import to "
+                    + groupId + ":" + artifactId + ":" + version);
+        }
+        UnresolvedPom imported = assembleOrCached(executor,
+                repository,
+                groupId,
+                artifactId,
+                version,
+                checksum,
+                new HashSet<>(),
+                unresolved);
+        for (Map.Entry<DependencyKey, DependencyValue> entry : imported.managedDependencies().entrySet()) {
+            MavenDependencyKey importKey = entry.getKey().resolve(imported.properties());
+            MavenDependencyValue importValue = entry.getValue().resolveManaged(imported.properties());
+            if (importValue.scope() == MavenDependencyScope.IMPORT) {
+                flattenImport(executor,
+                        repository,
+                        importKey.groupId(),
+                        importKey.artifactId(),
+                        importValue.version(),
+                        importValue.checksum(),
+                        managedDependencies,
+                        imports,
+                        unresolved);
+            } else {
+                managedDependencies.putIfAbsent(importKey, importValue);
+            }
+        }
     }
 
     private ResolvedPom resolveOrCached(Executor executor,
@@ -767,7 +829,7 @@ public class MavenPomResolver implements MavenResolver {
     }
 
     private static Optional<String> toTextChild400(Node node, String localName) {
-        return toChildren400(node, localName).map(Node::getTextContent).findFirst();
+        return toChildren400(node, localName).map(child -> child.getTextContent().trim()).findFirst();
     }
 
     private static Map.Entry<DependencyKey, DependencyValue> toDependency400(Node node) {
@@ -951,7 +1013,9 @@ public class MavenPomResolver implements MavenResolver {
 
         private MavenDependencyValue resolve(Map<String, String> properties, boolean defaultScope) {
             String resolvedScope = property(scope, properties);
-            return new MavenDependencyValue(property(version, properties),
+            String resolvedVersion = property(version, properties);
+            MavenDependencyKey.validate("version", resolvedVersion);
+            return new MavenDependencyValue(resolvedVersion,
                     resolvedScope == null && !defaultScope ? null : MavenDependencyScope.of(resolvedScope),
                     systemPath == null ? null : Path.of(property(systemPath, properties)),
                     exclusions == null ? null : exclusions.stream().map(exclusion -> new MavenDependencyName(
@@ -998,11 +1062,11 @@ public class MavenPomResolver implements MavenResolver {
 
     private static class DependencyResolution {
         private final SequencedSet<String> observedVersions = new LinkedHashSet<>();
+        private final Map<String, String> checksums = new HashMap<>();
         private String currentVersion;
         private MavenDependencyScope currentScope, widestScope;
         private Path systemPath;
         private List<MavenDependencyName> exclusions;
         private Boolean optional;
-        private String checksum;
     }
 }

--- a/sources/build/jenesis/maven/MavenRepositoryExport.java
+++ b/sources/build/jenesis/maven/MavenRepositoryExport.java
@@ -112,18 +112,31 @@ public class MavenRepositoryExport implements BuildStep {
                                               Coordinates sample,
                                               SequencedSet<String> versions,
                                               String timestamp) throws IOException {
-        List<String> sorted = versions.stream()
+        SequencedSet<String> merged = new LinkedHashSet<>(versions);
+        try (DirectoryStream<Path> entries = Files.newDirectoryStream(artifactDir)) {
+            for (Path entry : entries) {
+                if (Files.isDirectory(entry)) {
+                    merged.add(entry.getFileName().toString());
+                }
+            }
+        }
+        merged.addAll(readMetadataVersions(artifactDir.resolve("maven-metadata-local.xml")));
+        List<String> sorted = merged.stream()
                 .sorted(MavenDefaultVersionNegotiator::compareVersions)
                 .toList();
         String release = sorted.stream()
                 .filter(version -> !version.endsWith("-SNAPSHOT"))
                 .reduce((_, right) -> right)
                 .orElse(null);
+        String latest = sorted.isEmpty() ? null : sorted.getLast();
         Document document = newDocument();
         Element metadata = (Element) document.appendChild(document.createElement("metadata"));
         metadata.appendChild(document.createElement("groupId")).setTextContent(sample.groupId());
         metadata.appendChild(document.createElement("artifactId")).setTextContent(sample.artifactId());
         Element versioning = (Element) metadata.appendChild(document.createElement("versioning"));
+        if (latest != null) {
+            versioning.appendChild(document.createElement("latest")).setTextContent(latest);
+        }
         if (release != null) {
             versioning.appendChild(document.createElement("release")).setTextContent(release);
         }
@@ -133,6 +146,28 @@ public class MavenRepositoryExport implements BuildStep {
         }
         versioning.appendChild(document.createElement("lastUpdated")).setTextContent(timestamp);
         writeXml(document, artifactDir.resolve("maven-metadata-local.xml"));
+    }
+
+    private static SequencedSet<String> readMetadataVersions(Path metadata) throws IOException {
+        if (!Files.isRegularFile(metadata)) {
+            return new LinkedHashSet<>();
+        }
+        SequencedSet<String> versions = new LinkedHashSet<>();
+        try (InputStream stream = Files.newInputStream(metadata)) {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            NodeList nodes = factory.newDocumentBuilder().parse(stream).getElementsByTagName("version");
+            for (int index = 0; index < nodes.getLength(); index++) {
+                String text = nodes.item(index).getTextContent().trim();
+                if (!text.isEmpty()) {
+                    versions.add(text);
+                }
+            }
+        } catch (ParserConfigurationException | SAXException _) {
+            return new LinkedHashSet<>();
+        }
+        return versions;
     }
 
     private static void writeSnapshotMetadata(Path versionDir,

--- a/sources/build/jenesis/module/JenesisModuleRepository.java
+++ b/sources/build/jenesis/module/JenesisModuleRepository.java
@@ -56,10 +56,19 @@ public class JenesisModuleRepository implements Repository {
         int slash = identifier.indexOf('/');
         String moduleName = slash < 0 ? identifier : identifier.substring(0, slash);
         String version = slash < 0 ? null : identifier.substring(slash + 1);
+        requireSafeSegment("module name", moduleName);
+        if (version != null) {
+            requireSafeSegment("version", version);
+        }
         String relative = version == null
                 ? moduleName + "/" + moduleName + "." + type
                 : moduleName + "/" + version + "/" + moduleName + "." + type;
-        URI uri = root.resolve(relative);
+        URI base = root.normalize();
+        URI uri = base.resolve(relative).normalize();
+        URI contained = base.relativize(uri);
+        if (contained.isAbsolute() || contained.getPath().startsWith("..")) {
+            throw new IllegalArgumentException("Resolved location " + uri + " escapes repository root " + root);
+        }
         if ("file".equals(uri.getScheme())) {
             Path file = Path.of(uri);
             return Files.isRegularFile(file)
@@ -77,5 +86,30 @@ public class JenesisModuleRepository implements Repository {
             return Optional.empty();
         }
         return Optional.of(() -> stream);
+    }
+
+    private static void requireSafeSegment(String role, String value) {
+        if (value.isEmpty()) {
+            throw new IllegalArgumentException("Blank " + role + " is not a valid coordinate");
+        }
+        for (String segment : value.split("/", -1)) {
+            if (segment.equals("..")) {
+                throw new IllegalArgumentException("Illegal " + role + " '" + value + "': path traversal is not permitted");
+            }
+        }
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            boolean permitted = character >= 'a' && character <= 'z'
+                    || character >= 'A' && character <= 'Z'
+                    || character >= '0' && character <= '9'
+                    || character == '.'
+                    || character == '-'
+                    || character == '_'
+                    || character == '+';
+            if (!permitted) {
+                throw new IllegalArgumentException(
+                        "Illegal " + role + " '" + value + "': character '" + character + "' is not permitted");
+            }
+        }
     }
 }

--- a/sources/build/jenesis/module/ModularJarResolver.java
+++ b/sources/build/jenesis/module/ModularJarResolver.java
@@ -165,7 +165,13 @@ public class ModularJarResolver implements Resolver {
                         .sorted(Comparator.comparing(ModuleDescriptor.Requires::name))
                         .forEach(requires -> {
                             String name = requires.name();
-                            requires.rawCompiledVersion().ifPresent(v -> propagated.putIfAbsent(name, v));
+                            requires.rawCompiledVersion().ifPresent(v -> {
+                                if (v.isEmpty() || v.equals("..") || v.indexOf('/') >= 0 || v.indexOf('\\') >= 0) {
+                                    throw new IllegalArgumentException("Module " + current
+                                            + " declares an unsafe compiled version '" + v + "' for " + name);
+                                }
+                                propagated.putIfAbsent(name, v);
+                            });
                             if (observes) {
                                 parents.putIfAbsent(name, current);
                             }

--- a/sources/build/jenesis/module/ModuleInfoParser.java
+++ b/sources/build/jenesis/module/ModuleInfoParser.java
@@ -81,6 +81,13 @@ public class ModuleInfoParser {
                                         || token.startsWith("java.") || token.startsWith("jdk.")) {
                                     continue;
                                 }
+                                int repo = token.indexOf('/');
+                                int coordinate = repo < 1 ? -1 : token.indexOf('/', repo + 1);
+                                if (repo < 1 || coordinate <= repo || coordinate == token.length() - 1) {
+                                    throw new IllegalArgumentException("Malformed @jenesis.pin token '"
+                                            + token
+                                            + "': expected <scope>/<repository>/<coordinate>");
+                                }
                                 versions.put(token, version);
                             }
                             case "jenesis.plugin" -> {

--- a/sources/build/jenesis/project/GroovyDocumentationModule.java
+++ b/sources/build/jenesis/project/GroovyDocumentationModule.java
@@ -16,6 +16,7 @@ import build.jenesis.step.Dependencies;
 import build.jenesis.step.Javac;
 import build.jenesis.step.Javadoc;
 import build.jenesis.step.JdkProcessBuildStep;
+import build.jenesis.step.ProcessBuildStep;
 import build.jenesis.step.ProcessHandler;
 
 public class GroovyDocumentationModule implements BuildExecutorModule {
@@ -225,6 +226,14 @@ public class GroovyDocumentationModule implements BuildExecutorModule {
                 for (Path jar : Dependencies.select(argument.folder(), "compile")) {
                     jars.add(jar.toString());
                 }
+                Path javacProperties = argument.folder().resolve(ProcessBuildStep.PROCESS + "javac.properties");
+                if (Files.exists(javacProperties)) {
+                    SequencedProperties loaded = SequencedProperties.ofFiles(javacProperties);
+                    String value = loaded.getProperty("--release");
+                    if (value != null && !value.isEmpty()) {
+                        release = value;
+                    }
+                }
                 Path sources = argument.folder().resolve(Bind.SOURCES);
                 if (Files.exists(sources)) {
                     roots.add(sources.toString());
@@ -246,12 +255,6 @@ public class GroovyDocumentationModule implements BuildExecutorModule {
                             return FileVisitResult.CONTINUE;
                         }
                     });
-                }
-            }
-            for (SequencedMap<String, String> values : properties.values()) {
-                String candidate = values.get("maven.compiler.release");
-                if (candidate != null) {
-                    release = candidate;
                 }
             }
             if (!anyGroovy[0]) {

--- a/sources/build/jenesis/project/JenesisClassLoaderBridge.java
+++ b/sources/build/jenesis/project/JenesisClassLoaderBridge.java
@@ -13,27 +13,27 @@ import build.jenesis.BuildStepContext;
 import build.jenesis.BuildStepResult;
 import build.jenesis.ChecksumStatus;
 
-class JenesisClassLoaderBridge {
+class JenesisClassLoaderBridge implements AutoCloseable {
 
-    private final ModuleLayer layer;
-    private final ClassLoader loader;
+    private ModuleLayer layer;
+    private ClassLoader loader;
 
-    private final Class<?> foreignBuildExecutorModule;
+    private Class<?> foreignBuildExecutorModule;
 
-    private final MethodHandle foreignAccept;
-    private final MethodHandle foreignApply;
-    private final MethodHandle foreignShouldRun;
+    private MethodHandle foreignAccept;
+    private MethodHandle foreignApply;
+    private MethodHandle foreignShouldRun;
 
-    private final MethodHandle foreignContextCtor;
-    private final MethodHandle foreignArgumentCtor;
-    private final MethodHandle foreignResultNext;
+    private MethodHandle foreignContextCtor;
+    private MethodHandle foreignArgumentCtor;
+    private MethodHandle foreignResultNext;
 
-    private final Class<?> foreignBuildExecutor;
+    private Class<?> foreignBuildExecutor;
 
-    private final Class<? extends Annotation> foreignBuildModuleName;
-    private final MethodHandle foreignBuildModuleNameValue;
+    private Class<? extends Annotation> foreignBuildModuleName;
+    private MethodHandle foreignBuildModuleNameValue;
 
-    private final Map<String, Object> foreignChecksumValues;
+    private Map<String, Object> foreignChecksumValues;
 
     JenesisClassLoaderBridge(Collection<Path> artifacts) throws ReflectiveOperationException {
         ModuleFinder finder = ModuleFinder.of(artifacts.toArray(Path[]::new));
@@ -87,7 +87,27 @@ class JenesisClassLoaderBridge {
         foreignChecksumValues = Map.copyOf(values);
     }
 
+    @Override
+    public void close() {
+        layer = null;
+        loader = null;
+        foreignBuildExecutorModule = null;
+        foreignAccept = null;
+        foreignApply = null;
+        foreignShouldRun = null;
+        foreignContextCtor = null;
+        foreignArgumentCtor = null;
+        foreignResultNext = null;
+        foreignBuildExecutor = null;
+        foreignBuildModuleName = null;
+        foreignBuildModuleNameValue = null;
+        foreignChecksumValues = null;
+    }
+
     Object findProvider(String name) {
+        if (loader == null) {
+            throw new IllegalStateException("Build module class loader bridge was already closed");
+        }
         Object match = null;
         for (Object provider : ServiceLoader.load(layer, foreignBuildExecutorModule)) {
             Annotation annotation = provider.getClass().getAnnotation(foreignBuildModuleName);

--- a/sources/build/jenesis/project/KotlinCompilerModule.java
+++ b/sources/build/jenesis/project/KotlinCompilerModule.java
@@ -208,9 +208,11 @@ public class KotlinCompilerModule implements BuildExecutorModule {
                         @Override
                         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                             String name = file.toString();
-                            if (name.endsWith(".kt") || name.endsWith(".java")) {
+                            if (name.endsWith(".kt")
+                                    || (name.endsWith(".java")
+                                    && !file.getFileName().toString().equals("module-info.java"))) {
                                 files.add(name);
-                            } else if (includeResources) {
+                            } else if (includeResources && !name.endsWith(".java")) {
                                 BuildStep.linkOrCopy(target.resolve(sources.relativize(file)), file);
                             }
                             return FileVisitResult.CONTINUE;

--- a/sources/build/jenesis/project/MultiProjectModule.java
+++ b/sources/build/jenesis/project/MultiProjectModule.java
@@ -76,6 +76,7 @@ public record MultiProjectModule(BuildExecutorModule identifier,
                 MultiProject project = factory.apply(projects);
                 SequencedMap<String, SequencedSet<String>> pending = new LinkedHashMap<>(projects);
                 while (!pending.isEmpty()) {
+                    boolean progressed = false;
                     Iterator<Map.Entry<String, SequencedSet<String>>> it = pending.entrySet().iterator();
                     while (it.hasNext()) {
                         Map.Entry<String, SequencedSet<String>> entry = it.next();
@@ -103,7 +104,11 @@ public record MultiProjectModule(BuildExecutorModule identifier,
                                                     .map(identifier -> PREVIOUS.repeat(2) + identifier))
                                     .flatMap(Function.identity()));
                             it.remove();
+                            progressed = true;
                         }
+                    }
+                    if (!progressed) {
+                        throw new IllegalStateException("Cyclic module dependencies: " + pending.keySet());
                     }
                 }
             }, Stream.concat(Stream.of(GROUP), identified.sequencedKeySet().stream()));

--- a/sources/build/jenesis/project/ScalaDocumentationModule.java
+++ b/sources/build/jenesis/project/ScalaDocumentationModule.java
@@ -204,11 +204,12 @@ public class ScalaDocumentationModule implements BuildExecutorModule {
                 throws IOException {
             Path documentation = context.next().resolve(Javadoc.JAVADOC);
             Path output = Files.createDirectories(within == null ? documentation : documentation.resolve(within));
-            List<String> files = new ArrayList<>(), jars = new ArrayList<>(), classpath = new ArrayList<>();
+            List<String> files = new ArrayList<>(), jars = new ArrayList<>(), classRoots = new ArrayList<>(),
+                    classpath = new ArrayList<>();
             for (BuildStepArgument argument : arguments.values()) {
                 Path classes = argument.folder().resolve(BuildStep.CLASSES);
                 if (Files.exists(classes)) {
-                    classpath.add(classes.toString());
+                    classRoots.add(classes.toString());
                 }
                 for (Path jar : Dependencies.select(argument.folder(), qualifier)) {
                     jars.add(jar.toString());
@@ -238,16 +239,18 @@ public class ScalaDocumentationModule implements BuildExecutorModule {
                 throw new IllegalStateException(
                         "No scaladoc jars resolved upstream of the Scala documentation step");
             }
-            if (classpath.isEmpty()) {
+            if (classRoots.isEmpty()) {
                 return CompletableFuture.completedStage(null);
             }
+            List<String> userClasspath = new ArrayList<>(classRoots);
+            userClasspath.addAll(classpath);
             List<String> commands = new ArrayList<>(List.of(
                     "-cp", String.join(File.pathSeparator, jars),
                     "dotty.tools.scaladoc.Main",
                     "-d", output.toString(),
-                    "-classpath", String.join(File.pathSeparator, jars),
+                    "-classpath", String.join(File.pathSeparator, userClasspath),
                     "-project", "documentation"));
-            commands.addAll(classpath);
+            commands.addAll(classRoots);
             return CompletableFuture.completedStage(commands);
         }
     }

--- a/sources/build/jenesis/project/TestModule.java
+++ b/sources/build/jenesis/project/TestModule.java
@@ -495,6 +495,13 @@ public class TestModule implements BuildExecutorModule {
                     });
                 }
             }
+            if (matchedClasses.isEmpty() && matchedMethods.isEmpty() && groups.isEmpty()) {
+                throw new IllegalStateException("No tests matched the requested selection"
+                        + (filter != null ? ", filter: " + filter : "")
+                        + (group != null ? ", group: " + group : "")
+                        + ". Adjust jenesis.test.filter / jenesis.test.group or the isTest predicate,"
+                        + " or set jenesis.test.skip to skip testing.");
+            }
             commands.addAll(resolved.commands(
                     context.supplement(),
                     context.next(),

--- a/sources/build/jenesis/step/Download.java
+++ b/sources/build/jenesis/step/Download.java
@@ -53,7 +53,7 @@ public class Download implements BuildStep {
         List<CompletableFuture<?>> futures = new ArrayList<>();
         Path libs = Files.createDirectory(context.next().resolve(DEPENDENCIES));
         SequencedProperties index = new SequencedProperties();
-        Set<String> fetched = new HashSet<>();
+        SequencedMap<String, String[]> coalesced = new LinkedHashMap<>();
         for (Map.Entry<String, String> entry : merged.entrySet()) {
             String[] parts = split(entry.getKey());
             if (parts == null) {
@@ -62,12 +62,23 @@ public class Download implements BuildStep {
             String repo = parts[1], coordinate = parts[2];
             String dependency = repo + "/" + coordinate, name = dependency.replace('/', '-') + ".jar";
             index.setProperty(entry.getKey(), DEPENDENCIES + name);
-            if (!fetched.add(name)) {
-                continue;
+            String[] existing = coalesced.get(name);
+            if (existing == null) {
+                coalesced.put(name, new String[] {repo, coordinate, dependency, entry.getValue()});
+            } else if (!entry.getValue().isEmpty()) {
+                if (existing[3].isEmpty()) {
+                    existing[3] = entry.getValue();
+                } else if (!existing[3].equals(entry.getValue())) {
+                    throw new IllegalStateException("Conflicting checksums pinned for " + dependency
+                            + ": " + existing[3] + " and " + entry.getValue());
+                }
             }
+        }
+        for (String[] parts : coalesced.values()) {
+            String repo = parts[0], coordinate = parts[1], dependency = parts[2], name = dependency.replace('/', '-') + ".jar";
             Repository repository = repositories.getOrDefault(Resolver.base(repo), Repository.empty());
             Path previous = context.previous() == null ? null : context.previous().resolve(DEPENDENCIES + name);
-            String value = pinning == Pinning.IGNORE ? "" : entry.getValue();
+            String value = pinning == Pinning.IGNORE ? "" : parts[3];
             if (value.isEmpty()) {
                 if (previous != null && Files.exists(previous) && pinning != Pinning.STRICT) {
                     BuildStep.linkOrCopy(libs.resolve(name), previous);

--- a/sources/build/jenesis/step/Group.java
+++ b/sources/build/jenesis/step/Group.java
@@ -59,6 +59,7 @@ public class Group implements BuildStep {
             entry.getValue().stream()
                     .flatMap(dependency -> from.getOrDefault(dependency, Set.of()).stream())
                     .distinct()
+                    .filter(name -> !name.equals(entry.getKey()))
                     .forEach(name -> properties.setProperty(name, ""));
             properties.store(folder.resolve(BuildExecutorModule.encode(entry.getKey()) + ".properties"));
         }

--- a/sources/build/jenesis/step/ProcessBuildStep.java
+++ b/sources/build/jenesis/step/ProcessBuildStep.java
@@ -60,7 +60,8 @@ public abstract class ProcessBuildStep implements BuildStep {
             }
             properties.put(entry.getKey(), folderMap);
         }
-        return process(executor, context, arguments, properties).thenComposeAsync(processed -> {
+        AtomicReference<Thread> worker = new AtomicReference<>();
+        CompletableFuture<BuildStepResult> result = process(executor, context, arguments, properties).thenComposeAsync(processed -> {
             if (processed == null) {
                 return CompletableFuture.completedStage(new BuildStepResult(true));
             }
@@ -88,6 +89,7 @@ public abstract class ProcessBuildStep implements BuildStep {
                         String.join(" ", handler.commands()));
                 }
                 executor.execute(() -> {
+                    worker.set(Thread.currentThread());
                     try {
                         int exitCode = handler.execute(output, error);
                         if (acceptableExitCode(exitCode, executor, context, arguments)) {
@@ -104,6 +106,8 @@ public abstract class ProcessBuildStep implements BuildStep {
                         }
                     } catch (Throwable t) {
                         future.completeExceptionally(t);
+                    } finally {
+                        worker.set(null);
                     }
                 });
                 return future;
@@ -111,6 +115,15 @@ public abstract class ProcessBuildStep implements BuildStep {
                 future.completeExceptionally(t);
             }
             return future;
+        }).toCompletableFuture();
+        result.whenComplete((processed, throwable) -> {
+            if (throwable != null) {
+                Thread running = worker.get();
+                if (running != null && running != Thread.currentThread()) {
+                    running.interrupt();
+                }
+            }
         });
+        return result;
     }
 }

--- a/sources/build/jenesis/step/ProcessHandler.java
+++ b/sources/build/jenesis/step/ProcessHandler.java
@@ -120,6 +120,12 @@ public sealed interface ProcessHandler permits ProcessHandler.OfTool, ProcessHan
             try {
                 return process.waitFor();
             } catch (InterruptedException e) {
+                process.destroyForcibly();
+                try {
+                    process.waitFor(5, TimeUnit.SECONDS);
+                } catch (InterruptedException ignored) {
+                }
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             }
         }

--- a/sources/build/jenesis/step/Resolve.java
+++ b/sources/build/jenesis/step/Resolve.java
@@ -81,7 +81,11 @@ public class Resolve implements BuildStep {
                 for (String key : properties.stringPropertyNames()) {
                     String[] parts = split(key);
                     if (parts == null) {
-                        continue;
+                        throw new IllegalArgumentException("Malformed version pin '"
+                                + key
+                                + "' in "
+                                + versionsFile
+                                + ": expected <scope>/<repository>/<coordinate>");
                     }
                     versions.computeIfAbsent(parts[0], _ -> new LinkedHashMap<>())
                             .computeIfAbsent(parts[1], _ -> new LinkedHashMap<>())

--- a/tests/build/jenesis/test/RepositoryTest.java
+++ b/tests/build/jenesis/test/RepositoryTest.java
@@ -7,6 +7,7 @@ import build.jenesis.RepositoryItem;
 import build.jenesis.SequencedProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class RepositoryTest {
 
@@ -101,5 +102,22 @@ public class RepositoryTest {
         assertThat(item.get().file()).isPresent();
         assertThat(item.get().file().get().getParent()).isEqualTo(cache);
         assertThat(cache.toFile().list()).isNotEmpty();
+    }
+
+    @Test
+    public void cached_failed_stream_copy_leaves_no_file_at_the_target() throws IOException {
+        Path cache = Files.createDirectory(folder.resolve("cache"));
+        RepositoryItem failing = () -> new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw new IOException("interrupted");
+            }
+        };
+        Repository underlying = (_, _) -> Optional.of(failing);
+
+        assertThatThrownBy(() -> underlying.cached(cache).fetch(Runnable::run, "module/foo/1.0"))
+                .isInstanceOf(IOException.class);
+
+        assertThat(cache.toFile().list()).isEmpty();
     }
 }

--- a/tests/build/jenesis/test/SequencedPropertiesTest.java
+++ b/tests/build/jenesis/test/SequencedPropertiesTest.java
@@ -25,4 +25,13 @@ public class SequencedPropertiesTest {
         copy.load(new StringReader(writer.toString()));
         assertThat(copy.stringPropertyNames()).containsExactlyElementsOf(original.stringPropertyNames());
     }
+
+    @Test
+    public void can_suppress_header_comment() throws IOException {
+        SequencedProperties original = new SequencedProperties();
+        original.setProperty("k1", "v1");
+        StringWriter writer = new StringWriter();
+        original.store(writer, "header");
+        assertThat(writer.toString()).isEqualTo("k1=v1\n");
+    }
 }

--- a/tests/build/jenesis/test/docker/DockerizedJavaTest.java
+++ b/tests/build/jenesis/test/docker/DockerizedJavaTest.java
@@ -51,6 +51,34 @@ public class DockerizedJavaTest {
     }
 
     @Test
+    public void explicit_image_is_not_hardened_by_default() {
+        assertThat(new DockerizedJava(tmp, "dummy").hardened()).isFalse();
+    }
+
+    @Test
+    public void harden_toggles_flag_and_returns_new_instance() {
+        DockerizedJava original = new DockerizedJava(tmp, "dummy");
+        DockerizedJava hardened = original.harden(true);
+        assertThat(hardened).isNotSameAs(original);
+        assertThat(hardened.hardened()).isTrue();
+        assertThat(hardened.harden(false).hardened()).isFalse();
+    }
+
+    @Test
+    @EnabledIf("dockerAvailable")
+    public void implicit_image_command_drops_capabilities_and_new_privileges() throws IOException, InterruptedException {
+        List<String> command = new DockerizedJava(tmp).command(List.of("Main.java"));
+        assertThat(command).containsSubsequence("--cap-drop", "ALL", "--security-opt", "no-new-privileges");
+    }
+
+    @Test
+    @EnabledIf("dockerAvailable")
+    public void harden_false_omits_capability_drop_and_new_privileges() throws IOException, InterruptedException {
+        List<String> command = new DockerizedJava(tmp).harden(false).command(List.of("Main.java"));
+        assertThat(command).doesNotContain("--cap-drop", "--security-opt");
+    }
+
+    @Test
     public void parse_env_null_is_empty() {
         assertThat(DockerizedJava.Env.parse(null)).isEmpty();
     }

--- a/tests/build/jenesis/test/maven/MavenDefaultRepositoryTest.java
+++ b/tests/build/jenesis/test/maven/MavenDefaultRepositoryTest.java
@@ -347,6 +347,90 @@ public class MavenDefaultRepositoryTest {
     }
 
     @Test
+    public void rejects_coordinate_escaping_local_root() {
+        MavenRepository repository = new MavenDefaultRepository(this.repository.toUri(), local, Map.of(), _ -> {});
+        assertThatThrownBy(() -> repository.fetch(Runnable::run,
+                "..",
+                "artifact",
+                "1",
+                "jar",
+                null,
+                null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("escapes the local repository root");
+    }
+
+    @Test
+    public void fails_closed_when_validation_requested_but_sidecar_missing() throws IOException {
+        Files.writeString(Files
+                .createDirectories(repository.resolve("group/artifact/1"))
+                .resolve("artifact-1.jar"), "foo");
+        MavenRepository repository = new MavenDefaultRepository(this.repository.toUri(),
+                local,
+                Map.of("MD5", this.repository.toUri()), _ -> {});
+        assertThatThrownBy(() -> repository.fetch(Runnable::run,
+                "group",
+                "artifact",
+                "1",
+                "jar",
+                null,
+                null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No checksum sidecar available");
+        assertThat(local.resolve("group/artifact/1/artifact-1.jar")).doesNotExist();
+    }
+
+    @Test
+    public void fails_closed_when_cached_artifact_has_no_sidecar() throws IOException {
+        Files.writeString(Files
+                .createDirectories(local.resolve("group/artifact/1"))
+                .resolve("artifact-1.jar"), "foo");
+        MavenRepository repository = new MavenDefaultRepository(this.repository.toUri(),
+                local,
+                Map.of("MD5", this.repository.toUri()), _ -> {});
+        assertThatThrownBy(() -> repository.fetch(Runnable::run,
+                "group",
+                "artifact",
+                "1",
+                "jar",
+                null,
+                null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No checksum sidecar available");
+    }
+
+    @Test
+    public void validates_with_weaker_sidecar_when_stronger_absent() throws IOException, NoSuchAlgorithmException {
+        Files.writeString(Files
+                .createDirectories(repository.resolve("group/artifact/1"))
+                .resolve("artifact-1.jar"), "foo");
+        byte[] hash = MessageDigest.getInstance("SHA-1").digest("foo".getBytes(StandardCharsets.UTF_8));
+        try (Writer writer = Files.newBufferedWriter(repository
+                .resolve("group/artifact/1")
+                .resolve("artifact-1.jar.sha1"))) {
+            writer.write(HexFormat.of().formatHex(hash));
+        }
+        Map<String, URI> validations = new LinkedHashMap<>();
+        validations.put("SHA256", repository.toUri());
+        validations.put("SHA1", repository.toUri());
+        Path dependency = result.resolve("dependency.jar");
+        try (InputStream inputStream = new MavenDefaultRepository(repository.toUri(),
+                local,
+                validations, _ -> {}).fetch(Runnable::run,
+                "group",
+                "artifact",
+                "1",
+                "jar",
+                null,
+                null).orElseThrow().toInputStream()) {
+            Files.copy(inputStream, dependency);
+        }
+        assertThat(dependency).content().isEqualTo("foo");
+        assertThat(local.resolve("group/artifact/1/artifact-1.jar.sha1"))
+                .content().isEqualTo(HexFormat.of().formatHex(hash));
+    }
+
+    @Test
     public void can_fetch_metadata() throws IOException {
         Files.writeString(Files
                 .createDirectories(repository.resolve("group/artifact"))

--- a/tests/build/jenesis/test/maven/MavenDefaultVersionNegotiatorTest.java
+++ b/tests/build/jenesis/test/maven/MavenDefaultVersionNegotiatorTest.java
@@ -3,9 +3,13 @@ package build.jenesis.test.maven;
 import module java.base;
 import module org.junit.jupiter.api;
 import module org.junit.jupiter.params;
+import build.jenesis.RepositoryItem;
 import build.jenesis.maven.MavenDefaultVersionNegotiator;
+import build.jenesis.maven.MavenRepository;
+import build.jenesis.maven.MavenVersionNegotiator;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MavenDefaultVersionNegotiatorTest {
 
@@ -82,5 +86,72 @@ public class MavenDefaultVersionNegotiatorTest {
         assertThat(Integer.signum(MavenDefaultVersionNegotiator.compareVersions(right, left)))
                 .as("compareVersions(%s, %s) reversed", right, left)
                 .isEqualTo(-expected);
+    }
+
+    @Test
+    public void resolves_latest_without_release() throws IOException {
+        String resolved = negotiator().resolve(Runnable::run,
+                metadata("<metadata><versioning><latest>1.0-SNAPSHOT</latest></versioning></metadata>"),
+                "group",
+                "artifact",
+                null,
+                null,
+                "LATEST");
+        assertThat(resolved).isEqualTo("1.0-SNAPSHOT");
+    }
+
+    @Test
+    public void resolves_range_without_latest_and_release() throws IOException {
+        String resolved = negotiator().resolve(Runnable::run,
+                metadata("<metadata><versioning><versions>"
+                        + "<version>1.0</version><version>2.0</version>"
+                        + "</versions></versioning></metadata>"),
+                "group",
+                "artifact",
+                null,
+                null,
+                "[1.0,2.0)");
+        assertThat(resolved).isEqualTo("1.0");
+    }
+
+    @Test
+    public void release_without_release_fails() {
+        assertThatThrownBy(() -> negotiator().resolve(Runnable::run,
+                metadata("<metadata><versioning><latest>1.0-SNAPSHOT</latest></versioning></metadata>"),
+                "group",
+                "artifact",
+                null,
+                null,
+                "RELEASE"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Property not defined: release");
+    }
+
+    private static MavenVersionNegotiator negotiator() {
+        Supplier<MavenVersionNegotiator> supplier = MavenDefaultVersionNegotiator.closest();
+        return supplier.get();
+    }
+
+    private static MavenRepository metadata(String xml) {
+        return new MavenRepository() {
+            @Override
+            public Optional<RepositoryItem> fetch(Executor executor,
+                                                  String groupId,
+                                                  String artifactId,
+                                                  String version,
+                                                  String type,
+                                                  String classifier,
+                                                  String checksum) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<RepositoryItem> fetchMetadata(Executor executor,
+                                                          String groupId,
+                                                          String artifactId,
+                                                          String checksum) {
+                return Optional.of(() -> new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+            }
+        };
     }
 }

--- a/tests/build/jenesis/test/maven/MavenPomResolverTest.java
+++ b/tests/build/jenesis/test/maven/MavenPomResolverTest.java
@@ -788,6 +788,64 @@ public class MavenPomResolverTest {
     }
 
     @Test
+    public void scope_with_surrounding_whitespace_is_normalized() throws IOException {
+        addToRepository("group", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>other</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>1</version>
+                            <scope>
+                                runtime
+                            </scope>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        addToRepository("other", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                </project>
+                """);
+        SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies = mavenPomResolver.dependencies(
+                Runnable::run,
+                mavenRepository,
+                "group",
+                "artifact",
+                "1",
+                null);
+        assertThat(dependencies).containsExactly(Map.entry(
+                new MavenDependencyKey("other", "artifact", "jar", null),
+                new MavenDependencyValue("1", MavenDependencyScope.RUNTIME, null, null, null)));
+    }
+
+    @Test
+    public void unknown_scope_is_reported_with_offending_value() throws IOException {
+        addToRepository("group", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>other</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>1</version>
+                            <scope>bogus</scope>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        assertThatThrownBy(() -> mavenPomResolver.dependencies(
+                Runnable::run, mavenRepository, "group", "artifact", "1", null))
+                .hasStackTraceContaining("Unknown Maven dependency scope")
+                .hasStackTraceContaining("bogus");
+    }
+
+    @Test
     public void can_resolve_dependency_configuration() throws IOException {
         addToRepository("group", "artifact", "1", """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -1143,6 +1201,159 @@ public class MavenPomResolverTest {
                 null);
         assertThat(dependencies).containsExactly(Map.entry(
                 new MavenDependencyKey("other", "artifact", "jar", null),
+                new MavenDependencyValue("1", MavenDependencyScope.COMPILE, null, null, null)));
+    }
+
+    @Test
+    public void can_resolve_dependency_bom_configuration_flattens_nested_import() throws IOException {
+        addToRepository("group", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>leaf</groupId>
+                            <artifactId>artifact</artifactId>
+                        </dependency>
+                    </dependencies>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>aggregator</groupId>
+                                <artifactId>artifact</artifactId>
+                                <version>1</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """);
+        addToRepository("aggregator", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>nested</groupId>
+                                <artifactId>artifact</artifactId>
+                                <version>1</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """);
+        addToRepository("nested", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>leaf</groupId>
+                                <artifactId>artifact</artifactId>
+                                <version>1</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """);
+        addToRepository("leaf", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                </project>
+                """);
+        SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies = mavenPomResolver.dependencies(
+                Runnable::run,
+                mavenRepository,
+                "group",
+                "artifact",
+                "1",
+                null);
+        assertThat(dependencies).containsExactly(Map.entry(
+                new MavenDependencyKey("leaf", "artifact", "jar", null),
+                new MavenDependencyValue("1", MavenDependencyScope.COMPILE, null, null, null)));
+    }
+
+    @Test
+    public void can_resolve_dependency_bom_configuration_flattens_nested_import_with_own_properties() throws IOException {
+        addToRepository("group", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>leaf</groupId>
+                            <artifactId>artifact</artifactId>
+                        </dependency>
+                    </dependencies>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>aggregator</groupId>
+                                <artifactId>artifact</artifactId>
+                                <version>1</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """);
+        addToRepository("aggregator", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>nested</groupId>
+                                <artifactId>artifact</artifactId>
+                                <version>1</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """);
+        addToRepository("nested", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <properties>
+                        <leaf.version>1</leaf.version>
+                    </properties>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>leaf</groupId>
+                                <artifactId>artifact</artifactId>
+                                <version>${leaf.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """);
+        addToRepository("leaf", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                </project>
+                """);
+        SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies = mavenPomResolver.dependencies(
+                Runnable::run,
+                mavenRepository,
+                "group",
+                "artifact",
+                "1",
+                null);
+        assertThat(dependencies).containsExactly(Map.entry(
+                new MavenDependencyKey("leaf", "artifact", "jar", null),
                 new MavenDependencyValue("1", MavenDependencyScope.COMPILE, null, null, null)));
     }
 
@@ -3993,5 +4204,106 @@ public class MavenPomResolverTest {
                 "maven/group/artifact/1",
                 "maven/middle/artifact/1",
                 "maven/deep/artifact/7");
+    }
+
+    @Test
+    public void coordinate_key_rejects_traversal_component() {
+        assertThatThrownBy(() -> new MavenDependencyKey("..", "artifact", "jar", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("..");
+        assertThatThrownBy(() -> new MavenDependencyKey("group", "a/b", "jar", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("a/b");
+        assertThatThrownBy(() -> new MavenDependencyKey("group", "artifact", "ja\\r", null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void parsed_coordinate_rejects_traversal_component() {
+        assertThatThrownBy(() -> MavenDependencyKey.parseKey("group/.."))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("..");
+        assertThatThrownBy(() -> MavenDependencyKey.tryParse("group/artifact/.."))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("..");
+    }
+
+    @Test
+    public void transitive_traversal_coordinate_is_rejected() throws IOException {
+        addToRepository("group", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>..</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>1</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        assertThatThrownBy(() -> mavenPomResolver.dependencies(
+                Runnable::run, mavenRepository, "group", "artifact", "1", null))
+                .hasStackTraceContaining("Illegal Maven coordinate groupId");
+    }
+
+    @Test
+    public void conflicting_checksums_for_same_version_fail_resolution() throws IOException {
+        addToRepository("group", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>left</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>right</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>1</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        addToRepository("left", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>shared</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>1</version>
+                            <!--Checksum/SHA256/aaaa-->
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        addToRepository("right", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>shared</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>1</version>
+                            <!--Checksum/SHA256/bbbb-->
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        addToRepository("shared", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                </project>
+                """);
+        assertThatThrownBy(() -> mavenPomResolver.dependencies(
+                Runnable::run, mavenRepository, "group", "artifact", "1", null))
+                .hasStackTraceContaining("Conflicting checksums for shared:artifact:1");
     }
 }

--- a/tests/build/jenesis/test/maven/MavenRepositoryExportTest.java
+++ b/tests/build/jenesis/test/maven/MavenRepositoryExportTest.java
@@ -117,6 +117,28 @@ public class MavenRepositoryExportTest {
     }
 
     @Test
+    public void second_export_preserves_previously_exported_versions() throws IOException {
+        Path firstVersionDir = stageArtifact("com.example", "foo", "1.0", "v10");
+        run();
+
+        try (Stream<Path> staged = Files.list(firstVersionDir)) {
+            for (Path file : staged.toList()) {
+                Files.delete(file);
+            }
+        }
+        Files.delete(firstVersionDir);
+        stageArtifact("com.example", "foo", "2.0", "v20");
+        run();
+
+        Path metadata = target.resolve("com/example/foo/maven-metadata-local.xml");
+        String content = Files.readString(metadata);
+        assertThat(content).contains("<version>1.0</version>");
+        assertThat(content).contains("<version>2.0</version>");
+        assertThat(content).contains("<release>2.0</release>");
+        assertThat(content).contains("<latest>2.0</latest>");
+    }
+
+    @Test
     public void leaves_unrelated_files_in_target_untouched() throws IOException {
         Path otherArtifact = Files.createDirectories(target.resolve("org/other/lib/1.0"));
         Files.writeString(otherArtifact.resolve("lib-1.0.jar"), "untouched");

--- a/tests/build/jenesis/test/module/JenesisModuleRepositoryTest.java
+++ b/tests/build/jenesis/test/module/JenesisModuleRepositoryTest.java
@@ -6,6 +6,7 @@ import build.jenesis.RepositoryItem;
 import build.jenesis.module.JenesisModuleRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class JenesisModuleRepositoryTest {
 
@@ -141,6 +142,32 @@ public class JenesisModuleRepositoryTest {
         try (InputStream stream = item.orElseThrow().toInputStream()) {
             assertThat(new String(stream.readAllBytes(), StandardCharsets.UTF_8)).isEqualTo("jmod-bytes");
         }
+    }
+
+    @Test
+    public void rejects_version_segment_containing_path_traversal() throws IOException {
+        Path outside = Files.writeString(root.resolve("secret.jar"), "secret");
+
+        assertThatThrownBy(() -> new JenesisModuleRepository(root.resolve("module").toUri())
+                .fetch(Runnable::run, "build.jenesis/../../secret"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("traversal");
+
+        assertThat(Files.exists(outside)).isTrue();
+    }
+
+    @Test
+    public void rejects_version_with_unsafe_character() {
+        assertThatThrownBy(() -> new JenesisModuleRepository(root.toUri())
+                .fetch(Runnable::run, "build.jenesis/..%2f..%2fsecret"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void rejects_module_name_with_path_separator() {
+        assertThatThrownBy(() -> new JenesisModuleRepository(root.toUri())
+                .fetch(Runnable::run, "build\\jenesis"))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/tests/build/jenesis/test/module/ModularJarResolverTest.java
+++ b/tests/build/jenesis/test/module/ModularJarResolverTest.java
@@ -536,6 +536,25 @@ public class ModularJarResolverTest {
     }
 
     @Test
+    public void rejects_propagated_compiled_version_with_path_traversal() {
+        assertThatThrownBy(() -> new ModularJarResolver(false).dependencies(
+                Runnable::run,
+                "foo",
+                Map.of("foo", (_, coordinate) -> {
+                    RepositoryItem item = switch (coordinate) {
+                        case "root" -> () -> toJar("root", "1.0", require("dep", 0, "../../secret"));
+                        default -> null;
+                    };
+                    return Optional.ofNullable(item);
+                }),
+                new LinkedHashMap<>(Map.of("root", Collections.emptyNavigableSet())),
+                new LinkedHashMap<>(),
+                DependencyScope.COMPILE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("../../secret");
+    }
+
+    @Test
     public void picks_highest_versioned_module_info_under_runtime() throws IOException {
         int runtime = Runtime.version().feature();
         LinkedHashMap<Integer, String> versions = new LinkedHashMap<>();

--- a/tests/build/jenesis/test/module/ModularProjectTest.java
+++ b/tests/build/jenesis/test/module/ModularProjectTest.java
@@ -99,8 +99,8 @@ public class ModularProjectTest {
     public void emits_versions_properties_from_javadoc_pins() throws IOException {
         Files.writeString(project.resolve("module-info.java"), """
                 /**
-                 * @jenesis.pin bar 1.2.3
-                 * @jenesis.pin transitive.pin 9.9.9
+                 * @jenesis.pin compile/module/bar 1.2.3
+                 * @jenesis.pin compile/module/transitive.pin 9.9.9
                  */
                 module foo {
                   requires bar;
@@ -118,14 +118,14 @@ public class ModularProjectTest {
         assertThat(compileVersionsFile).exists();
         SequencedProperties compileVersions = SequencedProperties.ofFiles(compileVersionsFile);
         assertThat(compileVersions).containsOnly(
-                Map.entry("bar", "1.2.3"),
-                Map.entry("transitive.pin", "9.9.9"));
+                Map.entry("compile/module/bar", "1.2.3"),
+                Map.entry("compile/module/transitive.pin", "9.9.9"));
         Path runtimeVersionsFile = module.resolve(BuildStep.VERSIONS);
         assertThat(runtimeVersionsFile).exists();
         SequencedProperties runtimeVersions = SequencedProperties.ofFiles(runtimeVersionsFile);
         assertThat(runtimeVersions).containsOnly(
-                Map.entry("bar", "1.2.3"),
-                Map.entry("transitive.pin", "9.9.9"));
+                Map.entry("compile/module/bar", "1.2.3"),
+                Map.entry("compile/module/transitive.pin", "9.9.9"));
     }
 
     @Test

--- a/tests/build/jenesis/test/module/ModuleInfoParserTest.java
+++ b/tests/build/jenesis/test/module/ModuleInfoParserTest.java
@@ -6,6 +6,7 @@ import build.jenesis.module.ModuleInfo;
 import build.jenesis.module.ModuleInfoParser;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ModuleInfoParserTest {
 
@@ -138,37 +139,37 @@ public class ModuleInfoParserTest {
     public void single_requires_tag_is_extracted() throws IOException {
         Files.writeString(folder.resolve("module-info.java"), """
                 /**
-                 * @jenesis.pin bar 1.2.3
+                 * @jenesis.pin compile/module/bar 1.2.3
                  */
                 module foo {
                   requires bar;
                 }
                 """);
         ModuleInfo info = new ModuleInfoParser().identify(folder.resolve("module-info.java"));
-        assertThat(info.versions()).containsExactly(Map.entry("bar", "1.2.3"));
+        assertThat(info.versions()).containsExactly(Map.entry("compile/module/bar", "1.2.3"));
     }
 
     @Test
     public void requires_tag_carries_optional_checksum_after_version() throws IOException {
         Files.writeString(folder.resolve("module-info.java"), """
                 /**
-                 * @jenesis.pin bar 1.2.3 SHA256/cafebabe
+                 * @jenesis.pin compile/module/bar 1.2.3 SHA256/cafebabe
                  */
                 module foo {
                   requires bar;
                 }
                 """);
         ModuleInfo info = new ModuleInfoParser().identify(folder.resolve("module-info.java"));
-        assertThat(info.versions()).containsExactly(Map.entry("bar", "1.2.3 SHA256/cafebabe"));
+        assertThat(info.versions()).containsExactly(Map.entry("compile/module/bar", "1.2.3 SHA256/cafebabe"));
     }
 
     @Test
     public void multiple_requires_tags_preserve_order() throws IOException {
         Files.writeString(folder.resolve("module-info.java"), """
                 /**
-                 * @jenesis.pin bar 1.0
-                 * @jenesis.pin qux 2.0
-                 * @jenesis.pin baz 3.0
+                 * @jenesis.pin compile/module/bar 1.0
+                 * @jenesis.pin compile/module/qux 2.0
+                 * @jenesis.pin compile/module/baz 3.0
                  */
                 module foo {
                   requires bar;
@@ -176,16 +177,16 @@ public class ModuleInfoParserTest {
                 """);
         ModuleInfo info = new ModuleInfoParser().identify(folder.resolve("module-info.java"));
         assertThat(info.versions()).containsExactly(
-                Map.entry("bar", "1.0"),
-                Map.entry("qux", "2.0"),
-                Map.entry("baz", "3.0"));
+                Map.entry("compile/module/bar", "1.0"),
+                Map.entry("compile/module/qux", "2.0"),
+                Map.entry("compile/module/baz", "3.0"));
     }
 
     @Test
     public void pin_for_non_declared_module_is_extracted() throws IOException {
         Files.writeString(folder.resolve("module-info.java"), """
                 /**
-                 * @jenesis.pin transitive.pin 9.9.9
+                 * @jenesis.pin compile/module/transitive.pin 9.9.9
                  */
                 module foo {
                   requires bar;
@@ -193,23 +194,54 @@ public class ModuleInfoParserTest {
                 """);
         ModuleInfo info = new ModuleInfoParser().identify(folder.resolve("module-info.java"));
         assertThat(info.requires()).containsExactly("bar");
-        assertThat(info.versions()).containsExactly(Map.entry("transitive.pin", "9.9.9"));
+        assertThat(info.versions()).containsExactly(Map.entry("compile/module/transitive.pin", "9.9.9"));
     }
 
     @Test
     public void malformed_requires_tag_is_skipped() throws IOException {
         Files.writeString(folder.resolve("module-info.java"), """
                 /**
-                 * @jenesis.pin bar
+                 * @jenesis.pin compile/module/bar
                  * @jenesis.pin
-                 * @jenesis.pin qux 1.0
+                 * @jenesis.pin compile/module/qux 1.0
                  */
                 module foo {
                   requires bar;
                 }
                 """);
         ModuleInfo info = new ModuleInfoParser().identify(folder.resolve("module-info.java"));
-        assertThat(info.versions()).containsExactly(Map.entry("qux", "1.0"));
+        assertThat(info.versions()).containsExactly(Map.entry("compile/module/qux", "1.0"));
+    }
+
+    @Test
+    public void non_scope_first_pin_is_rejected() throws IOException {
+        Files.writeString(folder.resolve("module-info.java"), """
+                /**
+                 * @jenesis.pin bar 1.0
+                 */
+                module foo {
+                  requires bar;
+                }
+                """);
+        assertThatThrownBy(() -> new ModuleInfoParser().identify(folder.resolve("module-info.java")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("bar")
+                .hasMessageContaining("<scope>/<repository>/<coordinate>");
+    }
+
+    @Test
+    public void scope_and_repository_only_pin_is_rejected() throws IOException {
+        Files.writeString(folder.resolve("module-info.java"), """
+                /**
+                 * @jenesis.pin compile/module 1.0
+                 */
+                module foo {
+                  requires bar;
+                }
+                """);
+        assertThatThrownBy(() -> new ModuleInfoParser().identify(folder.resolve("module-info.java")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("compile/module");
     }
 
     @Test
@@ -218,14 +250,14 @@ public class ModuleInfoParserTest {
                 /**
                  * @jenesis.pin java.base 21
                  * @jenesis.pin jdk.compiler 21
-                 * @jenesis.pin bar 1.0
+                 * @jenesis.pin compile/module/bar 1.0
                  */
                 module foo {
                   requires bar;
                 }
                 """);
         ModuleInfo info = new ModuleInfoParser().identify(folder.resolve("module-info.java"));
-        assertThat(info.versions()).containsExactly(Map.entry("bar", "1.0"));
+        assertThat(info.versions()).containsExactly(Map.entry("compile/module/bar", "1.0"));
     }
 
     @Test
@@ -236,14 +268,14 @@ public class ModuleInfoParserTest {
                  *
                  * @author someone
                  * @since 1.0
-                 * @jenesis.pin bar 1.0
+                 * @jenesis.pin compile/module/bar 1.0
                  */
                 module foo {
                   requires bar;
                 }
                 """);
         ModuleInfo info = new ModuleInfoParser().identify(folder.resolve("module-info.java"));
-        assertThat(info.versions()).containsExactly(Map.entry("bar", "1.0"));
+        assertThat(info.versions()).containsExactly(Map.entry("compile/module/bar", "1.0"));
     }
 
     @Test
@@ -251,7 +283,7 @@ public class ModuleInfoParserTest {
         Files.writeString(folder.resolve("module-info.java"), """
                 /**
                  * @jenesis.release 25
-                 * @jenesis.pin bar 1.0
+                 * @jenesis.pin compile/module/bar 1.0
                  */
                 module foo {
                   requires bar;
@@ -259,7 +291,7 @@ public class ModuleInfoParserTest {
                 """);
         ModuleInfo info = new ModuleInfoParser().identify(folder.resolve("module-info.java"));
         assertThat(info.release()).isEqualTo("25");
-        assertThat(info.versions()).containsExactly(Map.entry("bar", "1.0"));
+        assertThat(info.versions()).containsExactly(Map.entry("compile/module/bar", "1.0"));
     }
 
     @Test
@@ -280,7 +312,7 @@ public class ModuleInfoParserTest {
     public void no_release_tag_yields_null_release() throws IOException {
         Files.writeString(folder.resolve("module-info.java"), """
                 /**
-                 * @jenesis.pin bar 1.0
+                 * @jenesis.pin compile/module/bar 1.0
                  */
                 module foo {
                   requires bar;
@@ -294,7 +326,7 @@ public class ModuleInfoParserTest {
     public void open_module_with_javadoc_pins() throws IOException {
         Files.writeString(folder.resolve("module-info.java"), """
                 /**
-                 * @jenesis.pin bar 1.0
+                 * @jenesis.pin compile/module/bar 1.0
                  */
                 open module foo {
                   requires bar;
@@ -302,7 +334,7 @@ public class ModuleInfoParserTest {
                 """);
         ModuleInfo info = new ModuleInfoParser().identify(folder.resolve("module-info.java"));
         assertThat(info.coordinate()).isEqualTo("foo");
-        assertThat(info.versions()).containsExactly(Map.entry("bar", "1.0"));
+        assertThat(info.versions()).containsExactly(Map.entry("compile/module/bar", "1.0"));
     }
 
     @Test

--- a/tests/build/jenesis/test/project/GroovyDocumentationModuleTest.java
+++ b/tests/build/jenesis/test/project/GroovyDocumentationModuleTest.java
@@ -1,0 +1,72 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.RepositoryItem;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.GroovyDocumentationModule;
+import build.jenesis.step.ProcessHandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GroovyDocumentationModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void honors_release_from_upstream_javac_properties() throws IOException {
+        Path sample = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample"));
+        Files.writeString(sample.resolve("Sample.groovy"), "package sample\nclass Sample {}");
+        Path process = Files.createDirectories(project.resolve("process"));
+        SequencedProperties javac = new SequencedProperties();
+        javac.setProperty("--release", "11");
+        javac.store(process.resolve("javac.properties"));
+        Path groovydocJar = Files.createFile(project.resolve("groovydoc.jar"));
+
+        List<String> captured = new ArrayList<>();
+        ToolProvider noop = new ToolProvider() {
+            @Override
+            public String name() {
+                return "groovydoc";
+            }
+
+            @Override
+            public int run(PrintWriter out, PrintWriter err, String... args) {
+                return 0;
+            }
+        };
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule(
+                "groovydoc",
+                new GroovyDocumentationModule(
+                        Map.of("maven", (_, _) -> Optional.of(RepositoryItem.ofFile(groovydocJar))),
+                        Map.of("maven", Resolver.identity()))
+                        .factory(commands -> {
+                            captured.addAll(commands);
+                            return ProcessHandler.OfTool.of(noop).apply(commands);
+                        }),
+                "project");
+        executor.execute();
+
+        assertThat(captured)
+                .as("--release=11 from process/javac.properties drives -javaVersion JAVA_11")
+                .containsSequence("-javaVersion", "JAVA_11");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/KotlinCompilerModuleTest.java
+++ b/tests/build/jenesis/test/project/KotlinCompilerModuleTest.java
@@ -109,6 +109,45 @@ public class KotlinCompilerModuleTest {
     }
 
     @Test
+    public void skips_module_info_so_kotlinc_does_not_parse_it() throws IOException {
+        SequencedProperties properties = new SequencedProperties();
+        properties.setProperty("kotlin/maven/org.jetbrains.kotlin/kotlin-compiler-embeddable", KOTLIN_VERSION);
+        properties.store(project.resolve(BuildStep.VERSIONS));
+        Path sampleDir = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample"));
+        Files.writeString(sampleDir.resolve("Sample.kt"), """
+                package sample
+                class Sample
+                """);
+        Files.writeString(project.resolve(BuildStep.SOURCES + "module-info.java"), """
+                module sample {
+                    exports sample;
+                }
+                """);
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule(
+                "kotlin",
+                new KotlinCompilerModule(
+                        Map.of("maven", mavenCentral()),
+                        Map.of("maven", new MavenPomResolver())),
+                "project");
+        executor.execute();
+
+        Path classes = root
+                .resolve("kotlin")
+                .resolve(KotlinCompilerModule.CLASSES)
+                .resolve("output")
+                .resolve(BuildStep.CLASSES);
+        assertThat(classes.resolve("sample/Sample.class"))
+                .as("kotlinc compiled the Kotlin source while ignoring module-info.java")
+                .isNotEmptyFile();
+        assertThat(classes.resolve("module-info.class"))
+                .as("kotlinc must not parse or emit module-info.java; javac owns it")
+                .doesNotExist();
+    }
+
+    @Test
     public void picks_up_release_from_upstream_javac_properties() throws IOException {
         SequencedProperties properties = new SequencedProperties();
         properties.setProperty("kotlin/maven/org.jetbrains.kotlin/kotlin-compiler-embeddable", KOTLIN_VERSION);

--- a/tests/build/jenesis/test/project/MultiProjectModuleTest.java
+++ b/tests/build/jenesis/test/project/MultiProjectModuleTest.java
@@ -12,6 +12,7 @@ import build.jenesis.SequencedProperties;
 import build.jenesis.project.MultiProjectModule;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MultiProjectModuleTest {
 
@@ -344,6 +345,35 @@ public class MultiProjectModuleTest {
         }));
         buildExecutor.execute("project/compose/module/1", "project/compose/module/5");
         assertThat(built).contains("1", "2", "3", "5").doesNotContain("4");
+    }
+
+    @Test
+    public void rejects_cyclic_modules() {
+        buildExecutor.addModule("project", new MultiProjectModule((buildExecutor, _) -> {
+            SequencedProperties coordinates1 = new SequencedProperties();
+            coordinates1.put("foo/bar", "");
+            coordinates1.store(module1.resolve(BuildStep.IDENTITY));
+            SequencedProperties dependencies1 = new SequencedProperties();
+            dependencies1.put("compile/foo/qux", "");
+            dependencies1.store(module1.resolve(BuildStep.REQUIRES));
+            buildExecutor.addSource("1-module", module1);
+            SequencedProperties coordinates2 = new SequencedProperties();
+            coordinates2.put("foo/qux", "");
+            coordinates2.store(module2.resolve(BuildStep.IDENTITY));
+            SequencedProperties dependencies2 = new SequencedProperties();
+            dependencies2.put("compile/foo/bar", "");
+            dependencies2.store(module2.resolve(BuildStep.REQUIRES));
+            buildExecutor.addSource("2-module", module2);
+        }, identifier -> Optional.of(identifier.substring(0, identifier.indexOf('-')).replace('-', '/')),
+                modules -> (name, dependencies, identifiers) -> (module, inherited) -> {
+            throw new AssertionError("Unexpected module: " + name);
+        }));
+        assertThatThrownBy(buildExecutor::execute)
+                .hasRootCauseInstanceOf(IllegalStateException.class)
+                .rootCause()
+                .hasMessageContaining("Cyclic module dependencies")
+                .hasMessageContaining("1")
+                .hasMessageContaining("2");
     }
 
 }

--- a/tests/build/jenesis/test/project/ScalaDocumentationModuleTest.java
+++ b/tests/build/jenesis/test/project/ScalaDocumentationModuleTest.java
@@ -1,0 +1,79 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.ScalaDocumentationModule;
+import build.jenesis.step.ProcessHandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ScalaDocumentationModuleTest {
+
+    @TempDir
+    private Path input, root;
+
+    @Test
+    public void classpath_carries_compile_dependencies_while_positional_inputs_are_class_roots() throws IOException {
+        Path toolJar = Files.createFile(input.resolve("scaladoc.jar"));
+        Path compileJar = Files.createFile(input.resolve("compile.jar"));
+        Path classes = Files.createDirectory(input.resolve(BuildStep.CLASSES));
+        Files.createFile(classes.resolve("Sample.tasty"));
+        Files.writeString(Files
+                .createDirectories(input.resolve(BuildStep.SOURCES))
+                .resolve("Sample.scala"), "class Sample\n");
+        SequencedProperties dependencies = new SequencedProperties();
+        dependencies.setProperty("scaladoc/local/scaladoc", "scaladoc.jar");
+        dependencies.setProperty("compile/local/compile", "compile.jar");
+        dependencies.store(input.resolve(BuildStep.DEPENDENCY_INDEX));
+
+        List<String>[] captured = new List[1];
+        BuildExecutor executor = BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+        executor.addSource("input", input);
+        executor.addModule("scaladoc",
+                new ScalaDocumentationModule(
+                        Map.of(),
+                        Map.of("module", (_, _, _, _, _, _, _) -> new LinkedHashMap<>()))
+                        .factory(commands -> {
+                            captured[0] = commands;
+                            return ProcessHandler.OfTool.of(new ToolProvider() {
+                                @Override
+                                public String name() {
+                                    return "scaladoc";
+                                }
+
+                                @Override
+                                public int run(PrintWriter out, PrintWriter err, String... args) {
+                                    return 0;
+                                }
+                            }).apply(commands);
+                        }),
+                "input");
+        executor.execute();
+
+        assertThat(captured[0]).isNotNull();
+        int classpathIndex = captured[0].indexOf("-classpath");
+        assertThat(classpathIndex).isGreaterThanOrEqualTo(0);
+        List<String> classpath = Arrays.asList(captured[0].get(classpathIndex + 1).split(File.pathSeparator));
+        assertThat(classpath)
+                .contains(classes.toString(), compileJar.toString())
+                .doesNotContain(toolJar.toString());
+
+        int cpIndex = captured[0].indexOf("-cp");
+        assertThat(cpIndex).isGreaterThanOrEqualTo(0);
+        assertThat(captured[0].get(cpIndex + 1)).isEqualTo(toolJar.toString());
+
+        int projectIndex = captured[0].indexOf("-project");
+        List<String> positional = captured[0].subList(projectIndex + 2, captured[0].size());
+        assertThat(positional).containsExactly(classes.toString());
+    }
+}

--- a/tests/build/jenesis/test/project/TestModuleTest.java
+++ b/tests/build/jenesis/test/project/TestModuleTest.java
@@ -357,6 +357,30 @@ public class TestModuleTest {
     }
 
     @Test
+    public void fails_when_selection_matches_no_tests() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("dependencies", dependencies);
+        executor.addSource("classes", classes);
+        executor.addModule(
+                "test",
+                new TestModule(Map.of("maven", new MavenDefaultRepository(
+                                URI.create("https://repo1.maven.org/maven2/"),
+                                null,
+                                Map.of(),
+                                _ -> {})),
+                        Map.of("maven", new MavenPomResolver()))
+                        .engine(new JUnitPlatform())
+                        .isTest((Predicate<String> & Serializable) _ -> false)
+                        .filter("sample\\.DoesNotExist").jarsOnly(false),
+                "dependencies", "classes");
+
+        assertThatThrownBy(executor::execute)
+                .hasRootCauseInstanceOf(IllegalStateException.class)
+                .rootCause()
+                .hasMessageContaining("No tests matched the requested selection");
+    }
+
+    @Test
     public void throws_when_no_engine_found() throws IOException {
         BuildExecutor executor = newExecutor();
         executor.addSource("dependencies", emptyDependencies);

--- a/tests/build/jenesis/test/step/DownloadTest.java
+++ b/tests/build/jenesis/test/step/DownloadTest.java
@@ -77,6 +77,49 @@ public class DownloadTest {
     }
 
     @Test
+    public void enforces_pin_shared_across_scopes() throws IOException, NoSuchAlgorithmException {
+        SequencedProperties properties = new SequencedProperties();
+        properties.setProperty("compile/foo/bar", "");
+        properties.setProperty("runtime/foo/bar", "SHA256/" + HexFormat.of().formatHex(
+                MessageDigest.getInstance("SHA256").digest("other".getBytes(StandardCharsets.UTF_8))));
+        properties.store(dependencies.resolve(BuildStep.REQUIRES));
+        assertThatThrownBy(() -> new Download(Map.of(
+                "foo",
+                (_, bar) -> Optional.of(() -> new ByteArrayInputStream(bar.getBytes(StandardCharsets.UTF_8)))
+        )).apply(
+                Runnable::run,
+                new BuildStepContext(previous, next, supplement),
+                new LinkedHashMap<>(Map.of("dependencies", new BuildStepArgument(
+                        dependencies,
+                        Map.of(Path.of(BuildStep.REQUIRES), ChecksumStatus.ADDED))))).toCompletableFuture().join())
+                .cause()
+                .isInstanceOf(RuntimeException.class)
+                .cause()
+                .hasMessageContaining("Mismatched digest for foo/bar");
+    }
+
+    @Test
+    public void rejects_conflicting_pins_across_scopes() throws IOException, NoSuchAlgorithmException {
+        SequencedProperties properties = new SequencedProperties();
+        properties.setProperty("compile/foo/bar", "SHA256/" + HexFormat.of().formatHex(
+                MessageDigest.getInstance("SHA256").digest("bar".getBytes(StandardCharsets.UTF_8))));
+        properties.setProperty("runtime/foo/bar", "SHA256/" + HexFormat.of().formatHex(
+                MessageDigest.getInstance("SHA256").digest("other".getBytes(StandardCharsets.UTF_8))));
+        properties.store(dependencies.resolve(BuildStep.REQUIRES));
+        assertThatThrownBy(() -> new Download(Map.of(
+                "foo",
+                (_, bar) -> Optional.of(() -> new ByteArrayInputStream(bar.getBytes(StandardCharsets.UTF_8)))
+        )).apply(
+                Runnable::run,
+                new BuildStepContext(previous, next, supplement),
+                new LinkedHashMap<>(Map.of("dependencies", new BuildStepArgument(
+                        dependencies,
+                        Map.of(Path.of(BuildStep.REQUIRES), ChecksumStatus.ADDED))))).toCompletableFuture().join())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Conflicting checksums pinned for foo/bar");
+    }
+
+    @Test
     public void rejects_dependency_with_mismatched_digest() throws IOException, NoSuchAlgorithmException {
         SequencedProperties properties = new SequencedProperties();
         properties.setProperty("compile/foo/bar", "SHA256/" + HexFormat.of().formatHex(

--- a/tests/build/jenesis/test/step/GroupTest.java
+++ b/tests/build/jenesis/test/step/GroupTest.java
@@ -93,4 +93,26 @@ public class GroupTest {
         assertThat(rightGroup.stringPropertyNames()).isEmpty();
         assertThat(result.next()).isTrue();
     }
+
+    @Test
+    public void does_not_link_self_referencing_group() throws IOException {
+        SequencedProperties leftCoordinates = new SequencedProperties();
+        leftCoordinates.setProperty("foo", "");
+        leftCoordinates.store(left.resolve(BuildStep.IDENTITY));
+        SequencedProperties leftDependencies = new SequencedProperties();
+        leftDependencies.setProperty("foo", "");
+        leftDependencies.store(left.resolve(BuildStep.REQUIRES));
+        BuildStepResult result = new Group(Optional::of).apply(
+                Runnable::run,
+                new BuildStepContext(previous, next, supplement),
+                new LinkedHashMap<>(Map.of(
+                        "left", new BuildStepArgument(
+                                left,
+                                Map.of(
+                                        Path.of(BuildStep.IDENTITY), ChecksumStatus.ADDED,
+                                        Path.of(BuildStep.REQUIRES), ChecksumStatus.ADDED))))).toCompletableFuture().join();
+        SequencedProperties leftGroup = SequencedProperties.ofFiles(next.resolve(Group.GROUPS + "left.properties"));
+        assertThat(leftGroup.stringPropertyNames()).isEmpty();
+        assertThat(result.next()).isTrue();
+    }
 }

--- a/tests/build/jenesis/test/step/ProcessHandlerTest.java
+++ b/tests/build/jenesis/test/step/ProcessHandlerTest.java
@@ -1,0 +1,55 @@
+package build.jenesis.test.step;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.step.ProcessHandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProcessHandlerTest {
+
+    @TempDir
+    private Path root;
+
+    @Test
+    public void interrupting_a_forked_process_destroys_it_and_restores_the_interrupt_flag() throws Exception {
+        Path source = root.resolve("Sleeper.java");
+        Files.writeString(source, """
+                public class Sleeper {
+                    public static void main(String[] args) throws InterruptedException {
+                        Thread.sleep(600_000);
+                    }
+                }
+                """);
+        Path output = root.resolve("output"), error = root.resolve("error");
+        ProcessHandler handler = ProcessHandler.OfProcess.ofJavaHome("bin/java")
+                .apply(List.of(source.toString()));
+
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        AtomicBoolean interruptRestored = new AtomicBoolean();
+        CountDownLatch started = new CountDownLatch(1), finished = new CountDownLatch(1);
+        Thread worker = new Thread(() -> {
+            started.countDown();
+            try {
+                handler.execute(output, error);
+            } catch (Throwable t) {
+                thrown.set(t);
+                interruptRestored.set(Thread.currentThread().isInterrupted());
+            } finally {
+                finished.countDown();
+            }
+        });
+        worker.start();
+        assertThat(started.await(10, TimeUnit.SECONDS)).isTrue();
+        Thread.sleep(1_000);
+        worker.interrupt();
+        assertThat(finished.await(30, TimeUnit.SECONDS))
+                .as("interrupting the worker tears the forked process down promptly")
+                .isTrue();
+        assertThat(thrown.get()).isInstanceOf(RuntimeException.class);
+        assertThat(thrown.get().getCause()).isInstanceOf(InterruptedException.class);
+        assertThat(interruptRestored.get())
+                .as("the interrupt flag is restored before rethrowing")
+                .isTrue();
+    }
+}

--- a/tests/build/jenesis/test/step/ResolveTest.java
+++ b/tests/build/jenesis/test/step/ResolveTest.java
@@ -13,6 +13,7 @@ import build.jenesis.SequencedProperties;
 import build.jenesis.step.Resolve;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ResolveTest {
 
@@ -173,5 +174,25 @@ public class ResolveTest {
         SequencedProperties dependencies = SequencedProperties.ofFiles(next.resolve(BuildStep.REQUIRES));
         assertThat(dependencies.stringPropertyNames())
                 .containsExactlyInAnyOrder("compile/foo/lib/1.0", "runtime/foo/lib/1.0");
+    }
+
+    @Test
+    public void malformed_version_pin_fails_loudly() throws IOException {
+        SequencedProperties versions = new SequencedProperties();
+        versions.setProperty("bar", "1.0");
+        versions.store(dependencies.resolve(BuildStep.VERSIONS));
+        Resolve resolve = new Resolve(Map.of("foo", Repository.empty()),
+                Map.of("foo", (_, prefix, _, descriptors, _, _, _) -> new LinkedHashMap<>()));
+        assertThatThrownBy(() -> resolve.apply(
+                Runnable::run,
+                new BuildStepContext(previous, next, supplement),
+                new LinkedHashMap<>(Map.of("dependencies", new BuildStepArgument(
+                        dependencies,
+                        Map.of(
+                                Path.of(BuildStep.VERSIONS),
+                                ChecksumStatus.ADDED))))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("bar")
+                .hasMessageContaining("<scope>/<repository>/<coordinate>");
     }
 }


### PR DESCRIPTION
## Summary

Addresses the **high and medium severity findings** from the multi-agent review of the scope-based dependency model, stacked on top of `plugin-scope-tags` (base branch = `plugin-scope-tags`, so it merges in order after #10 with no rebase).

30 findings across 20 disjoint file groups were implemented and adversarially scoped; 18 groups are fully fixed and 2 are partial (noted below). Every change keeps to the existing conventions (explicit types, no Javadoc, minimal comments, scope-first pins).

## Security hardening

- **Path traversal from untrusted coordinates** - `MavenDependencyKey` now rejects any group/artifact/type/classifier component containing `/`, `\`, `.` or `..` (and POM leaf text is trimmed); `MavenDefaultRepository` adds a `normalize().startsWith(local)` containment check before resolving a coordinate-derived path against the local repository root.
- **Path traversal via crafted module version** - `JenesisModuleRepository.fetch` validates module name and version against a safe charset and re-checks containment after `resolve`; `ModularJarResolver` rejects a propagated `rawCompiledVersion` containing `..`/separators.
- **Download dedup dropping a pinned checksum** - `Download` no longer skips checksum verification for scope-deduplicated entries; every scope entry's pin is enforced and conflicting pins for one coordinate fail the build.
- **Repository transport integrity** - the unpinned validation path now prefers SHA-512/SHA-256 sidecars (falling back to SHA-1) and **fails closed** when a checksum sidecar is missing, instead of silently accepting the artifact.
- **Docker isolation** - the in-container build is now terminal (no host re-run after a successful container build), and the implicit image runs with `--cap-drop ALL` and `--security-opt no-new-privileges`.
- **`install.sh` / SDK scripts** - `jenesis-init` (and `jenesis-init.bat`) copy only `build/jenesis` instead of the whole jar tree; the Windows launchers fail closed on a non-numeric Java version; the release workflow fails loudly when a `[release] 1.2.3` style mistake would otherwise auto-bump to the wrong version.

## Correctness

- **Nested BOM imports** are now flattened recursively (depth-first, resolved against each BOM's own properties), so aggregator BOMs that import other BOMs no longer lose transitive version constraints.
- **Cyclic / self-referential project graphs** throw a clear `IllegalStateException` naming the modules instead of hanging forever.
- **No-tests-matched** now fails the build consistently across JUnit Platform, JUnit 4 and TestNG instead of silently passing on two of three engines.
- **Scaladoc** passes the compile classpath to `-classpath` and only compiled class roots as positional inputs (was documenting dependency jars); **Groovydoc** reads the real `--release` from `javac.properties`; **Kotlin** excludes `module-info.java` from the Kotlin compiler inputs so modular Kotlin builds work.
- **Version metadata** - `maven-metadata` parsing tolerates missing `<latest>`/`<release>` (SNAPSHOT-only / plugin metadata); repository export merges with existing metadata and prior version directories instead of clobbering them.
- **Checksum re-binding** - the resolved checksum is bound to the negotiated winning version rather than the first-seen one (conflicts error out).
- **Misc robustness** - `SequencedProperties.store(writer, comment)` no longer corrupts output; `Repository.cached()` writes stream artifacts atomically (temp + `ATOMIC_MOVE`); malformed non-scope-first `@jenesis.pin` tags are rejected with a clear message instead of being silently dropped; process steps destroy a forcibly-interrupted subprocess and restore the interrupt flag.

## Docs

- `@jenesis.pin` help text in `Project.java`, the demo-14 run command, the demo-10 self-contradiction, and the release-syntax docs are corrected to match the enforced scope-first behavior.

## Partial (intentionally not over-reached)

- **Process timeout cleanup (part 3)** - the subprocess is now destroyed and the interrupt flag restored on interruption, but deleting the step's `next` temp dir strictly *after* worker termination needs an executor refactor and was left out to avoid restructuring the (opt-in, default-disabled) timeout path.
- **Classloader bridge close wiring** - `JenesisClassLoaderBridge` is now `AutoCloseable` with a real `close()`, but it is not yet invoked: a correct hook must fire only after the whole nested build completes (closing mid-build would break class loading), which needs a completion hook in the executor. No behavior change yet; the leak fix is staged for follow-up wiring.

## Validation

- `mvn test`: **898 tests, 0 failures** (was 860; +38 new tests, including path-traversal rejection, nested-BOM flattening, cycle detection, no-tests failure, checksum conflict, sidecar fail-closed, atomic cache write, pin-shape rejection).
- Full self-build (`java build/jenesis/Project.java stage`) green, including the 898-test step run through Jenesis's own runtime - confirming the stricter checksum/sidecar policy does not break resolution of the real dependency closure from Maven Central.
- Demos re-run green: modular-multi, kotlin (+documentation), scala documentation, groovy documentation, supply-chain-security, internal-module, external-module, docker-isolation.
