### PR TITLE
Preserve the resolver group in the resolved dependency index

### DIFF
--- a/demo/demo-08-annotations/sources/module-info.java
+++ b/demo/demo-08-annotations/sources/module-info.java
@@ -10,6 +10,8 @@
  * @jenesis.plugin org.immutables.value
  * @jenesis.pin org.immutables.value 2.12.2
  * @jenesis.pin org.immutables/value 2.12.2 SHA-256/fa9582d54d079bae233f3e580b5a1241417fcdd3e7049ece9f8ca85c8edd49e1
+ * @jenesis.pin plugin/maven/org.immutables/value 2.12.2 SHA-256/fa9582d54d079bae233f3e580b5a1241417fcdd3e7049ece9f8ca85c8edd49e1
+ * @jenesis.pin plugin/module/org.immutables.value 2.12.2 SHA-256/fa9582d54d079bae233f3e580b5a1241417fcdd3e7049ece9f8ca85c8edd49e1
  */
 module demo.annotations {
     requires static org.immutables.value;

--- a/demo/demo-09-kotlin/sources/module-info.java
+++ b/demo/demo-09-kotlin/sources/module-info.java
@@ -8,6 +8,7 @@
  * @jenesis.pin kotlin/maven/org.jetbrains.kotlin/kotlin-script-runtime 2.4.0-RC2 SHA-256/676934238966d037834d8285bfd7bd14c0c57f3b7ddd597f7ebd9e3c574a812f
  * @jenesis.pin kotlin/maven/org.jetbrains.kotlin/kotlin-stdlib 2.4.0-RC2 SHA-256/c67ed4aa99b5766e016f7c1a5d76424b67512cc8b6ca3a9f4ea97526bfee7a5e
  * @jenesis.pin kotlin/maven/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm 1.8.0 SHA-256/9860906a1937490bf5f3b06d2f0e10ef451e65b95b269f22daf68a3d1f5065c5
+ * @jenesis.pin kotlin/maven/org.jetbrains/annotations 13.0 SHA-256/ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478
  * @jenesis.pin org.jetbrains.kotlin/kotlin-stdlib 1.9.10 SHA-256/55e989c512b80907799f854309f3bc7782c5b3d13932442d0379d5c472711504
  * @jenesis.pin org.jetbrains.kotlin/kotlin-stdlib-common 1.9.10 SHA-256/cde3341ba18a2ba262b0b7cf6c55b20c90e8d434e42c9a13e6a3f770db965a88
  * @jenesis.pin org.jetbrains/annotations 13.0 SHA-256/ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478

--- a/demo/demo-24-kotlin-plugin/sources/module-info.java
+++ b/demo/demo-24-kotlin-plugin/sources/module-info.java
@@ -9,6 +9,7 @@
  * @jenesis.pin kotlin/maven/org.jetbrains.kotlin/kotlin-script-runtime 2.4.0-RC2 SHA-256/676934238966d037834d8285bfd7bd14c0c57f3b7ddd597f7ebd9e3c574a812f
  * @jenesis.pin kotlin/maven/org.jetbrains.kotlin/kotlin-stdlib 2.4.0-RC2 SHA-256/c67ed4aa99b5766e016f7c1a5d76424b67512cc8b6ca3a9f4ea97526bfee7a5e
  * @jenesis.pin kotlin/maven/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm 1.8.0 SHA-256/9860906a1937490bf5f3b06d2f0e10ef451e65b95b269f22daf68a3d1f5065c5
+ * @jenesis.pin kotlin/maven/org.jetbrains/annotations 13.0 SHA-256/ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478
  * @jenesis.pin kotlinx.serialization.core 1.7.3
  * @jenesis.pin org.jetbrains.kotlin/kotlin-stdlib 1.9.10 SHA-256/55e989c512b80907799f854309f3bc7782c5b3d13932442d0379d5c472711504
  * @jenesis.pin org.jetbrains.kotlin/kotlin-stdlib-common 1.9.10 SHA-256/cde3341ba18a2ba262b0b7cf6c55b20c90e8d434e42c9a13e6a3f770db965a88

--- a/sources/build/jenesis/maven/PinPom.java
+++ b/sources/build/jenesis/maven/PinPom.java
@@ -19,26 +19,16 @@ public class PinPom implements BuildStep {
     private static final Pattern INDENT = Pattern.compile("\\n([ \\t]+)<");
     private static final Pattern PIN_COMMENT = Pattern.compile("(?s)([ \\t]*)<!--\\s*jenesis\\.pin\\b.*?-->\\s*\\n");
 
-    private final String group;
     private final String prefix;
     private final String path;
     private final List<Path> pomFiles;
     private final transient HashDigestFunction hashFunction;
 
     public PinPom(String prefix, String path, Path pomFile, HashDigestFunction hashFunction) {
-        this("main", prefix, path, List.of(pomFile), hashFunction);
+        this(prefix, path, List.of(pomFile), hashFunction);
     }
 
     public PinPom(String prefix, String path, List<Path> pomFiles, HashDigestFunction hashFunction) {
-        this("main", prefix, path, pomFiles, hashFunction);
-    }
-
-    public PinPom(String group, String prefix, String path, Path pomFile, HashDigestFunction hashFunction) {
-        this(group, prefix, path, List.of(pomFile), hashFunction);
-    }
-
-    public PinPom(String group, String prefix, String path, List<Path> pomFiles, HashDigestFunction hashFunction) {
-        this.group = group;
         this.prefix = prefix;
         this.path = path;
         this.pomFiles = List.copyOf(pomFiles);
@@ -57,7 +47,7 @@ public class PinPom implements BuildStep {
             throws IOException {
         SequencedMap<String, Inventory.Dependency> closure = Inventory.closure(arguments.values(), path);
         Set<String> internal = collectInternal(Inventory.identities(arguments.values()));
-        SequencedMap<String, String> entries = collectEntries(closure, internal, hashFunction, group);
+        SequencedMap<String, String> entries = collectEntries(closure, internal, hashFunction);
         for (Path pomFile : pomFiles) {
             updatePom(pomFile, entries);
         }
@@ -82,7 +72,7 @@ public class PinPom implements BuildStep {
             int second = key.indexOf('/', first + 1);
             String group = key.substring(0, first);
             String repository = second < 0 ? "" : key.substring(first + 1, second);
-            if (repository.equals("maven") && group.equals(this.group)) {
+            if (repository.equals("maven") && group.equals("main")) {
                 managed.putIfAbsent(key.substring(second + 1), entry.getValue());
             } else {
                 qualified.put(key, entry.getValue());
@@ -126,16 +116,10 @@ public class PinPom implements BuildStep {
     static SequencedMap<String, String> collectEntries(SequencedMap<String, Inventory.Dependency> closure,
                                                        Set<String> internal,
                                                        HashDigestFunction hashFunction) throws IOException {
-        return collectEntries(closure, internal, hashFunction, "main");
-    }
-
-    static SequencedMap<String, String> collectEntries(SequencedMap<String, Inventory.Dependency> closure,
-                                                       Set<String> internal,
-                                                       HashDigestFunction hashFunction,
-                                                       String defaultGroup) throws IOException {
         SequencedMap<String, String> entries = new TreeMap<>();
         for (Map.Entry<String, Inventory.Dependency> dependency : closure.entrySet()) {
-            String key = dependency.getKey();
+            String group = dependency.getValue().group();
+            String key = dependency.getKey().substring(group.length() + 1);
             if (internal.contains(key)) {
                 continue;
             }
@@ -148,7 +132,7 @@ public class PinPom implements BuildStep {
             String version = key.substring(lastSlash + 1);
             String checksum = computeChecksum(dependency.getValue(), hashFunction);
             String value = checksum == null ? version : version + " " + checksum;
-            entries.putIfAbsent(dependency.getValue().group(defaultGroup) + "/" + coordinate, value);
+            entries.putIfAbsent(group + "/" + coordinate, value);
         }
         return entries;
     }

--- a/sources/build/jenesis/maven/Pom.java
+++ b/sources/build/jenesis/maven/Pom.java
@@ -57,16 +57,10 @@ public class Pom implements BuildStep {
         SequencedProperties metadata = SequencedProperties.ofFolders(folders, METADATA);
         SequencedMap<String, SequencedSet<String>> coordinateScopes = new LinkedHashMap<>();
         for (String key : requires.stringPropertyNames()) {
-            if (resolved) {
-                int first = key.indexOf('/');
-                coordinateScopes.computeIfAbsent(key.substring(first + 1), _ -> new LinkedHashSet<>())
-                        .add(key.substring(0, first));
-            } else {
-                int first = key.indexOf('/');
-                int second = key.indexOf('/', first + 1);
-                coordinateScopes.computeIfAbsent(key.substring(second + 1), _ -> new LinkedHashSet<>())
-                        .add(key.substring(first + 1, second));
-            }
+            int first = key.indexOf('/');
+            int second = key.indexOf('/', first + 1);
+            coordinateScopes.computeIfAbsent(key.substring(second + 1), _ -> new LinkedHashSet<>())
+                    .add(key.substring(first + 1, second));
         }
         SequencedMap<String, String> coordinateExclusions = new LinkedHashMap<>();
         for (String key : exclusions.stringPropertyNames()) {

--- a/sources/build/jenesis/module/PinModuleInfo.java
+++ b/sources/build/jenesis/module/PinModuleInfo.java
@@ -15,26 +15,16 @@ public class PinModuleInfo implements BuildStep {
     private static final Pattern JAVADOC_END = Pattern.compile("\\*/\\s*$");
     private static final Pattern PIN_TAG = Pattern.compile("^\\s*\\*\\s*@jenesis\\.pin\\s+\\S+.*$");
 
-    private final String group;
     private final String prefix;
     private final String path;
     private final List<Path> moduleInfoFiles;
     private final transient HashDigestFunction hashFunction;
 
     public PinModuleInfo(String prefix, String path, Path moduleInfoFile, HashDigestFunction hashFunction) {
-        this("main", prefix, path, List.of(moduleInfoFile), hashFunction);
+        this(prefix, path, List.of(moduleInfoFile), hashFunction);
     }
 
     public PinModuleInfo(String prefix, String path, List<Path> moduleInfoFiles, HashDigestFunction hashFunction) {
-        this("main", prefix, path, moduleInfoFiles, hashFunction);
-    }
-
-    public PinModuleInfo(String group, String prefix, String path, Path moduleInfoFile, HashDigestFunction hashFunction) {
-        this(group, prefix, path, List.of(moduleInfoFile), hashFunction);
-    }
-
-    public PinModuleInfo(String group, String prefix, String path, List<Path> moduleInfoFiles, HashDigestFunction hashFunction) {
-        this.group = group;
         this.prefix = prefix;
         this.path = path;
         this.moduleInfoFiles = List.copyOf(moduleInfoFiles);
@@ -53,7 +43,7 @@ public class PinModuleInfo implements BuildStep {
             throws IOException {
         SequencedMap<String, Inventory.Dependency> closure = Inventory.closure(arguments.values(), path);
         Set<String> internal = collectInternal(Inventory.identities(arguments.values()));
-        SequencedMap<String, String> entries = collectEntries(closure, internal, hashFunction, group);
+        SequencedMap<String, String> entries = collectEntries(closure, internal, hashFunction);
         for (Path file : moduleInfoFiles) {
             updateModuleInfo(file, entries);
         }
@@ -87,22 +77,17 @@ public class PinModuleInfo implements BuildStep {
     static SequencedMap<String, String> collectEntries(SequencedMap<String, Inventory.Dependency> closure,
                                                        Set<String> internal,
                                                        HashDigestFunction hashFunction) throws IOException {
-        return collectEntries(closure, internal, hashFunction, "main");
-    }
-
-    static SequencedMap<String, String> collectEntries(SequencedMap<String, Inventory.Dependency> closure,
-                                                       Set<String> internal,
-                                                       HashDigestFunction hashFunction,
-                                                       String defaultGroup) throws IOException {
         Set<Path> hashedElsewhere = new HashSet<>();
         for (Map.Entry<String, Inventory.Dependency> dependency : closure.entrySet()) {
-            if (!dependency.getKey().startsWith("module/") && dependency.getValue().jar() != null) {
+            String coordinate = dependency.getKey().substring(dependency.getValue().group().length() + 1);
+            if (!coordinate.startsWith("module/") && dependency.getValue().jar() != null) {
                 hashedElsewhere.add(dependency.getValue().jar());
             }
         }
         SequencedMap<String, String> entries = new TreeMap<>();
         for (Map.Entry<String, Inventory.Dependency> dependency : closure.entrySet()) {
-            String key = dependency.getKey();
+            String group = dependency.getValue().group();
+            String key = dependency.getKey().substring(group.length() + 1);
             if (internal.contains(key)) {
                 continue;
             }
@@ -113,9 +98,8 @@ public class PinModuleInfo implements BuildStep {
             }
             String coordinate = key.substring(0, lastSlash);
             String version = key.substring(lastSlash + 1);
-            String group = dependency.getValue().group(defaultGroup);
-            boolean moduleRoot = group.equals(defaultGroup) && coordinate.startsWith("module/");
-            String mavenCoordinate = group.equals(defaultGroup) && coordinate.startsWith("maven/")
+            boolean moduleRoot = group.equals("main") && coordinate.startsWith("module/");
+            String mavenCoordinate = group.equals("main") && coordinate.startsWith("maven/")
                     ? coordinate.substring("maven/".length())
                     : null;
             boolean mavenShortcut = mavenCoordinate != null

--- a/sources/build/jenesis/project/DokkaDocumentationModule.java
+++ b/sources/build/jenesis/project/DokkaDocumentationModule.java
@@ -161,7 +161,7 @@ public class DokkaDocumentationModule implements BuildExecutorModule {
                 if (Files.exists(classes)) {
                     classpath.add(classes.toString());
                 }
-                for (Path jar : Dependencies.select(argument.folder(), qualifierTrail)) {
+                for (Path jar : Dependencies.select(argument.folder(), qualifierTrail, qualifierTrail)) {
                     jars.add(jar.toString());
                 }
                 for (Path jar : Dependencies.select(argument.folder(), "compile")) {

--- a/sources/build/jenesis/project/GroovyCompilerModule.java
+++ b/sources/build/jenesis/project/GroovyCompilerModule.java
@@ -173,7 +173,7 @@ public class GroovyCompilerModule implements BuildExecutorModule {
                 if (Files.exists(classes)) {
                     classpath.add(classes.toString());
                 }
-                for (Path jar : Dependencies.select(argument.folder(), qualifier)) {
+                for (Path jar : Dependencies.select(argument.folder(), qualifier, qualifier)) {
                     jars.add(jar.toString());
                 }
                 for (Path jar : Dependencies.select(argument.folder(), "compile")) {

--- a/sources/build/jenesis/project/GroovyDocumentationModule.java
+++ b/sources/build/jenesis/project/GroovyDocumentationModule.java
@@ -187,7 +187,7 @@ public class GroovyDocumentationModule implements BuildExecutorModule {
                 if (Files.exists(classes)) {
                     classpath.add(classes.toString());
                 }
-                for (Path jar : Dependencies.select(argument.folder(), qualifier)) {
+                for (Path jar : Dependencies.select(argument.folder(), qualifier, qualifier)) {
                     jars.add(jar.toString());
                 }
                 for (Path jar : Dependencies.select(argument.folder(), "compile")) {

--- a/sources/build/jenesis/project/KotlinCompilerModule.java
+++ b/sources/build/jenesis/project/KotlinCompilerModule.java
@@ -172,10 +172,10 @@ public class KotlinCompilerModule implements BuildExecutorModule {
                     plugins = new ArrayList<>();
             String release = null;
             for (BuildStepArgument argument : arguments.values()) {
-                for (Path jar : Dependencies.select(argument.folder(), qualifier)) {
+                for (Path jar : Dependencies.select(argument.folder(), qualifier, qualifier)) {
                     jars.add(jar.toString());
                 }
-                for (Path jar : Dependencies.select(argument.folder(), "plugin:" + qualifier)) {
+                for (Path jar : Dependencies.select(argument.folder(), "plugin:" + qualifier, "plugin:" + qualifier)) {
                     plugins.add(jar.toString());
                 }
                 for (Path jar : Dependencies.select(argument.folder(), "compile")) {

--- a/sources/build/jenesis/project/ScalaCompilerModule.java
+++ b/sources/build/jenesis/project/ScalaCompilerModule.java
@@ -172,10 +172,10 @@ public class ScalaCompilerModule implements BuildExecutorModule {
                     plugins = new ArrayList<>();
             String release = null;
             for (BuildStepArgument argument : arguments.values()) {
-                for (Path jar : Dependencies.select(argument.folder(), qualifier)) {
+                for (Path jar : Dependencies.select(argument.folder(), qualifier, qualifier)) {
                     jars.add(jar.toString());
                 }
-                for (Path jar : Dependencies.select(argument.folder(), "plugin:" + qualifier)) {
+                for (Path jar : Dependencies.select(argument.folder(), "plugin:" + qualifier, "plugin:" + qualifier)) {
                     plugins.add(jar.toString());
                 }
                 for (Path jar : Dependencies.select(argument.folder(), "compile")) {

--- a/sources/build/jenesis/project/ScalaDocumentationModule.java
+++ b/sources/build/jenesis/project/ScalaDocumentationModule.java
@@ -178,7 +178,7 @@ public class ScalaDocumentationModule implements BuildExecutorModule {
                 if (Files.exists(classes)) {
                     classRoots.add(classes.toString());
                 }
-                for (Path jar : Dependencies.select(argument.folder(), qualifier)) {
+                for (Path jar : Dependencies.select(argument.folder(), qualifier, qualifier)) {
                     jars.add(jar.toString());
                 }
                 for (Path jar : Dependencies.select(argument.folder(), "compile")) {

--- a/sources/build/jenesis/step/Dependencies.java
+++ b/sources/build/jenesis/step/Dependencies.java
@@ -173,7 +173,7 @@ public class Dependencies implements BuildStep {
                         String coordinate = entry.getKey().substring(entry.getKey().indexOf('/') + 1);
                         String declared = repoEntry.getValue().get(coordinate);
                         String value = declared != null && !declared.isEmpty() ? declared : entry.getValue().checksum();
-                        String transitiveKey = scope + "/" + entry.getKey();
+                        String transitiveKey = group + "/" + scope + "/" + entry.getKey();
                         resolved.setProperty(transitiveKey, value);
                         materialized.putIfAbsent(transitiveKey, entry.getValue());
                     }
@@ -190,7 +190,7 @@ public class Dependencies implements BuildStep {
             if (first < 0 || second < 0) {
                 continue;
             }
-            String dependency = key.substring(first + 1), name = dependency.replace('/', '-') + ".jar";
+            String dependency = key.substring(second + 1), name = dependency.replace('/', '-') + ".jar";
             Resolver.Resolved artifact = entry.getValue();
             String value = resolved.getProperty(key);
             Path file = placed.get(name);
@@ -238,15 +238,19 @@ public class Dependencies implements BuildStep {
     }
 
     public static List<Path> select(Path folder, String scope) throws IOException {
+        return select(folder, "main", scope);
+    }
+
+    public static List<Path> select(Path folder, String group, String scope) throws IOException {
         Path file = folder.resolve(BuildStep.DEPENDENCIES);
         if (!Files.exists(file)) {
             return List.of();
         }
         SequencedProperties properties = SequencedProperties.ofFiles(file);
         SequencedSet<Path> selected = new LinkedHashSet<>();
+        String prefix = group + "/" + scope + "/";
         for (String key : properties.stringPropertyNames()) {
-            int slash = key.indexOf('/');
-            if (slash > 0 && key.substring(0, slash).equals(scope)) {
+            if (key.startsWith(prefix)) {
                 String value = properties.getProperty(key);
                 int space = value.indexOf(' ');
                 Path jar = folder.resolve(space < 0 ? value : value.substring(0, space)).normalize();

--- a/sources/build/jenesis/step/Inventory.java
+++ b/sources/build/jenesis/step/Inventory.java
@@ -104,8 +104,9 @@ public class Inventory implements BuildStep {
         SequencedProperties inventory = new SequencedProperties();
         SequencedSet<Path> runtime = new LinkedHashSet<>(artifacts);
         for (Map.Entry<String, Path> entry : closureJars.entrySet()) {
+            String group = entry.getKey().substring(0, entry.getKey().indexOf('/'));
             String scope = closureScopes.get(entry.getKey());
-            if (scope != null && List.of(scope.split(",")).contains("runtime")) {
+            if (group.equals("main") && scope != null && List.of(scope.split(",")).contains("runtime")) {
                 runtime.add(entry.getValue());
             }
         }
@@ -115,14 +116,18 @@ public class Inventory implements BuildStep {
         }
         int dependencyIndex = 0;
         for (Map.Entry<String, Path> entry : closureJars.entrySet()) {
+            int slash = entry.getKey().indexOf('/');
+            String group = entry.getKey().substring(0, slash);
+            String coordinate = entry.getKey().substring(slash + 1);
             String checksum = closureChecksums.get(entry.getKey());
             inventory.setProperty(prefix + "dependency." + dependencyIndex,
-                    entry.getKey() + " " + relativize(context, entry.getValue())
+                    coordinate + " " + relativize(context, entry.getValue())
                             + (checksum == null || checksum.isEmpty() ? "" : " " + checksum));
             String scope = closureScopes.get(entry.getKey());
             if (scope != null) {
                 inventory.setProperty(prefix + "dependency." + dependencyIndex + ".scope", scope);
             }
+            inventory.setProperty(prefix + "dependency." + dependencyIndex + ".group", group);
             dependencyIndex++;
         }
         writePaths(inventory, context, prefix + "artifacts", artifacts);
@@ -176,10 +181,7 @@ public class Inventory implements BuildStep {
         return ((path == null || path.isEmpty()) ? "module" : "module-" + path) + ".";
     }
 
-    public record Dependency(Path jar, String checksum, String scope) {
-        public String group(String defaultGroup) {
-            return scope == null || scope.contains("compile") || scope.contains("runtime") ? defaultGroup : scope;
-        }
+    public record Dependency(Path jar, String checksum, String scope, String group) {
     }
 
     public static SequencedMap<String, Dependency> closure(Iterable<BuildStepArgument> arguments, String path) throws IOException {
@@ -197,10 +199,15 @@ public class Inventory implements BuildStep {
                     break;
                 }
                 String[] parts = value.split(" ", 3);
-                closure.putIfAbsent(parts[0], new Dependency(
+                String group = inventory.getProperty(key + index + ".group");
+                if (group == null) {
+                    group = "main";
+                }
+                closure.putIfAbsent(group + "/" + parts[0], new Dependency(
                         argument.folder().resolve(parts[1]).normalize(),
                         parts.length > 2 ? parts[2] : "",
-                        inventory.getProperty(key + index + ".scope")));
+                        inventory.getProperty(key + index + ".scope"),
+                        group));
             }
         }
         return closure;
@@ -277,8 +284,15 @@ public class Inventory implements BuildStep {
         }
         SequencedProperties index = SequencedProperties.ofFiles(indexFile);
         for (String key : index.stringPropertyNames()) {
-            int slash = key.indexOf('/');
-            String scope = key.substring(0, slash), coordinate = key.substring(slash + 1);
+            int firstSlash = key.indexOf('/');
+            int secondSlash = firstSlash < 0 ? -1 : key.indexOf('/', firstSlash + 1);
+            if (secondSlash < 0) {
+                continue;
+            }
+            String group = key.substring(0, firstSlash);
+            String scope = key.substring(firstSlash + 1, secondSlash);
+            String coordinate = key.substring(secondSlash + 1);
+            String entry = group + "/" + coordinate;
             String value = index.getProperty(key);
             int space = value.indexOf(' ');
             Path file = folder.resolve(space < 0 ? value : value.substring(0, space)).normalize();
@@ -286,14 +300,14 @@ public class Inventory implements BuildStep {
                 continue;
             }
             if (space >= 0) {
-                checksums.putIfAbsent(coordinate, value.substring(space + 1));
+                checksums.putIfAbsent(entry, value.substring(space + 1));
             }
-            jars.putIfAbsent(coordinate, file);
-            String prior = scopes.get(coordinate);
+            jars.putIfAbsent(entry, file);
+            String prior = scopes.get(entry);
             if (prior == null) {
-                scopes.put(coordinate, scope);
+                scopes.put(entry, scope);
             } else if (!List.of(prior.split(",")).contains(scope)) {
-                scopes.put(coordinate, prior + "," + scope);
+                scopes.put(entry, prior + "," + scope);
             }
         }
     }

--- a/sources/build/jenesis/step/Javac.java
+++ b/sources/build/jenesis/step/Javac.java
@@ -128,7 +128,7 @@ public class Javac extends JdkProcessBuildStep {
             for (Path jar : Dependencies.select(argument.folder(), "compile")) {
                 path.add(jar.toString());
             }
-            for (Path jar : Dependencies.select(argument.folder(), "plugin")) {
+            for (Path jar : Dependencies.select(argument.folder(), "plugin", "plugin")) {
                 processorPath.add(jar.toString());
             }
             Path sources = argument.folder().resolve(Bind.SOURCES),

--- a/tests/build/jenesis/test/maven/PinPomTest.java
+++ b/tests/build/jenesis/test/maven/PinPomTest.java
@@ -43,6 +43,7 @@ public class PinPomTest {
     }
 
     private void writeResolved(String scope, Map<String, String> entries) throws IOException {
+        String group = scope.equals("compile") || scope.equals("runtime") ? "main" : scope;
         SequencedProperties properties = loadInventory();
         int index = count(properties, "module.dependency.");
         for (Map.Entry<String, String> entry : entries.entrySet()) {
@@ -55,6 +56,7 @@ public class PinPomTest {
             properties.setProperty("module.dependency." + index,
                     coordinate + " " + jar + (checksum.isEmpty() ? "" : " " + checksum));
             properties.setProperty("module.dependency." + index + ".scope", scope);
+            properties.setProperty("module.dependency." + index + ".group", group);
             index++;
         }
         properties.store(input.resolve(Inventory.INVENTORY));

--- a/tests/build/jenesis/test/maven/PomTest.java
+++ b/tests/build/jenesis/test/maven/PomTest.java
@@ -89,6 +89,50 @@ public class PomTest {
     }
 
     @Test
+    public void emits_resolved_dependencies_under_their_group() throws IOException {
+        SequencedProperties coordinates = new SequencedProperties();
+        coordinates.setProperty("maven/build.jenesis/jenesis/jar/1.0.0", "");
+        coordinates.store(argument.resolve(BuildStep.IDENTITY));
+        SequencedProperties dependencies = new SequencedProperties();
+        dependencies.setProperty("main/compile/maven/org.example/lib/1.2.3", "");
+        dependencies.setProperty("main/runtime/maven/org.example/lib/1.2.3", "");
+        dependencies.setProperty("kotlin/kotlin/maven/org.example/compiler/2.0.0", "");
+        dependencies.store(argument.resolve(BuildStep.DEPENDENCIES));
+        SequencedProperties metadata = new SequencedProperties();
+        metadata.setProperty("project", "build.jenesis");
+        metadata.setProperty("artifact", "jenesis");
+        metadata.setProperty("version", "1.0.0");
+        metadata.store(argument.resolve(BuildStep.METADATA));
+        BuildStepResult result = new Pom().resolved(true).apply(Runnable::run,
+                        new BuildStepContext(previous, next, supplement),
+                        new LinkedHashMap<>(Map.of("argument", new BuildStepArgument(
+                                argument,
+                                Map.of(
+                                        Path.of(BuildStep.IDENTITY), ChecksumStatus.ADDED,
+                                        Path.of(BuildStep.DEPENDENCIES), ChecksumStatus.ADDED,
+                                        Path.of(BuildStep.METADATA), ChecksumStatus.ADDED)))))
+                .toCompletableFuture()
+                .join();
+        assertThat(result.next()).isTrue();
+        assertThat(Files.readString(next.resolve(Pom.POM))).isEqualTo("""
+                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>build.jenesis</groupId>
+                    <artifactId>jenesis</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.example</groupId>
+                            <artifactId>lib</artifactId>
+                            <version>1.2.3</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+    }
+
+    @Test
     public void compile_only_dependency_is_emitted_with_provided_scope() throws IOException {
         SequencedProperties coordinates = new SequencedProperties();
         coordinates.setProperty("maven/build.jenesis/jenesis/jar/1.0.0", "");

--- a/tests/build/jenesis/test/module/PinModuleInfoTest.java
+++ b/tests/build/jenesis/test/module/PinModuleInfoTest.java
@@ -43,6 +43,10 @@ public class PinModuleInfoTest {
     }
 
     private void writeResolved(String scope, Map<String, String> entries) throws IOException {
+        writeResolved(scope.equals("compile") || scope.equals("runtime") ? "main" : scope, scope, entries);
+    }
+
+    private void writeResolved(String group, String scope, Map<String, String> entries) throws IOException {
         SequencedProperties properties = loadInventory();
         int index = count(properties, "module.dependency.");
         for (Map.Entry<String, String> entry : entries.entrySet()) {
@@ -55,6 +59,7 @@ public class PinModuleInfoTest {
             properties.setProperty("module.dependency." + index,
                     coordinate + " " + jar + (checksum.isEmpty() ? "" : " " + checksum));
             properties.setProperty("module.dependency." + index + ".scope", scope);
+            properties.setProperty("module.dependency." + index + ".group", group);
             index++;
         }
         properties.store(input.resolve(Inventory.INVENTORY));
@@ -81,24 +86,16 @@ public class PinModuleInfoTest {
     }
 
     @Test
-    public void renders_default_group_dependencies_under_an_overridden_group() throws IOException {
+    public void renders_dependencies_under_their_resolved_group() throws IOException {
         Path file = root.resolve("module-info.java");
         Files.writeString(file, """
                 module foo {
                 }
                 """);
-        writeResolved(Map.of("maven/org.example/lib/tests", "1.0 SHA-256/cafebabe"));
-        new PinModuleInfo("tool", "module", "", file, new HashDigestFunction("SHA-256"))
-                .apply(Runnable::run,
-                        new BuildStepContext(previous, next, supplement),
-                        new LinkedHashMap<>(Map.of("input", new BuildStepArgument(
-                                input,
-                                Map.of(Path.of(Inventory.INVENTORY), ChecksumStatus.ADDED)))))
-                .toCompletableFuture()
-                .join();
-        String result = Files.readString(file);
-        assertThat(result).contains("@jenesis.pin tool/maven/org.example/lib/tests 1.0 SHA-256/cafebabe");
-        assertThat(result).doesNotContain("main/maven/org.example/lib/tests");
+        writeResolved("tool", "runtime", Map.of("maven/org.example/lib", "1.0 SHA-256/cafebabe"));
+        String result = run(file);
+        assertThat(result).contains("@jenesis.pin tool/maven/org.example/lib 1.0 SHA-256/cafebabe");
+        assertThat(result).doesNotContain("main/maven/org.example/lib");
     }
 
     @Test

--- a/tests/build/jenesis/test/project/KotlinCompilerModuleTest.java
+++ b/tests/build/jenesis/test/project/KotlinCompilerModuleTest.java
@@ -344,7 +344,7 @@ public class KotlinCompilerModuleTest {
         Path resolvedOutput = root.resolve("kotlin").resolve("dependencies").resolve("output");
         SequencedProperties requires = SequencedProperties.ofFiles(resolvedOutput.resolve(BuildStep.DEPENDENCIES));
         assertThat(requires.stringPropertyNames())
-                .containsExactly("kotlin/maven/org.jetbrains.kotlin/kotlin-compiler-embeddable/RELEASE");
+                .containsExactly("kotlin/kotlin/maven/org.jetbrains.kotlin/kotlin-compiler-embeddable/RELEASE");
     }
 
     @Test

--- a/tests/build/jenesis/test/project/ScalaDocumentationModuleTest.java
+++ b/tests/build/jenesis/test/project/ScalaDocumentationModuleTest.java
@@ -28,8 +28,8 @@ public class ScalaDocumentationModuleTest {
                 .createDirectories(input.resolve(BuildStep.SOURCES))
                 .resolve("Sample.scala"), "class Sample\n");
         SequencedProperties dependencies = new SequencedProperties();
-        dependencies.setProperty("scaladoc/local/scaladoc", "scaladoc.jar");
-        dependencies.setProperty("compile/local/compile", "compile.jar");
+        dependencies.setProperty("scaladoc/scaladoc/local/scaladoc", "scaladoc.jar");
+        dependencies.setProperty("main/compile/local/compile", "compile.jar");
         dependencies.store(input.resolve(BuildStep.DEPENDENCIES));
 
         List<String>[] captured = new List[1];

--- a/tests/build/jenesis/test/step/BundleTest.java
+++ b/tests/build/jenesis/test/step/BundleTest.java
@@ -31,7 +31,7 @@ public class BundleTest {
         writePlainJar(Files.createDirectory(input.resolve(BuildStep.ARTIFACTS)).resolve("app.jar"));
         writePlainJar(Files.createDirectory(input.resolve("resolved")).resolve("lib.jar"));
         SequencedProperties index = new SequencedProperties();
-        index.setProperty("runtime/maven/lib", "resolved/lib.jar");
+        index.setProperty("main/runtime/maven/lib", "resolved/lib.jar");
         index.store(input.resolve(BuildStep.DEPENDENCIES));
         SequencedProperties launcher = new SequencedProperties();
         launcher.setProperty("--main-jar", "app.jar");

--- a/tests/build/jenesis/test/step/DependenciesExecutionTest.java
+++ b/tests/build/jenesis/test/step/DependenciesExecutionTest.java
@@ -41,10 +41,10 @@ public class DependenciesExecutionTest {
         SequencedMap<String, Path> steps = buildExecutor.execute();
         assertThat(steps).containsKey("output");
         SequencedProperties resolved = SequencedProperties.ofFiles(steps.get("output").resolve(BuildStep.DEPENDENCIES));
-        assertThat(resolved.stringPropertyNames()).containsExactly("compile/foo/bar");
-        assertThat(resolved.getProperty("compile/foo/bar")).doesNotContain(" ");
+        assertThat(resolved.stringPropertyNames()).containsExactly("main/compile/foo/bar");
+        assertThat(resolved.getProperty("main/compile/foo/bar")).doesNotContain(" ");
         assertThat(steps.get("output")
-                .resolve(resolved.getProperty("compile/foo/bar"))).content().isEqualTo("bar");
+                .resolve(resolved.getProperty("main/compile/foo/bar"))).content().isEqualTo("bar");
     }
 
 }

--- a/tests/build/jenesis/test/step/DependenciesResolutionTest.java
+++ b/tests/build/jenesis/test/step/DependenciesResolutionTest.java
@@ -82,10 +82,10 @@ public class DependenciesResolutionTest {
                                 ChecksumStatus.ADDED))))).toCompletableFuture().join();
         assertThat(result.next()).isTrue();
         SequencedProperties dependencies = SequencedProperties.ofFiles(next.resolve(BuildStep.DEPENDENCIES));
-        assertThat(dependencies.stringPropertyNames()).containsExactlyInAnyOrder("compile/foo/qux",
-                "compile/foo/transitive/qux",
-                "compile/foo/baz",
-                "compile/foo/transitive/baz");
+        assertThat(dependencies.stringPropertyNames()).containsExactlyInAnyOrder("main/compile/foo/qux",
+                "main/compile/foo/transitive/qux",
+                "main/compile/foo/baz",
+                "main/compile/foo/transitive/baz");
         for (String property : dependencies.stringPropertyNames()) {
             assertThat(dependencies.getProperty(property)).doesNotContain("SHA");
         }
@@ -110,7 +110,7 @@ public class DependenciesResolutionTest {
                                 ChecksumStatus.ADDED))))).toCompletableFuture().join();
         assertThat(result.next()).isTrue();
         SequencedProperties resolved = SequencedProperties.ofFiles(next.resolve(BuildStep.DEPENDENCIES));
-        assertThat(resolved.stringPropertyNames()).containsExactly("plugin:kotlin/maven/org.jetbrains/something");
+        assertThat(resolved.stringPropertyNames()).containsExactly("plugin:kotlin/plugin:kotlin/maven/org.jetbrains/something");
     }
 
     @Test
@@ -136,14 +136,14 @@ public class DependenciesResolutionTest {
                                 ChecksumStatus.ADDED))))).toCompletableFuture().join();
         assertThat(result.next()).isTrue();
         SequencedProperties dependencies = SequencedProperties.ofFiles(next.resolve(BuildStep.DEPENDENCIES));
-        assertThat(dependencies.stringPropertyNames()).containsExactlyInAnyOrder("compile/foo/qux",
-                "compile/foo/transitive/qux",
-                "compile/foo/baz",
-                "compile/foo/transitive/baz");
-        assertThat(dependencies.getProperty("compile/foo/qux")).endsWith(" bar");
-        assertThat(dependencies.getProperty("compile/foo/transitive/qux")).doesNotContain("SHA");
-        assertThat(dependencies.getProperty("compile/foo/baz")).doesNotContain("SHA");
-        assertThat(dependencies.getProperty("compile/foo/transitive/baz")).doesNotContain("SHA");
+        assertThat(dependencies.stringPropertyNames()).containsExactlyInAnyOrder("main/compile/foo/qux",
+                "main/compile/foo/transitive/qux",
+                "main/compile/foo/baz",
+                "main/compile/foo/transitive/baz");
+        assertThat(dependencies.getProperty("main/compile/foo/qux")).endsWith(" bar");
+        assertThat(dependencies.getProperty("main/compile/foo/transitive/qux")).doesNotContain("SHA");
+        assertThat(dependencies.getProperty("main/compile/foo/baz")).doesNotContain("SHA");
+        assertThat(dependencies.getProperty("main/compile/foo/transitive/baz")).doesNotContain("SHA");
     }
 
     @Test
@@ -169,14 +169,14 @@ public class DependenciesResolutionTest {
                                 ChecksumStatus.ADDED))))).toCompletableFuture().join();
         assertThat(result.next()).isTrue();
         SequencedProperties dependencies = SequencedProperties.ofFiles(next.resolve(BuildStep.DEPENDENCIES));
-        assertThat(dependencies.stringPropertyNames()).containsExactlyInAnyOrder("compile/foo/qux",
-                "compile/foo/transitive/qux",
-                "compile/foo/baz",
-                "compile/foo/transitive/baz");
-        assertThat(dependencies.getProperty("compile/foo/qux")).endsWith(" bar");
-        assertThat(dependencies.getProperty("compile/foo/transitive/qux")).endsWith(" " + sha256("transitive/qux"));
-        assertThat(dependencies.getProperty("compile/foo/baz")).endsWith(" " + sha256("baz"));
-        assertThat(dependencies.getProperty("compile/foo/transitive/baz")).endsWith(" " + sha256("transitive/baz"));
+        assertThat(dependencies.stringPropertyNames()).containsExactlyInAnyOrder("main/compile/foo/qux",
+                "main/compile/foo/transitive/qux",
+                "main/compile/foo/baz",
+                "main/compile/foo/transitive/baz");
+        assertThat(dependencies.getProperty("main/compile/foo/qux")).endsWith(" bar");
+        assertThat(dependencies.getProperty("main/compile/foo/transitive/qux")).endsWith(" " + sha256("transitive/qux"));
+        assertThat(dependencies.getProperty("main/compile/foo/baz")).endsWith(" " + sha256("baz"));
+        assertThat(dependencies.getProperty("main/compile/foo/transitive/baz")).endsWith(" " + sha256("transitive/baz"));
     }
 
     @Test
@@ -208,7 +208,7 @@ public class DependenciesResolutionTest {
         assertThat(result.next()).isTrue();
         SequencedProperties dependencies = SequencedProperties.ofFiles(next.resolve(BuildStep.DEPENDENCIES));
         assertThat(dependencies.stringPropertyNames())
-                .containsExactlyInAnyOrder("compile/foo/lib/1.0", "runtime/foo/lib/1.0");
+                .containsExactlyInAnyOrder("main/compile/foo/lib/1.0", "main/runtime/foo/lib/1.0");
     }
 
     @Test
@@ -240,7 +240,7 @@ public class DependenciesResolutionTest {
         assertThat(result.next()).isTrue();
         SequencedProperties dependencies = SequencedProperties.ofFiles(next.resolve(BuildStep.DEPENDENCIES));
         assertThat(dependencies.stringPropertyNames())
-                .containsExactlyInAnyOrder("compile/foo/lib/1.0", "extra/foo/lib/1.0");
+                .containsExactlyInAnyOrder("custom/compile/foo/lib/1.0", "custom/extra/foo/lib/1.0");
     }
 
     @Test
@@ -273,7 +273,7 @@ public class DependenciesResolutionTest {
         assertThat(result.next()).isTrue();
         SequencedProperties dependencies = SequencedProperties.ofFiles(next.resolve(BuildStep.DEPENDENCIES));
         assertThat(dependencies.stringPropertyNames())
-                .containsExactlyInAnyOrder("compile/foo/lib/1.0", "extra/foo/lib/1.0", "extra/foo/lib/FLOAT");
+                .containsExactlyInAnyOrder("main/compile/foo/lib/1.0", "main/extra/foo/lib/1.0", "other/extra/foo/lib/FLOAT");
     }
 
     @Test
@@ -353,7 +353,7 @@ public class DependenciesResolutionTest {
                         Map.of(Path.of(BuildStep.REQUIRES), ChecksumStatus.ADDED))))).toCompletableFuture().join();
         assertThat(result.next()).isTrue();
         SequencedProperties index = SequencedProperties.ofFiles(next.resolve(BuildStep.DEPENDENCIES));
-        assertThat(index.getProperty("compile/foo/bar")).isEqualTo("resolved/bar.jar");
+        assertThat(index.getProperty("main/compile/foo/bar")).isEqualTo("resolved/bar.jar");
         assertThat(next.resolve("resolved/bar.jar")).content().isEqualTo("bar");
     }
 

--- a/tests/build/jenesis/test/step/DependenciesTest.java
+++ b/tests/build/jenesis/test/step/DependenciesTest.java
@@ -25,9 +25,9 @@ public class DependenciesTest {
         jar("libs/b.jar");
         jar("libs/c.jar");
         SequencedProperties index = new SequencedProperties();
-        index.setProperty("compile/maven/a", "libs/a.jar");
-        index.setProperty("runtime/maven/c", "libs/c.jar");
-        index.setProperty("compile/maven/b", "libs/b.jar");
+        index.setProperty("main/compile/maven/a", "libs/a.jar");
+        index.setProperty("main/runtime/maven/c", "libs/c.jar");
+        index.setProperty("main/compile/maven/b", "libs/b.jar");
         index.store(folder.resolve(BuildStep.DEPENDENCIES));
         assertThat(Dependencies.select(folder, "compile"))
                 .containsExactly(folder.resolve("libs/a.jar"), folder.resolve("libs/b.jar"));
@@ -44,8 +44,8 @@ public class DependenciesTest {
     public void skips_entries_whose_jar_is_missing() throws IOException {
         jar("libs/present.jar");
         SequencedProperties index = new SequencedProperties();
-        index.setProperty("compile/maven/present", "libs/present.jar");
-        index.setProperty("compile/maven/absent", "libs/absent.jar");
+        index.setProperty("main/compile/maven/present", "libs/present.jar");
+        index.setProperty("main/compile/maven/absent", "libs/absent.jar");
         index.store(folder.resolve(BuildStep.DEPENDENCIES));
         assertThat(Dependencies.select(folder, "compile"))
                 .containsExactly(folder.resolve("libs/present.jar"));
@@ -56,12 +56,12 @@ public class DependenciesTest {
         jar("libs/processor.jar");
         jar("libs/kotlin-plugin.jar");
         SequencedProperties index = new SequencedProperties();
-        index.setProperty("plugin/maven/processor", "libs/processor.jar");
-        index.setProperty("plugin:kotlin/maven/kotlin-plugin", "libs/kotlin-plugin.jar");
+        index.setProperty("plugin/plugin/maven/processor", "libs/processor.jar");
+        index.setProperty("plugin:kotlin/plugin:kotlin/maven/kotlin-plugin", "libs/kotlin-plugin.jar");
         index.store(folder.resolve(BuildStep.DEPENDENCIES));
-        assertThat(Dependencies.select(folder, "plugin"))
+        assertThat(Dependencies.select(folder, "plugin", "plugin"))
                 .containsExactly(folder.resolve("libs/processor.jar"));
-        assertThat(Dependencies.select(folder, "plugin:kotlin"))
+        assertThat(Dependencies.select(folder, "plugin:kotlin", "plugin:kotlin"))
                 .containsExactly(folder.resolve("libs/kotlin-plugin.jar"));
     }
 }

--- a/tests/build/jenesis/test/step/InventoryTest.java
+++ b/tests/build/jenesis/test/step/InventoryTest.java
@@ -48,7 +48,7 @@ public class InventoryTest {
         Path runtimeDeps = Files.createDirectory(runtime.resolve("dependencies"));
         Path lib = Files.writeString(runtimeDeps.resolve("maven-org.example-lib-1.0.jar"), "library");
         SequencedProperties runtimeIndex = new SequencedProperties();
-        runtimeIndex.setProperty("runtime/maven/org.example/lib/1.0", "dependencies/maven-org.example-lib-1.0.jar");
+        runtimeIndex.setProperty("main/runtime/maven/org.example/lib/1.0", "dependencies/maven-org.example-lib-1.0.jar");
         runtimeIndex.store(runtime.resolve(BuildStep.DEPENDENCIES));
 
         BuildStepResult result = run(args("manifests", manifests, "produce", produce, "runtime", runtime));
@@ -218,13 +218,13 @@ public class InventoryTest {
         Path firstDir = Files.createDirectory(firstDeps.resolve("dependencies"));
         Path libA = Files.writeString(firstDir.resolve("maven-org.example-a-1.0.jar"), "a");
         SequencedProperties firstIndex = new SequencedProperties();
-        firstIndex.setProperty("runtime/maven/org.example/a/1.0", "dependencies/maven-org.example-a-1.0.jar");
+        firstIndex.setProperty("main/runtime/maven/org.example/a/1.0", "dependencies/maven-org.example-a-1.0.jar");
         firstIndex.store(firstDeps.resolve(BuildStep.DEPENDENCIES));
         Path secondDeps = Files.createDirectory(root.resolve("second"));
         Path secondDir = Files.createDirectory(secondDeps.resolve("dependencies"));
         Path libB = Files.writeString(secondDir.resolve("maven-org.example-b-1.0.jar"), "b");
         SequencedProperties secondIndex = new SequencedProperties();
-        secondIndex.setProperty("runtime/maven/org.example/b/1.0", "dependencies/maven-org.example-b-1.0.jar");
+        secondIndex.setProperty("main/runtime/maven/org.example/b/1.0", "dependencies/maven-org.example-b-1.0.jar");
         secondIndex.store(secondDeps.resolve(BuildStep.DEPENDENCIES));
 
         run(args("manifests", manifests, "first", firstDeps, "second", secondDeps));

--- a/tests/build/jenesis/test/step/JPackageTest.java
+++ b/tests/build/jenesis/test/step/JPackageTest.java
@@ -160,7 +160,7 @@ public class JPackageTest {
         Files.writeString(Files.createDirectory(bundle.resolve(BuildStep.ARTIFACTS)).resolve("app.jar"), "one");
         Files.writeString(Files.createDirectory(bundle.resolve("resolved")).resolve("app.jar"), "two");
         SequencedProperties index = new SequencedProperties();
-        index.setProperty("runtime/maven/app", "resolved/app.jar");
+        index.setProperty("main/runtime/maven/app", "resolved/app.jar");
         index.store(bundle.resolve(BuildStep.DEPENDENCIES));
         SequencedProperties configuration = new SequencedProperties();
         configuration.setProperty("--main-jar", "app.jar");

--- a/tests/build/jenesis/test/step/JavacTest.java
+++ b/tests/build/jenesis/test/step/JavacTest.java
@@ -411,7 +411,7 @@ public class JavacTest {
         Path jar = buildProcessorJar(Files.createDirectories(root.resolve("procbuild")), "one", "One", null);
         Files.copy(jar, Files.createDirectories(processorRoot.resolve("resolved")).resolve("processor.jar"));
         SequencedProperties index = new SequencedProperties();
-        index.setProperty("plugin/maven/processor", "resolved/processor.jar");
+        index.setProperty("plugin/plugin/maven/processor", "resolved/processor.jar");
         index.store(processorRoot.resolve(BuildStep.DEPENDENCIES));
 
         SequencedMap<String, BuildStepArgument> arguments = new LinkedHashMap<>();
@@ -448,8 +448,8 @@ public class JavacTest {
         Files.copy(buildProcessorJar(Files.createDirectories(root.resolve("modular")), "modular", "Modular", "proc.modular"),
                 processorRoot.resolve("modular.jar"));
         SequencedProperties index = new SequencedProperties();
-        index.setProperty("plugin/maven/plain", "resolved/plain.jar");
-        index.setProperty("plugin/maven/modular", "resolved/modular.jar");
+        index.setProperty("plugin/plugin/maven/plain", "resolved/plain.jar");
+        index.setProperty("plugin/plugin/maven/modular", "resolved/modular.jar");
         index.store(root.resolve("processor").resolve(BuildStep.DEPENDENCIES));
 
         SequencedMap<String, BuildStepArgument> arguments = new LinkedHashMap<>();


### PR DESCRIPTION
## Summary

The resolved index (`dependencies.properties`) dropped the resolver group, so a coordinate that appears in **both** the main closure and a tool closure (compiler, plugin, documentation) collapsed into one entry. This PR keys the index by `<group>/<scope>/<repository>/<coordinate>` and updates every consumer.

## Changes

- **`Dependencies`**: `select` gains a `group` parameter defaulting to `main`; the index writer preserves the group, as does `Inventory` (closure + per-dependency entries, with the runtime set and the bare/maven pin shortcuts kept to the main group).
- **`Pom`**: now reads the group-prefixed index when emitting a resolved POM. It previously read the group as the scope, failed the `compile`/`runtime` check, and emitted a **dependency-less POM**, which left modular libraries without their transitive dependencies for downstream consumers (e.g. a multi-module reactor where a sibling re-exports an external module).
- **Compiler / documentation modules**: select their tooling under the tool group; annotation processors select under the `plugin` group.
- **Demos**: re-pinned where a tool closure shares a coordinate with the main closure (immutables as both a compile dependency and an annotation processor; the Kotlin compiler's transitive `annotations`). These now receive their own group-qualified pins.

## Verification

- `mvn test`: 891 pass (includes a new `Pom` regression test for the resolved/group-prefixed path).
- Modular self-build (`pin`): green, zero pin drift.
- All 22 demos build green; pin drift limited to the three correct group-qualified additions above, each verified idempotent and green under strict pinning.