### PR TITLE
Let a build module define its own dependency group

### DIFF
--- a/demo/demo-16-internal-module/build/Demo.java
+++ b/demo/demo-16-internal-module/build/Demo.java
@@ -67,7 +67,7 @@ public class Demo {
             return (sub, inherited) -> {
                 InternalModule preprocess = new InternalModule(
                         "module",                           // resolution prefix for the plugin's requires
-                        "tool",                             // namespacing qualifier (currently unused)
+                        "tool",                             // dependency group for the plugin's resolved closure
                         pluginSource);
                 // Forward the project's sources (to preprocess) and its manifests (the
                 // pin map): InternalModule reads the pins from the manifests and

--- a/demo/demo-16-internal-module/sources/module-info.java
+++ b/demo/demo-16-internal-module/sources/module-info.java
@@ -1,7 +1,7 @@
 /**
  * @jenesis.main sample.Sample
- * @jenesis.pin build.jenesis 0.3.0 SHA-256/ce18b55b265ab1887cf1cb1595afab61f6e8ae312d517f7af44284a1022b0188
- * @jenesis.pin org.json 20251224 SHA-256/2a3438fbf9293174ea82bdfa35e83d8b965cfe6bddc034a1ac5d60107174c209
+ * @jenesis.pin tool/module/build.jenesis 0.3.0 SHA-256/ce18b55b265ab1887cf1cb1595afab61f6e8ae312d517f7af44284a1022b0188
+ * @jenesis.pin tool/module/org.json 20260522 SHA-256/d671b45e5954211f3566722aa614fbd3b5d46e95f4f9da4dc58c173280bb1799
  */
 module demo.internal {
     exports sample;

--- a/demo/demo-17-external-module/build/Demo.java
+++ b/demo/demo-17-external-module/build/Demo.java
@@ -99,7 +99,7 @@ public class Demo {
             return (sub, inherited) -> {
                 ExternalModule preprocess = new ExternalModule(
                         "module/demo.plugin",               // the coordinate to resolve
-                        "tool",                             // namespacing qualifier (currently unused)
+                        "tool",                             // dependency group for the plugin's resolved closure
                         pluginRepositories,
                         pluginResolvers);
                 // Forward the project's sources (to preprocess) and its manifests (the

--- a/demo/demo-17-external-module/sources/module-info.java
+++ b/demo/demo-17-external-module/sources/module-info.java
@@ -1,7 +1,8 @@
 /**
  * @jenesis.main sample.Sample
- * @jenesis.pin build.jenesis 0.3.0 SHA-256/ce18b55b265ab1887cf1cb1595afab61f6e8ae312d517f7af44284a1022b0188
- * @jenesis.pin org.json 20251224 SHA-256/2a3438fbf9293174ea82bdfa35e83d8b965cfe6bddc034a1ac5d60107174c209
+ * @jenesis.pin tool/module/build.jenesis 0.3.0 SHA-256/ce18b55b265ab1887cf1cb1595afab61f6e8ae312d517f7af44284a1022b0188
+ * @jenesis.pin tool/module/demo.plugin 1 SHA-256/4729836add3d5d516662b2c9a2387c897090a1d5265d539b27a2e2600188d1c2
+ * @jenesis.pin tool/module/org.json 20260522 SHA-256/d671b45e5954211f3566722aa614fbd3b5d46e95f4f9da4dc58c173280bb1799
  */
 module demo.internal {
     exports sample;

--- a/sources/build/jenesis/project/ExternalModule.java
+++ b/sources/build/jenesis/project/ExternalModule.java
@@ -22,15 +22,14 @@ public class ExternalModule implements BuildExecutorModule {
     private final Map<String, Resolver> resolvers;
     private final SequencedSet<String> additionalDependencies;
     private final String buildModuleName;
-    private final String qualifier;
     private final Pinning pinning;
     private final String group;
 
     public ExternalModule(String coordinate,
-                          String qualifier,
+                          String group,
                           Map<String, Repository> repositories,
                           Map<String, Resolver> resolvers) {
-        this(coordinate, repositories, resolvers, Collections.emptyNavigableSet(), null, qualifier, null, "main");
+        this(coordinate, repositories, resolvers, Collections.emptyNavigableSet(), null, null, group == null ? "main" : group);
     }
 
     private ExternalModule(String coordinate,
@@ -38,7 +37,6 @@ public class ExternalModule implements BuildExecutorModule {
                            Map<String, Resolver> resolvers,
                            SequencedSet<String> additionalDependencies,
                            String buildModuleName,
-                           String qualifier,
                            Pinning pinning,
                            String group) {
         this.coordinate = coordinate;
@@ -46,7 +44,6 @@ public class ExternalModule implements BuildExecutorModule {
         this.resolvers = resolvers;
         this.additionalDependencies = additionalDependencies;
         this.buildModuleName = buildModuleName;
-        this.qualifier = qualifier;
         this.pinning = pinning;
         this.group = group;
     }
@@ -61,7 +58,6 @@ public class ExternalModule implements BuildExecutorModule {
                 resolvers,
                 dependencies,
                 buildModuleName,
-                qualifier,
                 pinning,
                 group);
     }
@@ -72,7 +68,6 @@ public class ExternalModule implements BuildExecutorModule {
                 resolvers,
                 additionalDependencies,
                 name,
-                qualifier,
                 pinning,
                 group);
     }
@@ -83,7 +78,6 @@ public class ExternalModule implements BuildExecutorModule {
                 resolvers,
                 additionalDependencies,
                 buildModuleName,
-                qualifier,
                 pinning,
                 group);
     }
@@ -94,7 +88,6 @@ public class ExternalModule implements BuildExecutorModule {
                 resolvers,
                 additionalDependencies,
                 buildModuleName,
-                qualifier,
                 pinning,
                 group);
     }
@@ -127,7 +120,7 @@ public class ExternalModule implements BuildExecutorModule {
                 COORDINATE);
         buildExecutor.addModule(DELEGATE, (delegateExecutor, delegated) -> {
             List<Path> artifacts = new ArrayList<>(
-                    Dependencies.select(delegated.get(PREVIOUS + DEPENDENCIES), "runtime"));
+                    Dependencies.select(delegated.get(PREVIOUS + DEPENDENCIES), group, "runtime"));
             artifacts.sort(null);
             JenesisClassLoaderBridge bridge;
             Object foreignModule;

--- a/sources/build/jenesis/project/InternalModule.java
+++ b/sources/build/jenesis/project/InternalModule.java
@@ -33,12 +33,11 @@ public class InternalModule implements BuildExecutorModule {
     private final Map<String, Resolver> resolvers;
     private final SequencedSet<String> additionalDependencies;
     private final String buildModuleName;
-    private final String qualifier;
     private final Pinning pinning;
     private final String group;
 
     public InternalModule(String prefix,
-                          String qualifier,
+                          String group,
                           Path source) {
         this(prefix,
                 source,
@@ -46,21 +45,20 @@ public class InternalModule implements BuildExecutorModule {
                 Map.of(prefix, new ModularJarResolver(true)),
                 Collections.emptyNavigableSet(),
                 null,
-                qualifier,
                 null,
-                "main");
+                group == null ? "main" : group);
     }
 
     public InternalModule repositories(Map<String, Repository> repositories) {
-        return new InternalModule(prefix, source, repositories, resolvers, additionalDependencies, buildModuleName, qualifier, pinning, group);
+        return new InternalModule(prefix, source, repositories, resolvers, additionalDependencies, buildModuleName, pinning, group);
     }
 
     public InternalModule resolvers(Map<String, Resolver> resolvers) {
-        return new InternalModule(prefix, source, repositories, resolvers, additionalDependencies, buildModuleName, qualifier, pinning, group);
+        return new InternalModule(prefix, source, repositories, resolvers, additionalDependencies, buildModuleName, pinning, group);
     }
 
     public InternalModule group(String group) {
-        return new InternalModule(prefix, source, repositories, resolvers, additionalDependencies, buildModuleName, qualifier, pinning, group);
+        return new InternalModule(prefix, source, repositories, resolvers, additionalDependencies, buildModuleName, pinning, group);
     }
 
     private InternalModule(String prefix,
@@ -69,7 +67,6 @@ public class InternalModule implements BuildExecutorModule {
                            Map<String, Resolver> resolvers,
                            SequencedSet<String> additionalDependencies,
                            String buildModuleName,
-                           String qualifier,
                            Pinning pinning,
                            String group) {
         this.prefix = prefix;
@@ -78,7 +75,6 @@ public class InternalModule implements BuildExecutorModule {
         this.resolvers = resolvers;
         this.additionalDependencies = additionalDependencies;
         this.buildModuleName = buildModuleName;
-        this.qualifier = qualifier;
         this.pinning = pinning;
         this.group = group;
     }
@@ -90,7 +86,6 @@ public class InternalModule implements BuildExecutorModule {
                 resolvers,
                 new LinkedHashSet<>(List.of(dependencies)),
                 buildModuleName,
-                qualifier,
                 pinning,
                 group);
     }
@@ -102,7 +97,6 @@ public class InternalModule implements BuildExecutorModule {
                 resolvers,
                 new LinkedHashSet<>(dependencies),
                 buildModuleName,
-                qualifier,
                 pinning,
                 group);
     }
@@ -114,7 +108,6 @@ public class InternalModule implements BuildExecutorModule {
                 resolvers,
                 additionalDependencies,
                 name,
-                qualifier,
                 pinning,
                 group);
     }
@@ -126,7 +119,6 @@ public class InternalModule implements BuildExecutorModule {
                 resolvers,
                 additionalDependencies,
                 buildModuleName,
-                qualifier,
                 pinning,
                 group);
     }
@@ -154,7 +146,7 @@ public class InternalModule implements BuildExecutorModule {
         buildExecutor.addStep(DEPENDENCIES,
                 new Dependencies(repositories, resolvers).pinning(pinning),
                 REQUIRES);
-        buildExecutor.addModule(JAVA, new JavaToolchainModule(), SOURCE, DEPENDENCIES);
+        buildExecutor.addModule(JAVA, new JavaToolchainModule().group(group), SOURCE, DEPENDENCIES);
         buildExecutor.addModule(DELEGATE, (delegateExecutor, delegated) -> {
             Path mainArtifacts = delegated.get(PREVIOUS + MAIN_ARTIFACTS).resolve(BuildStep.ARTIFACTS);
             List<Path> artifacts = new ArrayList<>();
@@ -163,7 +155,7 @@ public class InternalModule implements BuildExecutorModule {
                     artifacts.add(file);
                 }
             }
-            artifacts.addAll(Dependencies.select(delegated.get(PREVIOUS + DEPENDENCIES), "runtime"));
+            artifacts.addAll(Dependencies.select(delegated.get(PREVIOUS + DEPENDENCIES), group, "runtime"));
             artifacts.sort(null);
             JenesisClassLoaderBridge bridge;
             Object foreignModule;

--- a/sources/build/jenesis/project/JavaToolchainModule.java
+++ b/sources/build/jenesis/project/JavaToolchainModule.java
@@ -24,6 +24,10 @@ public record JavaToolchainModule(BuildExecutorModule compiler,
         return new JavaToolchainModule(compiler, transformer, validator, archiver);
     }
 
+    public JavaToolchainModule group(String group) {
+        return compiler(new Javac(ProcessHandler.Factory.of()).group(group).asModule("javac"));
+    }
+
     public JavaToolchainModule archiver(BuildExecutorModule archiver) {
         return new JavaToolchainModule(compiler, transformer, validator, archiver);
     }

--- a/sources/build/jenesis/step/Javac.java
+++ b/sources/build/jenesis/step/Javac.java
@@ -16,17 +16,20 @@ public class Javac extends JdkProcessBuildStep {
 
     private final boolean includeResources;
     private final PathPlacement placement;
+    private final String group;
 
     public Javac(ProcessHandler.Factory factory) {
-        this(factory.apply("javac", "bin/javac"), true, PathPlacement.INFERRED);
+        this(factory.apply("javac", "bin/javac"), true, PathPlacement.INFERRED, "main");
     }
 
     private Javac(Function<List<String>, ? extends ProcessHandler> factory,
                   boolean includeResources,
-                  PathPlacement placement) {
+                  PathPlacement placement,
+                  String group) {
         super("javac", factory);
         this.includeResources = includeResources;
         this.placement = placement;
+        this.group = group;
     }
 
     public static void writeRelease(Path folder, String release) throws IOException {
@@ -40,11 +43,15 @@ public class Javac extends JdkProcessBuildStep {
     }
 
     public Javac includeResources(boolean includeResources) {
-        return new Javac(factory, includeResources, placement);
+        return new Javac(factory, includeResources, placement, group);
     }
 
     public Javac modulePath(PathPlacement placement) {
-        return new Javac(factory, includeResources, placement);
+        return new Javac(factory, includeResources, placement, group);
+    }
+
+    public Javac group(String group) {
+        return new Javac(factory, includeResources, placement, group);
     }
 
     @Override
@@ -125,7 +132,7 @@ public class Javac extends JdkProcessBuildStep {
                 siblingClasses = new ArrayList<>(),
                 commands = new ArrayList<>(List.of("-d", target.toString()));
         for (BuildStepArgument argument : arguments.values()) {
-            for (Path jar : Dependencies.select(argument.folder(), "compile")) {
+            for (Path jar : Dependencies.select(argument.folder(), group, "compile")) {
                 path.add(jar.toString());
             }
             for (Path jar : Dependencies.select(argument.folder(), "plugin", "plugin")) {
@@ -236,7 +243,7 @@ public class Javac extends JdkProcessBuildStep {
             if (Files.exists(classes)) {
                 dependencyPath.add(classes.toString());
             }
-            for (Path jar : Dependencies.select(argument.folder(), "compile")) {
+            for (Path jar : Dependencies.select(argument.folder(), group, "compile")) {
                 dependencyPath.add(jar.toString());
             }
             Path sources = argument.folder().resolve(Bind.SOURCES);


### PR DESCRIPTION
## Summary

Stacked on #17. A build plugin loaded via `InternalModule`/`ExternalModule` resolved its closure (`build.jenesis`, `org.json`, ...) under the `main` group, so its dependencies were indistinguishable from the project's own in the generated pins. This lets a build module declare its own group (demo-16/17 use `"tool"`), distinguishing its resolved closure in the pin step - the design the maintainer described.

## Changes

- The `qualifier` field on `InternalModule`/`ExternalModule` was stored but never used; it becomes the **group** (the public constructor's second argument). A `null` value still defaults to `"main"`, so every existing call site (and all tests) keep main-group behavior unchanged.
- `Javac` gains a `group` parameter (default `"main"`) for its compile-classpath selection; `JavaToolchainModule.group(...)` configures its default compiler so a build module compiles against its own group's dependencies.
- The internal/external runtime classpath selects read the build module's group instead of assuming `"main"`.
- demo-16/17 re-pinned under `tool/` (`build.jenesis 0.3.0` unchanged, just group-qualified; the external module additionally pins its staged `demo.plugin` coordinate).

## Verification

- `mvn test`: 891 pass (zero Internal/External test churn - the null→main default preserves their behavior).
- Modular self-build (`pin`): green, zero pin drift.
- demo-16/17 build green via their CI commands (demo-16 also strict-green; demo-17 strict remains the pre-existing documented limitation around the maven `build.jenesis` coordinate).
- The `Javac` change is a no-op at `group="main"`, so the non-plugin demos are unaffected.