### PR TITLE
Add inferred code-quality tool plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,27 @@ Two callbacks govern how the build is assembled, and they are pluggable independ
   The chain is best-effort: every tool tolerates a non-zero exit so a documentation tool that fails never fails the
   build, and `aggregate` always guarantees a root `index.html` (linking to any per-language subfolders that
   rendered) so the produced `-javadoc.jar`, a Maven Central prerequisite, is never empty.
+- The **inferred code-quality chains** bring the same zero-config activation to static-analysis and formatting
+  tools, split by what they inspect. `InferredByteCodeQualityModule` covers tools that read compiled **class
+  files** (SpotBugs), and `InferredSourceCodeQualityModule` covers tools that read **source files** (Checkstyle,
+  PMD, detekt, ktlint, Scalastyle, scalafmt, CodeNarc). Activation is **config-file-only**: a tool is wired if,
+  and only if, its conventional configuration file is present in the project. Each module checks its inherited
+  input folders for the trigger file, so no extra wiring or source-tree knowledge is needed. The triggers are
+  `spotbugs-exclude.xml` (or `spotbugs.xml`) for SpotBugs, `checkstyle.xml` for Checkstyle, `pmd.xml` for PMD,
+  `detekt.yml` for detekt, `.editorconfig` for ktlint, `scalastyle-config.xml` for Scalastyle, `.scalafmt.conf`
+  for scalafmt, and `codenarc.xml` for CodeNarc. Like the compilers, each tool resolves in its **own dependency
+  group** (named after the tool) so its runtime never mixes with the project's compile classpath, floats
+  `RELEASE` (pinnable through the usual `@jenesis.pin` tags), and runs in a forked JVM against the compiled
+  `classes/` or the bound `sources/`. Each tool **writes its report and does not fail the build by default**
+  (report-only); calling `.strict()` on a tool makes a non-zero tool exit fail the build, gated through
+  `acceptableExitCode`. A tool whose language is absent self-skips (detekt does nothing when a project has no
+  `.kt` sources), so an unrelated trigger file never forces analysis. Each tool is a self-contained
+  `BuildExecutorModule` following the compiler-module shape (`required` -> `dependencies` -> `check`). Wiring
+  these chains into the default layouts is deferred; today they are added explicitly in a build script or
+  exercised directly in tests. Java source formatting (Spotless, google-java-format) is intentionally left out
+  for now because neither exposes a project-root configuration file to infer from. The detekt runner targets the
+  1.x main class (`io.gitlab.arturbosch.detekt.cli.Main`); detekt 2.x relocates it to `dev.detekt.cli.Main`, so
+  the floated `RELEASE` and runner main class want confirming against the resolved jar.
 
 Layouts always combine their built-in repositories and resolvers (e.g. a Maven default for `MAVEN`, a chained
 Jenesis module repository for `MODULAR`) with any user-provided ones. The merged map then has each sub-module's `assign`

--- a/sources/build/jenesis/maven/MavenPomResolver.java
+++ b/sources/build/jenesis/maven/MavenPomResolver.java
@@ -953,7 +953,9 @@ public class MavenPomResolver implements MavenResolver {
                     replacement = System.getProperty(property);
                 }
                 if (replacement == null) {
-                    throw new IllegalStateException("Property not defined: " + property);
+                    // Maven leaves an undefined property as a literal rather than failing model assembly;
+                    // it only errors if the value is actually used to fetch an artifact.
+                    matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group()));
                 } else {
                     HashSet<String> duplicates = new HashSet<>(previous);
                     if (!duplicates.add(property)) {

--- a/sources/build/jenesis/project/CheckstyleModule.java
+++ b/sources/build/jenesis/project/CheckstyleModule.java
@@ -30,10 +30,9 @@ public class CheckstyleModule implements BuildExecutorModule {
     private final String group;
     private final String configFile;
     private final boolean strict;
-    private final transient Function<List<String>, ? extends ProcessHandler> factory;
 
     public CheckstyleModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
-        this(repositories, resolvers, null, "checkstyle", "checkstyle.xml", false, null);
+        this(repositories, resolvers, null, "checkstyle", "checkstyle.xml", false);
     }
 
     private CheckstyleModule(Map<String, Repository> repositories,
@@ -41,55 +40,53 @@ public class CheckstyleModule implements BuildExecutorModule {
                              Pinning pinning,
                              String group,
                              String configFile,
-                             boolean strict,
-                             Function<List<String>, ? extends ProcessHandler> factory) {
+                             boolean strict) {
         this.repositories = repositories;
         this.resolvers = resolvers;
         this.pinning = pinning;
         this.group = group;
         this.configFile = configFile;
         this.strict = strict;
-        this.factory = factory;
+    }
+
+    public static boolean isConfigured(SequencedMap<String, Path> inherited) {
+        for (Path folder : inherited.values()) {
+            if (Files.isRegularFile(folder.resolve("checkstyle.xml"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public CheckstyleModule pinning(Pinning pinning) {
-        return new CheckstyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new CheckstyleModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public CheckstyleModule group(String group) {
-        return new CheckstyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new CheckstyleModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public CheckstyleModule configFile(String configFile) {
-        return new CheckstyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new CheckstyleModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public CheckstyleModule strict(boolean strict) {
-        return new CheckstyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
-    }
-
-    public CheckstyleModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
-        return new CheckstyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new CheckstyleModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     @Override
     public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
-        SequencedSet<String> upstream = inherited.sequencedKeySet();
-        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        buildExecutor.addStep(REQUIRED, new Requires(group), inherited.sequencedKeySet());
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(REQUIRED);
-        resolveInputs.addAll(upstream);
+        resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
                 new Dependencies(repositories, resolvers).pinning(pinning),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);
-        checkInputs.addAll(upstream);
-        buildExecutor.addStep(CHECK,
-                factory == null
-                        ? new Check(group, configFile, strict)
-                        : new Check(group, configFile, strict, factory),
-                checkInputs);
+        checkInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(CHECK, new Check(group, configFile, strict), checkInputs);
     }
 
     private record Requires(String group) implements BuildStep {
@@ -118,14 +115,7 @@ public class CheckstyleModule implements BuildExecutorModule {
         private final boolean strict;
 
         private Check(String group, String configFile, boolean strict) {
-            this(group, configFile, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
-        }
-
-        private Check(String group,
-                      String configFile,
-                      boolean strict,
-                      Function<List<String>, ? extends ProcessHandler> factory) {
-            super("checkstyle", factory);
+            super("checkstyle", ProcessHandler.OfProcess.ofJavaHome("bin/java"));
             this.group = group;
             this.configFile = configFile;
             this.strict = strict;

--- a/sources/build/jenesis/project/CheckstyleModule.java
+++ b/sources/build/jenesis/project/CheckstyleModule.java
@@ -1,0 +1,193 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Bind;
+import build.jenesis.step.Dependencies;
+import build.jenesis.step.JdkProcessBuildStep;
+import build.jenesis.step.ProcessHandler;
+
+public class CheckstyleModule implements BuildExecutorModule {
+
+    public static final String CHECK = "check";
+    private static final String REQUIRED = "required", DEPENDENCIES = "dependencies";
+
+    private static final String MAVEN_GROUP = "com.puppycrawl.tools";
+    private static final String MAVEN_ARTIFACT = "checkstyle";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String group;
+    private final String configFile;
+    private final boolean strict;
+    private final transient Function<List<String>, ? extends ProcessHandler> factory;
+
+    public CheckstyleModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "checkstyle", "checkstyle.xml", false, null);
+    }
+
+    private CheckstyleModule(Map<String, Repository> repositories,
+                             Map<String, Resolver> resolvers,
+                             Pinning pinning,
+                             String group,
+                             String configFile,
+                             boolean strict,
+                             Function<List<String>, ? extends ProcessHandler> factory) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.group = group;
+        this.configFile = configFile;
+        this.strict = strict;
+        this.factory = factory;
+    }
+
+    public CheckstyleModule pinning(Pinning pinning) {
+        return new CheckstyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public CheckstyleModule group(String group) {
+        return new CheckstyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public CheckstyleModule configFile(String configFile) {
+        return new CheckstyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public CheckstyleModule strict(boolean strict) {
+        return new CheckstyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public CheckstyleModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
+        return new CheckstyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        SequencedSet<String> upstream = inherited.sequencedKeySet();
+        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(upstream);
+        buildExecutor.addStep(DEPENDENCIES,
+                new Dependencies(repositories, resolvers).pinning(pinning),
+                resolveInputs);
+        SequencedSet<String> checkInputs = new LinkedHashSet<>();
+        checkInputs.add(DEPENDENCIES);
+        checkInputs.addAll(upstream);
+        buildExecutor.addStep(CHECK,
+                factory == null
+                        ? new Check(group, configFile, strict)
+                        : new Check(group, configFile, strict, factory),
+                checkInputs);
+    }
+
+    private record Requires(String group) implements BuildStep {
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return false;
+        }
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(group + "/runtime/maven/" + MAVEN_GROUP + "/" + MAVEN_ARTIFACT + "/RELEASE", "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private static class Check extends JdkProcessBuildStep {
+
+        private final String group;
+        private final String configFile;
+        private final boolean strict;
+
+        private Check(String group, String configFile, boolean strict) {
+            this(group, configFile, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
+        }
+
+        private Check(String group,
+                      String configFile,
+                      boolean strict,
+                      Function<List<String>, ? extends ProcessHandler> factory) {
+            super("checkstyle", factory);
+            this.group = group;
+            this.configFile = configFile;
+            this.strict = strict;
+        }
+
+        @Override
+        public boolean acceptableExitCode(int code,
+                                          Executor executor,
+                                          BuildStepContext context,
+                                          SequencedMap<String, BuildStepArgument> arguments) {
+            return !strict || code == 0;
+        }
+
+        @Override
+        public CompletionStage<List<String>> process(Executor executor,
+                                                     BuildStepContext context,
+                                                     SequencedMap<String, BuildStepArgument> arguments,
+                                                     SequencedMap<String, SequencedMap<String, String>> properties)
+                throws IOException {
+            List<String> jars = new ArrayList<>(), files = new ArrayList<>();
+            Path config = null;
+            for (BuildStepArgument argument : arguments.values()) {
+                for (Path jar : Dependencies.select(argument.folder(), group, "runtime")) {
+                    jars.add(jar.toString());
+                }
+                Path candidate = argument.folder().resolve(configFile);
+                if (Files.isRegularFile(candidate)) {
+                    config = candidate;
+                }
+                Path sources = argument.folder().resolve(Bind.SOURCES);
+                if (Files.exists(sources)) {
+                    Files.walkFileTree(sources, new SimpleFileVisitor<>() {
+                        @Override
+                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                            if (file.toString().endsWith(".java")
+                                    && !file.getFileName().toString().equals("module-info.java")) {
+                                files.add(file.toString());
+                            }
+                            return FileVisitResult.CONTINUE;
+                        }
+                    });
+                }
+            }
+            if (files.isEmpty()) {
+                return CompletableFuture.completedStage(null);
+            }
+            if (jars.isEmpty()) {
+                throw new IllegalStateException("No Checkstyle jars resolved upstream of the Checkstyle step");
+            }
+            if (config == null) {
+                throw new IllegalStateException("No " + configFile + " found among the inputs of the Checkstyle step");
+            }
+            files.sort(null);
+            Path report = context.next().resolve("checkstyle-report.xml");
+            List<String> commands = new ArrayList<>(List.of(
+                    "-cp", String.join(File.pathSeparator, jars),
+                    "com.puppycrawl.tools.checkstyle.Main",
+                    "-c", config.toString(),
+                    "-f", "xml",
+                    "-o", report.toString()));
+            commands.addAll(files);
+            return CompletableFuture.completedStage(commands);
+        }
+    }
+}

--- a/sources/build/jenesis/project/CodeNarcModule.java
+++ b/sources/build/jenesis/project/CodeNarcModule.java
@@ -27,10 +27,9 @@ public class CodeNarcModule implements BuildExecutorModule {
     private final String group;
     private final String configFile;
     private final boolean strict;
-    private final transient Function<List<String>, ? extends ProcessHandler> factory;
 
     public CodeNarcModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
-        this(repositories, resolvers, null, "codenarc", "codenarc.xml", false, null);
+        this(repositories, resolvers, null, "codenarc", "codenarc.xml", false);
     }
 
     private CodeNarcModule(Map<String, Repository> repositories,
@@ -38,55 +37,53 @@ public class CodeNarcModule implements BuildExecutorModule {
                            Pinning pinning,
                            String group,
                            String configFile,
-                           boolean strict,
-                           Function<List<String>, ? extends ProcessHandler> factory) {
+                           boolean strict) {
         this.repositories = repositories;
         this.resolvers = resolvers;
         this.pinning = pinning;
         this.group = group;
         this.configFile = configFile;
         this.strict = strict;
-        this.factory = factory;
+    }
+
+    public static boolean isConfigured(SequencedMap<String, Path> inherited) {
+        for (Path folder : inherited.values()) {
+            if (Files.isRegularFile(folder.resolve("codenarc.xml"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public CodeNarcModule pinning(Pinning pinning) {
-        return new CodeNarcModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new CodeNarcModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public CodeNarcModule group(String group) {
-        return new CodeNarcModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new CodeNarcModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public CodeNarcModule configFile(String configFile) {
-        return new CodeNarcModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new CodeNarcModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public CodeNarcModule strict(boolean strict) {
-        return new CodeNarcModule(repositories, resolvers, pinning, group, configFile, strict, factory);
-    }
-
-    public CodeNarcModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
-        return new CodeNarcModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new CodeNarcModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     @Override
     public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
-        SequencedSet<String> upstream = inherited.sequencedKeySet();
-        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        buildExecutor.addStep(REQUIRED, new Requires(group), inherited.sequencedKeySet());
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(REQUIRED);
-        resolveInputs.addAll(upstream);
+        resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
                 new Dependencies(repositories, resolvers).pinning(pinning),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);
-        checkInputs.addAll(upstream);
-        buildExecutor.addStep(CHECK,
-                factory == null
-                        ? new Check(group, configFile, strict)
-                        : new Check(group, configFile, strict, factory),
-                checkInputs);
+        checkInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(CHECK, new Check(group, configFile, strict), checkInputs);
     }
 
     private record Requires(String group) implements BuildStep {
@@ -117,14 +114,7 @@ public class CodeNarcModule implements BuildExecutorModule {
         private final boolean strict;
 
         private Check(String group, String configFile, boolean strict) {
-            this(group, configFile, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
-        }
-
-        private Check(String group,
-                      String configFile,
-                      boolean strict,
-                      Function<List<String>, ? extends ProcessHandler> factory) {
-            super("codenarc", factory);
+            super("codenarc", ProcessHandler.OfProcess.ofJavaHome("bin/java"));
             this.group = group;
             this.configFile = configFile;
             this.strict = strict;

--- a/sources/build/jenesis/project/CodeNarcModule.java
+++ b/sources/build/jenesis/project/CodeNarcModule.java
@@ -1,0 +1,185 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Bind;
+import build.jenesis.step.Dependencies;
+import build.jenesis.step.JdkProcessBuildStep;
+import build.jenesis.step.ProcessHandler;
+
+public class CodeNarcModule implements BuildExecutorModule {
+
+    public static final String CHECK = "check";
+    private static final String REQUIRED = "required", DEPENDENCIES = "dependencies";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String group;
+    private final String configFile;
+    private final boolean strict;
+    private final transient Function<List<String>, ? extends ProcessHandler> factory;
+
+    public CodeNarcModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "codenarc", "codenarc.xml", false, null);
+    }
+
+    private CodeNarcModule(Map<String, Repository> repositories,
+                           Map<String, Resolver> resolvers,
+                           Pinning pinning,
+                           String group,
+                           String configFile,
+                           boolean strict,
+                           Function<List<String>, ? extends ProcessHandler> factory) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.group = group;
+        this.configFile = configFile;
+        this.strict = strict;
+        this.factory = factory;
+    }
+
+    public CodeNarcModule pinning(Pinning pinning) {
+        return new CodeNarcModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public CodeNarcModule group(String group) {
+        return new CodeNarcModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public CodeNarcModule configFile(String configFile) {
+        return new CodeNarcModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public CodeNarcModule strict(boolean strict) {
+        return new CodeNarcModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public CodeNarcModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
+        return new CodeNarcModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        SequencedSet<String> upstream = inherited.sequencedKeySet();
+        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(upstream);
+        buildExecutor.addStep(DEPENDENCIES,
+                new Dependencies(repositories, resolvers).pinning(pinning),
+                resolveInputs);
+        SequencedSet<String> checkInputs = new LinkedHashSet<>();
+        checkInputs.add(DEPENDENCIES);
+        checkInputs.addAll(upstream);
+        buildExecutor.addStep(CHECK,
+                factory == null
+                        ? new Check(group, configFile, strict)
+                        : new Check(group, configFile, strict, factory),
+                checkInputs);
+    }
+
+    private record Requires(String group) implements BuildStep {
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return false;
+        }
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(group + "/runtime/maven/org.codenarc/CodeNarc/RELEASE", "");
+            requires.setProperty(group + "/runtime/maven/org.apache.groovy/groovy/RELEASE", "");
+            requires.setProperty(group + "/runtime/maven/org.slf4j/slf4j-simple/RELEASE", "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private static class Check extends JdkProcessBuildStep {
+
+        private final String group;
+        private final String configFile;
+        private final boolean strict;
+
+        private Check(String group, String configFile, boolean strict) {
+            this(group, configFile, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
+        }
+
+        private Check(String group,
+                      String configFile,
+                      boolean strict,
+                      Function<List<String>, ? extends ProcessHandler> factory) {
+            super("codenarc", factory);
+            this.group = group;
+            this.configFile = configFile;
+            this.strict = strict;
+        }
+
+        @Override
+        public boolean acceptableExitCode(int code,
+                                          Executor executor,
+                                          BuildStepContext context,
+                                          SequencedMap<String, BuildStepArgument> arguments) {
+            return !strict || code == 0;
+        }
+
+        @Override
+        public CompletionStage<List<String>> process(Executor executor,
+                                                     BuildStepContext context,
+                                                     SequencedMap<String, BuildStepArgument> arguments,
+                                                     SequencedMap<String, SequencedMap<String, String>> properties)
+                throws IOException {
+            List<String> jars = new ArrayList<>();
+            Path baseDir = null, config = null;
+            for (BuildStepArgument argument : arguments.values()) {
+                for (Path jar : Dependencies.select(argument.folder(), group, "runtime")) {
+                    jars.add(jar.toString());
+                }
+                Path candidate = argument.folder().resolve(configFile);
+                if (Files.isRegularFile(candidate)) {
+                    config = candidate;
+                }
+                Path sources = argument.folder().resolve(Bind.SOURCES);
+                if (baseDir == null && Files.isDirectory(sources)) {
+                    try (Stream<Path> walk = Files.walk(sources)) {
+                        if (walk.anyMatch(file -> file.toString().endsWith(".groovy"))) {
+                            baseDir = sources;
+                        }
+                    }
+                }
+            }
+            if (baseDir == null) {
+                return CompletableFuture.completedStage(null);
+            }
+            if (jars.isEmpty()) {
+                throw new IllegalStateException("No CodeNarc jars resolved upstream of the CodeNarc step");
+            }
+            if (config == null) {
+                throw new IllegalStateException("No " + configFile + " found among the inputs of the CodeNarc step");
+            }
+            Path report = context.next().resolve("codenarc-report.xml");
+            List<String> commands = new ArrayList<>(List.of(
+                    "-cp", String.join(File.pathSeparator, jars),
+                    "org.codenarc.CodeNarc",
+                    "-basedir=" + baseDir,
+                    "-rulesetfiles=file:" + config,
+                    "-report=xml:" + report));
+            return CompletableFuture.completedStage(commands);
+        }
+    }
+}

--- a/sources/build/jenesis/project/DetektModule.java
+++ b/sources/build/jenesis/project/DetektModule.java
@@ -1,0 +1,186 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Bind;
+import build.jenesis.step.Dependencies;
+import build.jenesis.step.JdkProcessBuildStep;
+import build.jenesis.step.ProcessHandler;
+
+public class DetektModule implements BuildExecutorModule {
+
+    public static final String CHECK = "check";
+    private static final String REQUIRED = "required", DEPENDENCIES = "dependencies";
+
+    private static final String MAVEN_GROUP = "io.gitlab.arturbosch.detekt";
+    private static final String MAVEN_ARTIFACT = "detekt-cli";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String group;
+    private final String configFile;
+    private final boolean strict;
+    private final transient Function<List<String>, ? extends ProcessHandler> factory;
+
+    public DetektModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "detekt", "detekt.yml", false, null);
+    }
+
+    private DetektModule(Map<String, Repository> repositories,
+                         Map<String, Resolver> resolvers,
+                         Pinning pinning,
+                         String group,
+                         String configFile,
+                         boolean strict,
+                         Function<List<String>, ? extends ProcessHandler> factory) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.group = group;
+        this.configFile = configFile;
+        this.strict = strict;
+        this.factory = factory;
+    }
+
+    public DetektModule pinning(Pinning pinning) {
+        return new DetektModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public DetektModule group(String group) {
+        return new DetektModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public DetektModule configFile(String configFile) {
+        return new DetektModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public DetektModule strict(boolean strict) {
+        return new DetektModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public DetektModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
+        return new DetektModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        SequencedSet<String> upstream = inherited.sequencedKeySet();
+        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(upstream);
+        buildExecutor.addStep(DEPENDENCIES,
+                new Dependencies(repositories, resolvers).pinning(pinning),
+                resolveInputs);
+        SequencedSet<String> checkInputs = new LinkedHashSet<>();
+        checkInputs.add(DEPENDENCIES);
+        checkInputs.addAll(upstream);
+        buildExecutor.addStep(CHECK,
+                factory == null
+                        ? new Check(group, configFile, strict)
+                        : new Check(group, configFile, strict, factory),
+                checkInputs);
+    }
+
+    private record Requires(String group) implements BuildStep {
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return false;
+        }
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(group + "/runtime/maven/" + MAVEN_GROUP + "/" + MAVEN_ARTIFACT + "/RELEASE", "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private static class Check extends JdkProcessBuildStep {
+
+        private final String group;
+        private final String configFile;
+        private final boolean strict;
+
+        private Check(String group, String configFile, boolean strict) {
+            this(group, configFile, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
+        }
+
+        private Check(String group,
+                      String configFile,
+                      boolean strict,
+                      Function<List<String>, ? extends ProcessHandler> factory) {
+            super("detekt", factory);
+            this.group = group;
+            this.configFile = configFile;
+            this.strict = strict;
+        }
+
+        @Override
+        public boolean acceptableExitCode(int code,
+                                          Executor executor,
+                                          BuildStepContext context,
+                                          SequencedMap<String, BuildStepArgument> arguments) {
+            return !strict || code == 0;
+        }
+
+        @Override
+        public CompletionStage<List<String>> process(Executor executor,
+                                                     BuildStepContext context,
+                                                     SequencedMap<String, BuildStepArgument> arguments,
+                                                     SequencedMap<String, SequencedMap<String, String>> properties)
+                throws IOException {
+            List<String> jars = new ArrayList<>(), roots = new ArrayList<>();
+            boolean hasKotlin = false;
+            Path config = null;
+            for (BuildStepArgument argument : arguments.values()) {
+                for (Path jar : Dependencies.select(argument.folder(), group, "runtime")) {
+                    jars.add(jar.toString());
+                }
+                Path candidate = argument.folder().resolve(configFile);
+                if (Files.isRegularFile(candidate)) {
+                    config = candidate;
+                }
+                Path sources = argument.folder().resolve(Bind.SOURCES);
+                if (Files.isDirectory(sources)) {
+                    roots.add(sources.toString());
+                    try (Stream<Path> walk = Files.walk(sources)) {
+                        hasKotlin = hasKotlin || walk.anyMatch(file -> file.toString().endsWith(".kt"));
+                    }
+                }
+            }
+            if (!hasKotlin) {
+                return CompletableFuture.completedStage(null);
+            }
+            if (jars.isEmpty()) {
+                throw new IllegalStateException("No detekt jars resolved upstream of the detekt step");
+            }
+            if (config == null) {
+                throw new IllegalStateException("No " + configFile + " found among the inputs of the detekt step");
+            }
+            Path report = context.next().resolve("detekt-report.xml");
+            List<String> commands = new ArrayList<>(List.of(
+                    "-cp", String.join(File.pathSeparator, jars),
+                    "io.gitlab.arturbosch.detekt.cli.Main",
+                    "--input", String.join(File.pathSeparator, roots),
+                    "--config", config.toString(),
+                    "--report", "xml:" + report));
+            return CompletableFuture.completedStage(commands);
+        }
+    }
+}

--- a/sources/build/jenesis/project/DetektModule.java
+++ b/sources/build/jenesis/project/DetektModule.java
@@ -30,10 +30,9 @@ public class DetektModule implements BuildExecutorModule {
     private final String group;
     private final String configFile;
     private final boolean strict;
-    private final transient Function<List<String>, ? extends ProcessHandler> factory;
 
     public DetektModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
-        this(repositories, resolvers, null, "detekt", "detekt.yml", false, null);
+        this(repositories, resolvers, null, "detekt", "detekt.yml", false);
     }
 
     private DetektModule(Map<String, Repository> repositories,
@@ -41,55 +40,53 @@ public class DetektModule implements BuildExecutorModule {
                          Pinning pinning,
                          String group,
                          String configFile,
-                         boolean strict,
-                         Function<List<String>, ? extends ProcessHandler> factory) {
+                         boolean strict) {
         this.repositories = repositories;
         this.resolvers = resolvers;
         this.pinning = pinning;
         this.group = group;
         this.configFile = configFile;
         this.strict = strict;
-        this.factory = factory;
+    }
+
+    public static boolean isConfigured(SequencedMap<String, Path> inherited) {
+        for (Path folder : inherited.values()) {
+            if (Files.isRegularFile(folder.resolve("detekt.yml"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public DetektModule pinning(Pinning pinning) {
-        return new DetektModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new DetektModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public DetektModule group(String group) {
-        return new DetektModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new DetektModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public DetektModule configFile(String configFile) {
-        return new DetektModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new DetektModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public DetektModule strict(boolean strict) {
-        return new DetektModule(repositories, resolvers, pinning, group, configFile, strict, factory);
-    }
-
-    public DetektModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
-        return new DetektModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new DetektModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     @Override
     public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
-        SequencedSet<String> upstream = inherited.sequencedKeySet();
-        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        buildExecutor.addStep(REQUIRED, new Requires(group), inherited.sequencedKeySet());
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(REQUIRED);
-        resolveInputs.addAll(upstream);
+        resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
                 new Dependencies(repositories, resolvers).pinning(pinning),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);
-        checkInputs.addAll(upstream);
-        buildExecutor.addStep(CHECK,
-                factory == null
-                        ? new Check(group, configFile, strict)
-                        : new Check(group, configFile, strict, factory),
-                checkInputs);
+        checkInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(CHECK, new Check(group, configFile, strict), checkInputs);
     }
 
     private record Requires(String group) implements BuildStep {
@@ -118,14 +115,7 @@ public class DetektModule implements BuildExecutorModule {
         private final boolean strict;
 
         private Check(String group, String configFile, boolean strict) {
-            this(group, configFile, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
-        }
-
-        private Check(String group,
-                      String configFile,
-                      boolean strict,
-                      Function<List<String>, ? extends ProcessHandler> factory) {
-            super("detekt", factory);
+            super("detekt", ProcessHandler.OfProcess.ofJavaHome("bin/java"));
             this.group = group;
             this.configFile = configFile;
             this.strict = strict;

--- a/sources/build/jenesis/project/InferredByteCodeQualityModule.java
+++ b/sources/build/jenesis/project/InferredByteCodeQualityModule.java
@@ -33,19 +33,9 @@ public class InferredByteCodeQualityModule implements BuildExecutorModule {
 
     @Override
     public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
-        SequencedSet<String> upstream = inherited.sequencedKeySet();
-        if (hasFile(inherited, "spotbugs-exclude.xml") || hasFile(inherited, "spotbugs.xml")) {
+        if (SpotBugsModule.isConfigured(inherited)) {
             buildExecutor.addModule(SPOTBUGS,
-                    new SpotBugsModule(repositories, resolvers).pinning(pinning), upstream);
+                    new SpotBugsModule(repositories, resolvers).pinning(pinning), inherited.sequencedKeySet());
         }
-    }
-
-    private static boolean hasFile(SequencedMap<String, Path> inherited, String fileName) {
-        for (Path folder : inherited.values()) {
-            if (Files.isRegularFile(folder.resolve(fileName))) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/sources/build/jenesis/project/InferredByteCodeQualityModule.java
+++ b/sources/build/jenesis/project/InferredByteCodeQualityModule.java
@@ -1,0 +1,51 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+
+public class InferredByteCodeQualityModule implements BuildExecutorModule {
+
+    public static final String SPOTBUGS = "spotbugs";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+
+    public InferredByteCodeQualityModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null);
+    }
+
+    private InferredByteCodeQualityModule(Map<String, Repository> repositories,
+                                          Map<String, Resolver> resolvers,
+                                          Pinning pinning) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+    }
+
+    public InferredByteCodeQualityModule pinning(Pinning pinning) {
+        return new InferredByteCodeQualityModule(repositories, resolvers, pinning);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        SequencedSet<String> upstream = inherited.sequencedKeySet();
+        if (hasFile(inherited, "spotbugs-exclude.xml") || hasFile(inherited, "spotbugs.xml")) {
+            buildExecutor.addModule(SPOTBUGS,
+                    new SpotBugsModule(repositories, resolvers).pinning(pinning), upstream);
+        }
+    }
+
+    private static boolean hasFile(SequencedMap<String, Path> inherited, String fileName) {
+        for (Path folder : inherited.values()) {
+            if (Files.isRegularFile(folder.resolve(fileName))) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/sources/build/jenesis/project/InferredSourceCodeQualityModule.java
+++ b/sources/build/jenesis/project/InferredSourceCodeQualityModule.java
@@ -1,0 +1,76 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+
+public class InferredSourceCodeQualityModule implements BuildExecutorModule {
+
+    public static final String CHECKSTYLE = "checkstyle", PMD = "pmd", DETEKT = "detekt",
+            KTLINT = "ktlint", SCALASTYLE = "scalastyle", SCALAFMT = "scalafmt", CODENARC = "codenarc";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+
+    public InferredSourceCodeQualityModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null);
+    }
+
+    private InferredSourceCodeQualityModule(Map<String, Repository> repositories,
+                                            Map<String, Resolver> resolvers,
+                                            Pinning pinning) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+    }
+
+    public InferredSourceCodeQualityModule pinning(Pinning pinning) {
+        return new InferredSourceCodeQualityModule(repositories, resolvers, pinning);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        SequencedSet<String> upstream = inherited.sequencedKeySet();
+        if (hasFile(inherited, "checkstyle.xml")) {
+            buildExecutor.addModule(CHECKSTYLE,
+                    new CheckstyleModule(repositories, resolvers).pinning(pinning), upstream);
+        }
+        if (hasFile(inherited, "pmd.xml")) {
+            buildExecutor.addModule(PMD,
+                    new PmdModule(repositories, resolvers).pinning(pinning), upstream);
+        }
+        if (hasFile(inherited, "detekt.yml")) {
+            buildExecutor.addModule(DETEKT,
+                    new DetektModule(repositories, resolvers).pinning(pinning), upstream);
+        }
+        if (hasFile(inherited, ".editorconfig")) {
+            buildExecutor.addModule(KTLINT,
+                    new KtlintModule(repositories, resolvers).pinning(pinning), upstream);
+        }
+        if (hasFile(inherited, "scalastyle-config.xml")) {
+            buildExecutor.addModule(SCALASTYLE,
+                    new ScalastyleModule(repositories, resolvers).pinning(pinning), upstream);
+        }
+        if (hasFile(inherited, ".scalafmt.conf")) {
+            buildExecutor.addModule(SCALAFMT,
+                    new ScalafmtModule(repositories, resolvers).pinning(pinning), upstream);
+        }
+        if (hasFile(inherited, "codenarc.xml")) {
+            buildExecutor.addModule(CODENARC,
+                    new CodeNarcModule(repositories, resolvers).pinning(pinning), upstream);
+        }
+    }
+
+    private static boolean hasFile(SequencedMap<String, Path> inherited, String fileName) {
+        for (Path folder : inherited.values()) {
+            if (Files.isRegularFile(folder.resolve(fileName))) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/sources/build/jenesis/project/InferredSourceCodeQualityModule.java
+++ b/sources/build/jenesis/project/InferredSourceCodeQualityModule.java
@@ -34,43 +34,33 @@ public class InferredSourceCodeQualityModule implements BuildExecutorModule {
 
     @Override
     public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
-        SequencedSet<String> upstream = inherited.sequencedKeySet();
-        if (hasFile(inherited, "checkstyle.xml")) {
+        if (CheckstyleModule.isConfigured(inherited)) {
             buildExecutor.addModule(CHECKSTYLE,
-                    new CheckstyleModule(repositories, resolvers).pinning(pinning), upstream);
+                    new CheckstyleModule(repositories, resolvers).pinning(pinning), inherited.sequencedKeySet());
         }
-        if (hasFile(inherited, "pmd.xml")) {
+        if (PmdModule.isConfigured(inherited)) {
             buildExecutor.addModule(PMD,
-                    new PmdModule(repositories, resolvers).pinning(pinning), upstream);
+                    new PmdModule(repositories, resolvers).pinning(pinning), inherited.sequencedKeySet());
         }
-        if (hasFile(inherited, "detekt.yml")) {
+        if (DetektModule.isConfigured(inherited)) {
             buildExecutor.addModule(DETEKT,
-                    new DetektModule(repositories, resolvers).pinning(pinning), upstream);
+                    new DetektModule(repositories, resolvers).pinning(pinning), inherited.sequencedKeySet());
         }
-        if (hasFile(inherited, ".editorconfig")) {
+        if (KtlintModule.isConfigured(inherited)) {
             buildExecutor.addModule(KTLINT,
-                    new KtlintModule(repositories, resolvers).pinning(pinning), upstream);
+                    new KtlintModule(repositories, resolvers).pinning(pinning), inherited.sequencedKeySet());
         }
-        if (hasFile(inherited, "scalastyle-config.xml")) {
+        if (ScalastyleModule.isConfigured(inherited)) {
             buildExecutor.addModule(SCALASTYLE,
-                    new ScalastyleModule(repositories, resolvers).pinning(pinning), upstream);
+                    new ScalastyleModule(repositories, resolvers).pinning(pinning), inherited.sequencedKeySet());
         }
-        if (hasFile(inherited, ".scalafmt.conf")) {
+        if (ScalafmtModule.isConfigured(inherited)) {
             buildExecutor.addModule(SCALAFMT,
-                    new ScalafmtModule(repositories, resolvers).pinning(pinning), upstream);
+                    new ScalafmtModule(repositories, resolvers).pinning(pinning), inherited.sequencedKeySet());
         }
-        if (hasFile(inherited, "codenarc.xml")) {
+        if (CodeNarcModule.isConfigured(inherited)) {
             buildExecutor.addModule(CODENARC,
-                    new CodeNarcModule(repositories, resolvers).pinning(pinning), upstream);
+                    new CodeNarcModule(repositories, resolvers).pinning(pinning), inherited.sequencedKeySet());
         }
-    }
-
-    private static boolean hasFile(SequencedMap<String, Path> inherited, String fileName) {
-        for (Path folder : inherited.values()) {
-            if (Files.isRegularFile(folder.resolve(fileName))) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/sources/build/jenesis/project/KtlintModule.java
+++ b/sources/build/jenesis/project/KtlintModule.java
@@ -29,58 +29,57 @@ public class KtlintModule implements BuildExecutorModule {
     private final Pinning pinning;
     private final String group;
     private final boolean strict;
-    private final transient Function<List<String>, ? extends ProcessHandler> factory;
 
     public KtlintModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
-        this(repositories, resolvers, null, "ktlint", false, null);
+        this(repositories, resolvers, null, "ktlint", false);
     }
 
     private KtlintModule(Map<String, Repository> repositories,
                          Map<String, Resolver> resolvers,
                          Pinning pinning,
                          String group,
-                         boolean strict,
-                         Function<List<String>, ? extends ProcessHandler> factory) {
+                         boolean strict) {
         this.repositories = repositories;
         this.resolvers = resolvers;
         this.pinning = pinning;
         this.group = group;
         this.strict = strict;
-        this.factory = factory;
+    }
+
+    public static boolean isConfigured(SequencedMap<String, Path> inherited) {
+        for (Path folder : inherited.values()) {
+            if (Files.isRegularFile(folder.resolve(".editorconfig"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public KtlintModule pinning(Pinning pinning) {
-        return new KtlintModule(repositories, resolvers, pinning, group, strict, factory);
+        return new KtlintModule(repositories, resolvers, pinning, group, strict);
     }
 
     public KtlintModule group(String group) {
-        return new KtlintModule(repositories, resolvers, pinning, group, strict, factory);
+        return new KtlintModule(repositories, resolvers, pinning, group, strict);
     }
 
     public KtlintModule strict(boolean strict) {
-        return new KtlintModule(repositories, resolvers, pinning, group, strict, factory);
-    }
-
-    public KtlintModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
-        return new KtlintModule(repositories, resolvers, pinning, group, strict, factory);
+        return new KtlintModule(repositories, resolvers, pinning, group, strict);
     }
 
     @Override
     public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
-        SequencedSet<String> upstream = inherited.sequencedKeySet();
-        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        buildExecutor.addStep(REQUIRED, new Requires(group), inherited.sequencedKeySet());
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(REQUIRED);
-        resolveInputs.addAll(upstream);
+        resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
                 new Dependencies(repositories, resolvers).pinning(pinning),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);
-        checkInputs.addAll(upstream);
-        buildExecutor.addStep(CHECK,
-                factory == null ? new Check(group, strict) : new Check(group, strict, factory),
-                checkInputs);
+        checkInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(CHECK, new Check(group, strict), checkInputs);
     }
 
     private record Requires(String group) implements BuildStep {
@@ -108,11 +107,7 @@ public class KtlintModule implements BuildExecutorModule {
         private final boolean strict;
 
         private Check(String group, boolean strict) {
-            this(group, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
-        }
-
-        private Check(String group, boolean strict, Function<List<String>, ? extends ProcessHandler> factory) {
-            super("ktlint", factory);
+            super("ktlint", ProcessHandler.OfProcess.ofJavaHome("bin/java"));
             this.group = group;
             this.strict = strict;
         }

--- a/sources/build/jenesis/project/KtlintModule.java
+++ b/sources/build/jenesis/project/KtlintModule.java
@@ -1,0 +1,168 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Bind;
+import build.jenesis.step.Dependencies;
+import build.jenesis.step.JdkProcessBuildStep;
+import build.jenesis.step.ProcessHandler;
+
+public class KtlintModule implements BuildExecutorModule {
+
+    public static final String CHECK = "check";
+    private static final String REQUIRED = "required", DEPENDENCIES = "dependencies";
+
+    private static final String MAVEN_GROUP = "com.pinterest.ktlint";
+    private static final String MAVEN_ARTIFACT = "ktlint-cli";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String group;
+    private final boolean strict;
+    private final transient Function<List<String>, ? extends ProcessHandler> factory;
+
+    public KtlintModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "ktlint", false, null);
+    }
+
+    private KtlintModule(Map<String, Repository> repositories,
+                         Map<String, Resolver> resolvers,
+                         Pinning pinning,
+                         String group,
+                         boolean strict,
+                         Function<List<String>, ? extends ProcessHandler> factory) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.group = group;
+        this.strict = strict;
+        this.factory = factory;
+    }
+
+    public KtlintModule pinning(Pinning pinning) {
+        return new KtlintModule(repositories, resolvers, pinning, group, strict, factory);
+    }
+
+    public KtlintModule group(String group) {
+        return new KtlintModule(repositories, resolvers, pinning, group, strict, factory);
+    }
+
+    public KtlintModule strict(boolean strict) {
+        return new KtlintModule(repositories, resolvers, pinning, group, strict, factory);
+    }
+
+    public KtlintModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
+        return new KtlintModule(repositories, resolvers, pinning, group, strict, factory);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        SequencedSet<String> upstream = inherited.sequencedKeySet();
+        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(upstream);
+        buildExecutor.addStep(DEPENDENCIES,
+                new Dependencies(repositories, resolvers).pinning(pinning),
+                resolveInputs);
+        SequencedSet<String> checkInputs = new LinkedHashSet<>();
+        checkInputs.add(DEPENDENCIES);
+        checkInputs.addAll(upstream);
+        buildExecutor.addStep(CHECK,
+                factory == null ? new Check(group, strict) : new Check(group, strict, factory),
+                checkInputs);
+    }
+
+    private record Requires(String group) implements BuildStep {
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return false;
+        }
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(group + "/runtime/maven/" + MAVEN_GROUP + "/" + MAVEN_ARTIFACT + "/RELEASE", "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private static class Check extends JdkProcessBuildStep {
+
+        private final String group;
+        private final boolean strict;
+
+        private Check(String group, boolean strict) {
+            this(group, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
+        }
+
+        private Check(String group, boolean strict, Function<List<String>, ? extends ProcessHandler> factory) {
+            super("ktlint", factory);
+            this.group = group;
+            this.strict = strict;
+        }
+
+        @Override
+        public boolean acceptableExitCode(int code,
+                                          Executor executor,
+                                          BuildStepContext context,
+                                          SequencedMap<String, BuildStepArgument> arguments) {
+            return !strict || code == 0;
+        }
+
+        @Override
+        public CompletionStage<List<String>> process(Executor executor,
+                                                     BuildStepContext context,
+                                                     SequencedMap<String, BuildStepArgument> arguments,
+                                                     SequencedMap<String, SequencedMap<String, String>> properties)
+                throws IOException {
+            List<String> jars = new ArrayList<>(), files = new ArrayList<>();
+            for (BuildStepArgument argument : arguments.values()) {
+                for (Path jar : Dependencies.select(argument.folder(), group, "runtime")) {
+                    jars.add(jar.toString());
+                }
+                Path sources = argument.folder().resolve(Bind.SOURCES);
+                if (Files.isDirectory(sources)) {
+                    Files.walkFileTree(sources, new SimpleFileVisitor<>() {
+                        @Override
+                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                            if (file.toString().endsWith(".kt")) {
+                                files.add(file.toString());
+                            }
+                            return FileVisitResult.CONTINUE;
+                        }
+                    });
+                }
+            }
+            if (files.isEmpty()) {
+                return CompletableFuture.completedStage(null);
+            }
+            if (jars.isEmpty()) {
+                throw new IllegalStateException("No ktlint jars resolved upstream of the ktlint step");
+            }
+            files.sort(null);
+            Path report = context.next().resolve("ktlint-report.xml");
+            List<String> commands = new ArrayList<>(List.of(
+                    "-cp", String.join(File.pathSeparator, jars),
+                    "com.pinterest.ktlint.Main",
+                    "--reporter=checkstyle,output=" + report));
+            commands.addAll(files);
+            return CompletableFuture.completedStage(commands);
+        }
+    }
+}

--- a/sources/build/jenesis/project/PmdModule.java
+++ b/sources/build/jenesis/project/PmdModule.java
@@ -30,10 +30,9 @@ public class PmdModule implements BuildExecutorModule {
     private final String group;
     private final String configFile;
     private final boolean strict;
-    private final transient Function<List<String>, ? extends ProcessHandler> factory;
 
     public PmdModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
-        this(repositories, resolvers, null, "pmd", "pmd.xml", false, null);
+        this(repositories, resolvers, null, "pmd", "pmd.xml", false);
     }
 
     private PmdModule(Map<String, Repository> repositories,
@@ -41,55 +40,53 @@ public class PmdModule implements BuildExecutorModule {
                       Pinning pinning,
                       String group,
                       String configFile,
-                      boolean strict,
-                      Function<List<String>, ? extends ProcessHandler> factory) {
+                      boolean strict) {
         this.repositories = repositories;
         this.resolvers = resolvers;
         this.pinning = pinning;
         this.group = group;
         this.configFile = configFile;
         this.strict = strict;
-        this.factory = factory;
+    }
+
+    public static boolean isConfigured(SequencedMap<String, Path> inherited) {
+        for (Path folder : inherited.values()) {
+            if (Files.isRegularFile(folder.resolve("pmd.xml"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public PmdModule pinning(Pinning pinning) {
-        return new PmdModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new PmdModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public PmdModule group(String group) {
-        return new PmdModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new PmdModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public PmdModule configFile(String configFile) {
-        return new PmdModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new PmdModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public PmdModule strict(boolean strict) {
-        return new PmdModule(repositories, resolvers, pinning, group, configFile, strict, factory);
-    }
-
-    public PmdModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
-        return new PmdModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new PmdModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     @Override
     public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
-        SequencedSet<String> upstream = inherited.sequencedKeySet();
-        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        buildExecutor.addStep(REQUIRED, new Requires(group), inherited.sequencedKeySet());
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(REQUIRED);
-        resolveInputs.addAll(upstream);
+        resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
                 new Dependencies(repositories, resolvers).pinning(pinning),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);
-        checkInputs.addAll(upstream);
-        buildExecutor.addStep(CHECK,
-                factory == null
-                        ? new Check(group, configFile, strict)
-                        : new Check(group, configFile, strict, factory),
-                checkInputs);
+        checkInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(CHECK, new Check(group, configFile, strict), checkInputs);
     }
 
     private record Requires(String group) implements BuildStep {
@@ -118,14 +115,7 @@ public class PmdModule implements BuildExecutorModule {
         private final boolean strict;
 
         private Check(String group, String configFile, boolean strict) {
-            this(group, configFile, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
-        }
-
-        private Check(String group,
-                      String configFile,
-                      boolean strict,
-                      Function<List<String>, ? extends ProcessHandler> factory) {
-            super("pmd", factory);
+            super("pmd", ProcessHandler.OfProcess.ofJavaHome("bin/java"));
             this.group = group;
             this.configFile = configFile;
             this.strict = strict;

--- a/sources/build/jenesis/project/PmdModule.java
+++ b/sources/build/jenesis/project/PmdModule.java
@@ -1,0 +1,191 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Bind;
+import build.jenesis.step.Dependencies;
+import build.jenesis.step.JdkProcessBuildStep;
+import build.jenesis.step.ProcessHandler;
+
+public class PmdModule implements BuildExecutorModule {
+
+    public static final String CHECK = "check";
+    private static final String REQUIRED = "required", DEPENDENCIES = "dependencies";
+
+    private static final String MAVEN_GROUP = "net.sourceforge.pmd";
+    private static final String MAVEN_ARTIFACT = "pmd-dist";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String group;
+    private final String configFile;
+    private final boolean strict;
+    private final transient Function<List<String>, ? extends ProcessHandler> factory;
+
+    public PmdModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "pmd", "pmd.xml", false, null);
+    }
+
+    private PmdModule(Map<String, Repository> repositories,
+                      Map<String, Resolver> resolvers,
+                      Pinning pinning,
+                      String group,
+                      String configFile,
+                      boolean strict,
+                      Function<List<String>, ? extends ProcessHandler> factory) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.group = group;
+        this.configFile = configFile;
+        this.strict = strict;
+        this.factory = factory;
+    }
+
+    public PmdModule pinning(Pinning pinning) {
+        return new PmdModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public PmdModule group(String group) {
+        return new PmdModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public PmdModule configFile(String configFile) {
+        return new PmdModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public PmdModule strict(boolean strict) {
+        return new PmdModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public PmdModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
+        return new PmdModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        SequencedSet<String> upstream = inherited.sequencedKeySet();
+        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(upstream);
+        buildExecutor.addStep(DEPENDENCIES,
+                new Dependencies(repositories, resolvers).pinning(pinning),
+                resolveInputs);
+        SequencedSet<String> checkInputs = new LinkedHashSet<>();
+        checkInputs.add(DEPENDENCIES);
+        checkInputs.addAll(upstream);
+        buildExecutor.addStep(CHECK,
+                factory == null
+                        ? new Check(group, configFile, strict)
+                        : new Check(group, configFile, strict, factory),
+                checkInputs);
+    }
+
+    private record Requires(String group) implements BuildStep {
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return false;
+        }
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(group + "/runtime/maven/" + MAVEN_GROUP + "/" + MAVEN_ARTIFACT + "/RELEASE", "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private static class Check extends JdkProcessBuildStep {
+
+        private final String group;
+        private final String configFile;
+        private final boolean strict;
+
+        private Check(String group, String configFile, boolean strict) {
+            this(group, configFile, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
+        }
+
+        private Check(String group,
+                      String configFile,
+                      boolean strict,
+                      Function<List<String>, ? extends ProcessHandler> factory) {
+            super("pmd", factory);
+            this.group = group;
+            this.configFile = configFile;
+            this.strict = strict;
+        }
+
+        @Override
+        public boolean acceptableExitCode(int code,
+                                          Executor executor,
+                                          BuildStepContext context,
+                                          SequencedMap<String, BuildStepArgument> arguments) {
+            return !strict || code == 0;
+        }
+
+        @Override
+        public CompletionStage<List<String>> process(Executor executor,
+                                                     BuildStepContext context,
+                                                     SequencedMap<String, BuildStepArgument> arguments,
+                                                     SequencedMap<String, SequencedMap<String, String>> properties)
+                throws IOException {
+            List<String> jars = new ArrayList<>(), roots = new ArrayList<>();
+            boolean hasJava = false;
+            Path config = null;
+            for (BuildStepArgument argument : arguments.values()) {
+                for (Path jar : Dependencies.select(argument.folder(), group, "runtime")) {
+                    jars.add(jar.toString());
+                }
+                Path candidate = argument.folder().resolve(configFile);
+                if (Files.isRegularFile(candidate)) {
+                    config = candidate;
+                }
+                Path sources = argument.folder().resolve(Bind.SOURCES);
+                if (Files.isDirectory(sources)) {
+                    roots.add(sources.toString());
+                    try (Stream<Path> walk = Files.walk(sources)) {
+                        hasJava = hasJava || walk.anyMatch(file -> file.toString().endsWith(".java"));
+                    }
+                }
+            }
+            if (!hasJava) {
+                return CompletableFuture.completedStage(null);
+            }
+            if (jars.isEmpty()) {
+                throw new IllegalStateException("No PMD jars resolved upstream of the PMD step");
+            }
+            if (config == null) {
+                throw new IllegalStateException("No " + configFile + " found among the inputs of the PMD step");
+            }
+            Path report = context.next().resolve("pmd-report.xml");
+            List<String> commands = new ArrayList<>(List.of(
+                    "-cp", String.join(File.pathSeparator, jars),
+                    "net.sourceforge.pmd.cli.PmdCli", "check",
+                    "--no-cache",
+                    "-R", config.toString(),
+                    "-f", "xml",
+                    "-r", report.toString()));
+            for (String root : roots) {
+                commands.add("-d");
+                commands.add(root);
+            }
+            return CompletableFuture.completedStage(commands);
+        }
+    }
+}

--- a/sources/build/jenesis/project/ScalafmtModule.java
+++ b/sources/build/jenesis/project/ScalafmtModule.java
@@ -1,0 +1,185 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Bind;
+import build.jenesis.step.Dependencies;
+import build.jenesis.step.JdkProcessBuildStep;
+import build.jenesis.step.ProcessHandler;
+
+public class ScalafmtModule implements BuildExecutorModule {
+
+    public static final String CHECK = "check";
+    private static final String REQUIRED = "required", DEPENDENCIES = "dependencies";
+
+    private static final String MAVEN_GROUP = "org.scalameta";
+    private static final String MAVEN_ARTIFACT = "scalafmt-cli_2.13";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String group;
+    private final String configFile;
+    private final boolean strict;
+    private final transient Function<List<String>, ? extends ProcessHandler> factory;
+
+    public ScalafmtModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "scalafmt", ".scalafmt.conf", false, null);
+    }
+
+    private ScalafmtModule(Map<String, Repository> repositories,
+                           Map<String, Resolver> resolvers,
+                           Pinning pinning,
+                           String group,
+                           String configFile,
+                           boolean strict,
+                           Function<List<String>, ? extends ProcessHandler> factory) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.group = group;
+        this.configFile = configFile;
+        this.strict = strict;
+        this.factory = factory;
+    }
+
+    public ScalafmtModule pinning(Pinning pinning) {
+        return new ScalafmtModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public ScalafmtModule group(String group) {
+        return new ScalafmtModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public ScalafmtModule configFile(String configFile) {
+        return new ScalafmtModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public ScalafmtModule strict(boolean strict) {
+        return new ScalafmtModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public ScalafmtModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
+        return new ScalafmtModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        SequencedSet<String> upstream = inherited.sequencedKeySet();
+        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(upstream);
+        buildExecutor.addStep(DEPENDENCIES,
+                new Dependencies(repositories, resolvers).pinning(pinning),
+                resolveInputs);
+        SequencedSet<String> checkInputs = new LinkedHashSet<>();
+        checkInputs.add(DEPENDENCIES);
+        checkInputs.addAll(upstream);
+        buildExecutor.addStep(CHECK,
+                factory == null
+                        ? new Check(group, configFile, strict)
+                        : new Check(group, configFile, strict, factory),
+                checkInputs);
+    }
+
+    private record Requires(String group) implements BuildStep {
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return false;
+        }
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(group + "/runtime/maven/" + MAVEN_GROUP + "/" + MAVEN_ARTIFACT + "/RELEASE", "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private static class Check extends JdkProcessBuildStep {
+
+        private final String group;
+        private final String configFile;
+        private final boolean strict;
+
+        private Check(String group, String configFile, boolean strict) {
+            this(group, configFile, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
+        }
+
+        private Check(String group,
+                      String configFile,
+                      boolean strict,
+                      Function<List<String>, ? extends ProcessHandler> factory) {
+            super("scalafmt", factory);
+            this.group = group;
+            this.configFile = configFile;
+            this.strict = strict;
+        }
+
+        @Override
+        public boolean acceptableExitCode(int code,
+                                          Executor executor,
+                                          BuildStepContext context,
+                                          SequencedMap<String, BuildStepArgument> arguments) {
+            return !strict || code == 0;
+        }
+
+        @Override
+        public CompletionStage<List<String>> process(Executor executor,
+                                                     BuildStepContext context,
+                                                     SequencedMap<String, BuildStepArgument> arguments,
+                                                     SequencedMap<String, SequencedMap<String, String>> properties)
+                throws IOException {
+            List<String> jars = new ArrayList<>(), roots = new ArrayList<>();
+            boolean hasScala = false;
+            Path config = null;
+            for (BuildStepArgument argument : arguments.values()) {
+                for (Path jar : Dependencies.select(argument.folder(), group, "runtime")) {
+                    jars.add(jar.toString());
+                }
+                Path candidate = argument.folder().resolve(configFile);
+                if (Files.isRegularFile(candidate)) {
+                    config = candidate;
+                }
+                Path sources = argument.folder().resolve(Bind.SOURCES);
+                if (Files.isDirectory(sources)) {
+                    roots.add(sources.toString());
+                    try (Stream<Path> walk = Files.walk(sources)) {
+                        hasScala = hasScala || walk.anyMatch(file -> file.toString().endsWith(".scala"));
+                    }
+                }
+            }
+            if (!hasScala) {
+                return CompletableFuture.completedStage(null);
+            }
+            if (jars.isEmpty()) {
+                throw new IllegalStateException("No scalafmt jars resolved upstream of the scalafmt step");
+            }
+            if (config == null) {
+                throw new IllegalStateException("No " + configFile + " found among the inputs of the scalafmt step");
+            }
+            List<String> commands = new ArrayList<>(List.of(
+                    "-cp", String.join(File.pathSeparator, jars),
+                    "org.scalafmt.cli.Cli",
+                    "--test",
+                    "--config", config.toString()));
+            commands.addAll(roots);
+            return CompletableFuture.completedStage(commands);
+        }
+    }
+}

--- a/sources/build/jenesis/project/ScalafmtModule.java
+++ b/sources/build/jenesis/project/ScalafmtModule.java
@@ -30,10 +30,9 @@ public class ScalafmtModule implements BuildExecutorModule {
     private final String group;
     private final String configFile;
     private final boolean strict;
-    private final transient Function<List<String>, ? extends ProcessHandler> factory;
 
     public ScalafmtModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
-        this(repositories, resolvers, null, "scalafmt", ".scalafmt.conf", false, null);
+        this(repositories, resolvers, null, "scalafmt", ".scalafmt.conf", false);
     }
 
     private ScalafmtModule(Map<String, Repository> repositories,
@@ -41,55 +40,53 @@ public class ScalafmtModule implements BuildExecutorModule {
                            Pinning pinning,
                            String group,
                            String configFile,
-                           boolean strict,
-                           Function<List<String>, ? extends ProcessHandler> factory) {
+                           boolean strict) {
         this.repositories = repositories;
         this.resolvers = resolvers;
         this.pinning = pinning;
         this.group = group;
         this.configFile = configFile;
         this.strict = strict;
-        this.factory = factory;
+    }
+
+    public static boolean isConfigured(SequencedMap<String, Path> inherited) {
+        for (Path folder : inherited.values()) {
+            if (Files.isRegularFile(folder.resolve(".scalafmt.conf"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public ScalafmtModule pinning(Pinning pinning) {
-        return new ScalafmtModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new ScalafmtModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public ScalafmtModule group(String group) {
-        return new ScalafmtModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new ScalafmtModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public ScalafmtModule configFile(String configFile) {
-        return new ScalafmtModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new ScalafmtModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public ScalafmtModule strict(boolean strict) {
-        return new ScalafmtModule(repositories, resolvers, pinning, group, configFile, strict, factory);
-    }
-
-    public ScalafmtModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
-        return new ScalafmtModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new ScalafmtModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     @Override
     public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
-        SequencedSet<String> upstream = inherited.sequencedKeySet();
-        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        buildExecutor.addStep(REQUIRED, new Requires(group), inherited.sequencedKeySet());
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(REQUIRED);
-        resolveInputs.addAll(upstream);
+        resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
                 new Dependencies(repositories, resolvers).pinning(pinning),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);
-        checkInputs.addAll(upstream);
-        buildExecutor.addStep(CHECK,
-                factory == null
-                        ? new Check(group, configFile, strict)
-                        : new Check(group, configFile, strict, factory),
-                checkInputs);
+        checkInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(CHECK, new Check(group, configFile, strict), checkInputs);
     }
 
     private record Requires(String group) implements BuildStep {
@@ -118,14 +115,7 @@ public class ScalafmtModule implements BuildExecutorModule {
         private final boolean strict;
 
         private Check(String group, String configFile, boolean strict) {
-            this(group, configFile, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
-        }
-
-        private Check(String group,
-                      String configFile,
-                      boolean strict,
-                      Function<List<String>, ? extends ProcessHandler> factory) {
-            super("scalafmt", factory);
+            super("scalafmt", ProcessHandler.OfProcess.ofJavaHome("bin/java"));
             this.group = group;
             this.configFile = configFile;
             this.strict = strict;

--- a/sources/build/jenesis/project/ScalastyleModule.java
+++ b/sources/build/jenesis/project/ScalastyleModule.java
@@ -177,7 +177,7 @@ public class ScalastyleModule implements BuildExecutorModule {
             List<String> commands = new ArrayList<>(List.of(
                     "-cp", String.join(File.pathSeparator, jars),
                     "org.scalastyle.Main",
-                    "-c", config.toString(),
+                    "--config", config.toString(),
                     "--xmlOutput", report.toString()));
             commands.addAll(roots);
             return CompletableFuture.completedStage(commands);

--- a/sources/build/jenesis/project/ScalastyleModule.java
+++ b/sources/build/jenesis/project/ScalastyleModule.java
@@ -1,0 +1,186 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Bind;
+import build.jenesis.step.Dependencies;
+import build.jenesis.step.JdkProcessBuildStep;
+import build.jenesis.step.ProcessHandler;
+
+public class ScalastyleModule implements BuildExecutorModule {
+
+    public static final String CHECK = "check";
+    private static final String REQUIRED = "required", DEPENDENCIES = "dependencies";
+
+    private static final String MAVEN_GROUP = "com.beautiful-scala";
+    private static final String MAVEN_ARTIFACT = "scalastyle_2.13";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String group;
+    private final String configFile;
+    private final boolean strict;
+    private final transient Function<List<String>, ? extends ProcessHandler> factory;
+
+    public ScalastyleModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "scalastyle", "scalastyle-config.xml", false, null);
+    }
+
+    private ScalastyleModule(Map<String, Repository> repositories,
+                             Map<String, Resolver> resolvers,
+                             Pinning pinning,
+                             String group,
+                             String configFile,
+                             boolean strict,
+                             Function<List<String>, ? extends ProcessHandler> factory) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.group = group;
+        this.configFile = configFile;
+        this.strict = strict;
+        this.factory = factory;
+    }
+
+    public ScalastyleModule pinning(Pinning pinning) {
+        return new ScalastyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public ScalastyleModule group(String group) {
+        return new ScalastyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public ScalastyleModule configFile(String configFile) {
+        return new ScalastyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public ScalastyleModule strict(boolean strict) {
+        return new ScalastyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public ScalastyleModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
+        return new ScalastyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        SequencedSet<String> upstream = inherited.sequencedKeySet();
+        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(upstream);
+        buildExecutor.addStep(DEPENDENCIES,
+                new Dependencies(repositories, resolvers).pinning(pinning),
+                resolveInputs);
+        SequencedSet<String> checkInputs = new LinkedHashSet<>();
+        checkInputs.add(DEPENDENCIES);
+        checkInputs.addAll(upstream);
+        buildExecutor.addStep(CHECK,
+                factory == null
+                        ? new Check(group, configFile, strict)
+                        : new Check(group, configFile, strict, factory),
+                checkInputs);
+    }
+
+    private record Requires(String group) implements BuildStep {
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return false;
+        }
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(group + "/runtime/maven/" + MAVEN_GROUP + "/" + MAVEN_ARTIFACT + "/RELEASE", "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private static class Check extends JdkProcessBuildStep {
+
+        private final String group;
+        private final String configFile;
+        private final boolean strict;
+
+        private Check(String group, String configFile, boolean strict) {
+            this(group, configFile, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
+        }
+
+        private Check(String group,
+                      String configFile,
+                      boolean strict,
+                      Function<List<String>, ? extends ProcessHandler> factory) {
+            super("scalastyle", factory);
+            this.group = group;
+            this.configFile = configFile;
+            this.strict = strict;
+        }
+
+        @Override
+        public boolean acceptableExitCode(int code,
+                                          Executor executor,
+                                          BuildStepContext context,
+                                          SequencedMap<String, BuildStepArgument> arguments) {
+            return !strict || code == 0;
+        }
+
+        @Override
+        public CompletionStage<List<String>> process(Executor executor,
+                                                     BuildStepContext context,
+                                                     SequencedMap<String, BuildStepArgument> arguments,
+                                                     SequencedMap<String, SequencedMap<String, String>> properties)
+                throws IOException {
+            List<String> jars = new ArrayList<>(), roots = new ArrayList<>();
+            boolean hasScala = false;
+            Path config = null;
+            for (BuildStepArgument argument : arguments.values()) {
+                for (Path jar : Dependencies.select(argument.folder(), group, "runtime")) {
+                    jars.add(jar.toString());
+                }
+                Path candidate = argument.folder().resolve(configFile);
+                if (Files.isRegularFile(candidate)) {
+                    config = candidate;
+                }
+                Path sources = argument.folder().resolve(Bind.SOURCES);
+                if (Files.isDirectory(sources)) {
+                    roots.add(sources.toString());
+                    try (Stream<Path> walk = Files.walk(sources)) {
+                        hasScala = hasScala || walk.anyMatch(file -> file.toString().endsWith(".scala"));
+                    }
+                }
+            }
+            if (!hasScala) {
+                return CompletableFuture.completedStage(null);
+            }
+            if (jars.isEmpty()) {
+                throw new IllegalStateException("No Scalastyle jars resolved upstream of the Scalastyle step");
+            }
+            if (config == null) {
+                throw new IllegalStateException("No " + configFile + " found among the inputs of the Scalastyle step");
+            }
+            Path report = context.next().resolve("scalastyle-report.xml");
+            List<String> commands = new ArrayList<>(List.of(
+                    "-cp", String.join(File.pathSeparator, jars),
+                    "org.scalastyle.Main",
+                    "-c", config.toString(),
+                    "--xmlOutput", report.toString()));
+            commands.addAll(roots);
+            return CompletableFuture.completedStage(commands);
+        }
+    }
+}

--- a/sources/build/jenesis/project/ScalastyleModule.java
+++ b/sources/build/jenesis/project/ScalastyleModule.java
@@ -30,10 +30,9 @@ public class ScalastyleModule implements BuildExecutorModule {
     private final String group;
     private final String configFile;
     private final boolean strict;
-    private final transient Function<List<String>, ? extends ProcessHandler> factory;
 
     public ScalastyleModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
-        this(repositories, resolvers, null, "scalastyle", "scalastyle-config.xml", false, null);
+        this(repositories, resolvers, null, "scalastyle", "scalastyle-config.xml", false);
     }
 
     private ScalastyleModule(Map<String, Repository> repositories,
@@ -41,55 +40,53 @@ public class ScalastyleModule implements BuildExecutorModule {
                              Pinning pinning,
                              String group,
                              String configFile,
-                             boolean strict,
-                             Function<List<String>, ? extends ProcessHandler> factory) {
+                             boolean strict) {
         this.repositories = repositories;
         this.resolvers = resolvers;
         this.pinning = pinning;
         this.group = group;
         this.configFile = configFile;
         this.strict = strict;
-        this.factory = factory;
+    }
+
+    public static boolean isConfigured(SequencedMap<String, Path> inherited) {
+        for (Path folder : inherited.values()) {
+            if (Files.isRegularFile(folder.resolve("scalastyle-config.xml"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public ScalastyleModule pinning(Pinning pinning) {
-        return new ScalastyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new ScalastyleModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public ScalastyleModule group(String group) {
-        return new ScalastyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new ScalastyleModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public ScalastyleModule configFile(String configFile) {
-        return new ScalastyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new ScalastyleModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public ScalastyleModule strict(boolean strict) {
-        return new ScalastyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
-    }
-
-    public ScalastyleModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
-        return new ScalastyleModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new ScalastyleModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     @Override
     public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
-        SequencedSet<String> upstream = inherited.sequencedKeySet();
-        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        buildExecutor.addStep(REQUIRED, new Requires(group), inherited.sequencedKeySet());
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(REQUIRED);
-        resolveInputs.addAll(upstream);
+        resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
                 new Dependencies(repositories, resolvers).pinning(pinning),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);
-        checkInputs.addAll(upstream);
-        buildExecutor.addStep(CHECK,
-                factory == null
-                        ? new Check(group, configFile, strict)
-                        : new Check(group, configFile, strict, factory),
-                checkInputs);
+        checkInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(CHECK, new Check(group, configFile, strict), checkInputs);
     }
 
     private record Requires(String group) implements BuildStep {
@@ -118,14 +115,7 @@ public class ScalastyleModule implements BuildExecutorModule {
         private final boolean strict;
 
         private Check(String group, String configFile, boolean strict) {
-            this(group, configFile, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
-        }
-
-        private Check(String group,
-                      String configFile,
-                      boolean strict,
-                      Function<List<String>, ? extends ProcessHandler> factory) {
-            super("scalastyle", factory);
+            super("scalastyle", ProcessHandler.OfProcess.ofJavaHome("bin/java"));
             this.group = group;
             this.configFile = configFile;
             this.strict = strict;

--- a/sources/build/jenesis/project/SpotBugsModule.java
+++ b/sources/build/jenesis/project/SpotBugsModule.java
@@ -1,0 +1,188 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Dependencies;
+import build.jenesis.step.JdkProcessBuildStep;
+import build.jenesis.step.ProcessHandler;
+
+public class SpotBugsModule implements BuildExecutorModule {
+
+    public static final String CHECK = "check";
+    private static final String REQUIRED = "required", DEPENDENCIES = "dependencies";
+
+    private static final String MAVEN_GROUP = "com.github.spotbugs";
+    private static final String MAVEN_ARTIFACT = "spotbugs";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String group;
+    private final String configFile;
+    private final boolean strict;
+    private final transient Function<List<String>, ? extends ProcessHandler> factory;
+
+    public SpotBugsModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "spotbugs", "spotbugs-exclude.xml", false, null);
+    }
+
+    private SpotBugsModule(Map<String, Repository> repositories,
+                           Map<String, Resolver> resolvers,
+                           Pinning pinning,
+                           String group,
+                           String configFile,
+                           boolean strict,
+                           Function<List<String>, ? extends ProcessHandler> factory) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.group = group;
+        this.configFile = configFile;
+        this.strict = strict;
+        this.factory = factory;
+    }
+
+    public SpotBugsModule pinning(Pinning pinning) {
+        return new SpotBugsModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public SpotBugsModule group(String group) {
+        return new SpotBugsModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public SpotBugsModule configFile(String configFile) {
+        return new SpotBugsModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public SpotBugsModule strict(boolean strict) {
+        return new SpotBugsModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    public SpotBugsModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
+        return new SpotBugsModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        SequencedSet<String> upstream = inherited.sequencedKeySet();
+        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(upstream);
+        buildExecutor.addStep(DEPENDENCIES,
+                new Dependencies(repositories, resolvers).pinning(pinning),
+                resolveInputs);
+        SequencedSet<String> checkInputs = new LinkedHashSet<>();
+        checkInputs.add(DEPENDENCIES);
+        checkInputs.addAll(upstream);
+        buildExecutor.addStep(CHECK,
+                factory == null
+                        ? new Check(group, configFile, strict)
+                        : new Check(group, configFile, strict, factory),
+                checkInputs);
+    }
+
+    private record Requires(String group) implements BuildStep {
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return false;
+        }
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(group + "/runtime/maven/" + MAVEN_GROUP + "/" + MAVEN_ARTIFACT + "/RELEASE", "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private static class Check extends JdkProcessBuildStep {
+
+        private final String group;
+        private final String configFile;
+        private final boolean strict;
+
+        private Check(String group, String configFile, boolean strict) {
+            this(group, configFile, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
+        }
+
+        private Check(String group,
+                      String configFile,
+                      boolean strict,
+                      Function<List<String>, ? extends ProcessHandler> factory) {
+            super("spotbugs", factory);
+            this.group = group;
+            this.configFile = configFile;
+            this.strict = strict;
+        }
+
+        @Override
+        public boolean acceptableExitCode(int code,
+                                          Executor executor,
+                                          BuildStepContext context,
+                                          SequencedMap<String, BuildStepArgument> arguments) {
+            return !strict || code == 0;
+        }
+
+        @Override
+        public CompletionStage<List<String>> process(Executor executor,
+                                                     BuildStepContext context,
+                                                     SequencedMap<String, BuildStepArgument> arguments,
+                                                     SequencedMap<String, SequencedMap<String, String>> properties)
+                throws IOException {
+            List<String> jars = new ArrayList<>(), classes = new ArrayList<>(), auxiliary = new ArrayList<>();
+            Path config = null;
+            for (BuildStepArgument argument : arguments.values()) {
+                for (Path jar : Dependencies.select(argument.folder(), group, "runtime")) {
+                    jars.add(jar.toString());
+                }
+                for (Path jar : Dependencies.select(argument.folder(), "compile")) {
+                    auxiliary.add(jar.toString());
+                }
+                Path candidate = argument.folder().resolve(configFile);
+                if (Files.isRegularFile(candidate)) {
+                    config = candidate;
+                }
+                Path compiled = argument.folder().resolve(BuildStep.CLASSES);
+                if (Files.isDirectory(compiled)) {
+                    classes.add(compiled.toString());
+                }
+            }
+            if (classes.isEmpty()) {
+                return CompletableFuture.completedStage(null);
+            }
+            if (jars.isEmpty()) {
+                throw new IllegalStateException("No SpotBugs jars resolved upstream of the SpotBugs step");
+            }
+            Path report = context.next().resolve("spotbugs-report.xml");
+            List<String> commands = new ArrayList<>(List.of(
+                    "-cp", String.join(File.pathSeparator, jars),
+                    "edu.umd.cs.findbugs.LaunchAppropriateUI", "-textui",
+                    "-xml", "-output", report.toString()));
+            if (config != null) {
+                commands.add("-exclude");
+                commands.add(config.toString());
+            }
+            if (!auxiliary.isEmpty()) {
+                commands.add("-auxclasspath");
+                commands.add(String.join(File.pathSeparator, auxiliary));
+            }
+            commands.addAll(classes);
+            return CompletableFuture.completedStage(commands);
+        }
+    }
+}

--- a/sources/build/jenesis/project/SpotBugsModule.java
+++ b/sources/build/jenesis/project/SpotBugsModule.java
@@ -29,10 +29,9 @@ public class SpotBugsModule implements BuildExecutorModule {
     private final String group;
     private final String configFile;
     private final boolean strict;
-    private final transient Function<List<String>, ? extends ProcessHandler> factory;
 
     public SpotBugsModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
-        this(repositories, resolvers, null, "spotbugs", "spotbugs-exclude.xml", false, null);
+        this(repositories, resolvers, null, "spotbugs", "spotbugs-exclude.xml", false);
     }
 
     private SpotBugsModule(Map<String, Repository> repositories,
@@ -40,55 +39,54 @@ public class SpotBugsModule implements BuildExecutorModule {
                            Pinning pinning,
                            String group,
                            String configFile,
-                           boolean strict,
-                           Function<List<String>, ? extends ProcessHandler> factory) {
+                           boolean strict) {
         this.repositories = repositories;
         this.resolvers = resolvers;
         this.pinning = pinning;
         this.group = group;
         this.configFile = configFile;
         this.strict = strict;
-        this.factory = factory;
+    }
+
+    public static boolean isConfigured(SequencedMap<String, Path> inherited) {
+        for (Path folder : inherited.values()) {
+            if (Files.isRegularFile(folder.resolve("spotbugs-exclude.xml"))
+                    || Files.isRegularFile(folder.resolve("spotbugs.xml"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public SpotBugsModule pinning(Pinning pinning) {
-        return new SpotBugsModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new SpotBugsModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public SpotBugsModule group(String group) {
-        return new SpotBugsModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new SpotBugsModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public SpotBugsModule configFile(String configFile) {
-        return new SpotBugsModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new SpotBugsModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     public SpotBugsModule strict(boolean strict) {
-        return new SpotBugsModule(repositories, resolvers, pinning, group, configFile, strict, factory);
-    }
-
-    public SpotBugsModule factory(Function<List<String>, ? extends ProcessHandler> factory) {
-        return new SpotBugsModule(repositories, resolvers, pinning, group, configFile, strict, factory);
+        return new SpotBugsModule(repositories, resolvers, pinning, group, configFile, strict);
     }
 
     @Override
     public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
-        SequencedSet<String> upstream = inherited.sequencedKeySet();
-        buildExecutor.addStep(REQUIRED, new Requires(group), upstream);
+        buildExecutor.addStep(REQUIRED, new Requires(group), inherited.sequencedKeySet());
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(REQUIRED);
-        resolveInputs.addAll(upstream);
+        resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
                 new Dependencies(repositories, resolvers).pinning(pinning),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);
-        checkInputs.addAll(upstream);
-        buildExecutor.addStep(CHECK,
-                factory == null
-                        ? new Check(group, configFile, strict)
-                        : new Check(group, configFile, strict, factory),
-                checkInputs);
+        checkInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(CHECK, new Check(group, configFile, strict), checkInputs);
     }
 
     private record Requires(String group) implements BuildStep {
@@ -117,14 +115,7 @@ public class SpotBugsModule implements BuildExecutorModule {
         private final boolean strict;
 
         private Check(String group, String configFile, boolean strict) {
-            this(group, configFile, strict, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
-        }
-
-        private Check(String group,
-                      String configFile,
-                      boolean strict,
-                      Function<List<String>, ? extends ProcessHandler> factory) {
-            super("spotbugs", factory);
+            super("spotbugs", ProcessHandler.OfProcess.ofJavaHome("bin/java"));
             this.group = group;
             this.configFile = configFile;
             this.strict = strict;

--- a/tests/build/jenesis/test/maven/MavenPomResolverTest.java
+++ b/tests/build/jenesis/test/maven/MavenPomResolverTest.java
@@ -265,9 +265,6 @@ public class MavenPomResolverTest {
 
     @Test
     public void undefined_property_in_unconsumed_managed_dependency_is_tolerated() throws IOException {
-        // Mirrors log4j-core 2.25.1, whose POM manages error_prone_annotations at ${error-prone.version}
-        // but only defines error-prone-annotations.version. Maven leaves the unresolved managed version in
-        // place because nothing consumes that entry; resolution must not fail with "Property not defined".
         addToRepository("group", "artifact", "1", """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/tests/build/jenesis/test/maven/MavenPomResolverTest.java
+++ b/tests/build/jenesis/test/maven/MavenPomResolverTest.java
@@ -264,6 +264,51 @@ public class MavenPomResolverTest {
     }
 
     @Test
+    public void undefined_property_in_unconsumed_managed_dependency_is_tolerated() throws IOException {
+        // Mirrors log4j-core 2.25.1, whose POM manages error_prone_annotations at ${error-prone.version}
+        // but only defines error-prone-annotations.version. Maven leaves the unresolved managed version in
+        // place because nothing consumes that entry; resolution must not fail with "Property not defined".
+        addToRepository("group", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>unused</groupId>
+                                <artifactId>managed</artifactId>
+                                <version>${undefined.property}</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                    <dependencies>
+                        <dependency>
+                            <groupId>other</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>1</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        addToRepository("other", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                </project>
+                """);
+        SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies = mavenPomResolver.dependencies(
+                Runnable::run,
+                mavenRepository,
+                "group",
+                "artifact",
+                "1",
+                null);
+        assertThat(dependencies).containsExactly(Map.entry(
+                new MavenDependencyKey("other", "artifact", "jar", null),
+                new MavenDependencyValue("1", MavenDependencyScope.COMPILE, null, null, null)));
+    }
+
+    @Test
     public void can_resolve_dependencies_with_nested_property() throws IOException {
         addToRepository("group", "artifact", "1", """
                 <?xml version="1.0" encoding="UTF-8"?>

--- a/tests/build/jenesis/test/project/CheckstyleModuleRunTest.java
+++ b/tests/build/jenesis/test/project/CheckstyleModuleRunTest.java
@@ -1,0 +1,96 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.maven.MavenDefaultRepository;
+import build.jenesis.maven.MavenPomResolver;
+import build.jenesis.project.CheckstyleModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class CheckstyleModuleRunTest {
+
+    private static final String CONFIG = """
+            <?xml version="1.0"?>
+            <!DOCTYPE module PUBLIC
+                "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+                "https://checkstyle.org/dtds/configuration_1_3.dtd">
+            <module name="Checker">
+                <property name="severity" value="error"/>
+                <module name="TreeWalker">
+                    <module name="TypeName"/>
+                </module>
+            </module>
+            """;
+
+    @TempDir
+    private Path root, project;
+
+    @BeforeEach
+    public void writeProject() throws IOException {
+        Files.writeString(project.resolve("checkstyle.xml"), CONFIG);
+        Path sampleDir = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample"));
+        Files.writeString(sampleDir.resolve("badName.java"), """
+                package sample;
+                public class badName {
+                }
+                """);
+    }
+
+    @Test
+    public void writes_a_report_without_failing_the_build_in_report_only_mode() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule(
+                "checkstyle",
+                new CheckstyleModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver())),
+                "project");
+        executor.execute();
+
+        Path report = root.resolve("checkstyle").resolve("check").resolve("output").resolve("checkstyle-report.xml");
+        assertThat(report)
+                .as("report-only run still produces the Checkstyle XML report")
+                .isNotEmptyFile();
+        assertThat(report).content().contains("badName");
+    }
+
+    @Test
+    public void strict_mode_fails_the_build_on_a_violation() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule(
+                "checkstyle",
+                new CheckstyleModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver()))
+                        .strict(true),
+                "project");
+
+        assertThatThrownBy(executor::execute)
+                .hasRootCauseInstanceOf(IllegalStateException.class)
+                .rootCause()
+                .hasMessageContaining("Unexpected exit code");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+
+    private static Repository mavenCentral() {
+        Path local = Path.of(System.getProperty("user.home"), ".m2", "repository");
+        return new MavenDefaultRepository(
+                URI.create("https://repo1.maven.org/maven2/"),
+                Files.isDirectory(local) ? local : null,
+                Map.of(),
+                _ -> {});
+    }
+}

--- a/tests/build/jenesis/test/project/CheckstyleModuleTest.java
+++ b/tests/build/jenesis/test/project/CheckstyleModuleTest.java
@@ -1,0 +1,69 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.RepositoryItem;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.CheckstyleModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CheckstyleModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void requires_step_emits_the_checkstyle_maven_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("checkstyle", new CheckstyleModule(Map.of(), Map.of()), "project");
+        executor.execute("checkstyle/required");
+
+        Path requiredOutput = root.resolve("checkstyle").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("checkstyle/runtime/maven/com.puppycrawl.tools/checkstyle/RELEASE");
+    }
+
+    @Test
+    public void group_emits_an_independent_resolution_trail() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule(
+                "checkstyle",
+                new CheckstyleModule(Map.of("maven", files()), Map.of("maven", Resolver.identity()))
+                        .group("custom"),
+                "project");
+        executor.execute("checkstyle/dependencies");
+
+        Path resolvedOutput = root.resolve("checkstyle").resolve("dependencies").resolve("output");
+        SequencedProperties resolved = SequencedProperties.ofFiles(resolvedOutput.resolve(BuildStep.DEPENDENCIES));
+        assertThat(resolved.stringPropertyNames())
+                .containsExactly("custom/runtime/maven/com.puppycrawl.tools/checkstyle/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+
+    private Repository files() {
+        return (_, coordinate) -> {
+            Path file = Files.write(
+                    Files.createDirectories(root.resolve("served")).resolve(coordinate.replace('/', '-') + ".jar"),
+                    coordinate.getBytes(StandardCharsets.UTF_8));
+            return Optional.of(RepositoryItem.ofFile(file));
+        };
+    }
+}

--- a/tests/build/jenesis/test/project/CodeNarcModuleRunTest.java
+++ b/tests/build/jenesis/test/project/CodeNarcModuleRunTest.java
@@ -1,0 +1,82 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.SequencedProperties;
+import build.jenesis.maven.MavenDefaultRepository;
+import build.jenesis.maven.MavenPomResolver;
+import build.jenesis.project.CodeNarcModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CodeNarcModuleRunTest {
+
+    private static final String CONFIG = """
+            <ruleset xmlns="http://codenarc.org/ruleset/1.0">
+                <rule class="org.codenarc.rule.basic.EmptyIfStatementRule"/>
+            </ruleset>
+            """;
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void downloads_the_pinned_codenarc_and_writes_a_report() throws IOException {
+        SequencedProperties versions = new SequencedProperties();
+        versions.setProperty("codenarc/maven/org.codenarc/CodeNarc", "3.5.0");
+        versions.setProperty("codenarc/maven/org.apache.groovy/groovy", "4.0.23");
+        versions.setProperty("codenarc/maven/org.slf4j/slf4j-simple", "2.0.16");
+        versions.store(project.resolve(BuildStep.VERSIONS));
+        Files.writeString(project.resolve("codenarc.xml"), CONFIG);
+        Path sampleDir = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample"));
+        Files.writeString(sampleDir.resolve("Sample.groovy"), """
+                package sample
+                class Sample {
+                    void run() {
+                        if (true) { }
+                    }
+                }
+                """);
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule(
+                "codenarc",
+                new CodeNarcModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver())),
+                "project");
+        executor.execute();
+
+        Path resolved = root.resolve("codenarc").resolve("dependencies").resolve("output").resolve("resolved");
+        try (Stream<Path> jars = Files.list(resolved)) {
+            assertThat(jars.map(jar -> jar.getFileName().toString()))
+                    .as("the pinned CodeNarc version resolves")
+                    .anyMatch(name -> name.contains("CodeNarc") && name.contains("3.5.0"));
+        }
+        Path report = root.resolve("codenarc").resolve("check").resolve("output").resolve("codenarc-report.xml");
+        assertThat(report).isNotEmptyFile();
+        assertThat(report).content().contains("EmptyIfStatement");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+
+    private static Repository mavenCentral() {
+        Path local = Path.of(System.getProperty("user.home"), ".m2", "repository");
+        return new MavenDefaultRepository(
+                URI.create("https://repo1.maven.org/maven2/"),
+                Files.isDirectory(local) ? local : null,
+                Map.of(),
+                _ -> {});
+    }
+}

--- a/tests/build/jenesis/test/project/CodeNarcModuleTest.java
+++ b/tests/build/jenesis/test/project/CodeNarcModuleTest.java
@@ -1,0 +1,43 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.CodeNarcModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CodeNarcModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void requires_step_emits_codenarc_with_its_groovy_and_logging_runtime() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("codenarc", new CodeNarcModule(Map.of(), Map.of()), "project");
+        executor.execute("codenarc/required");
+
+        Path requiredOutput = root.resolve("codenarc").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly(
+                        "codenarc/runtime/maven/org.codenarc/CodeNarc/RELEASE",
+                        "codenarc/runtime/maven/org.apache.groovy/groovy/RELEASE",
+                        "codenarc/runtime/maven/org.slf4j/slf4j-simple/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/DetektModuleRunTest.java
+++ b/tests/build/jenesis/test/project/DetektModuleRunTest.java
@@ -1,0 +1,80 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.SequencedProperties;
+import build.jenesis.maven.MavenDefaultRepository;
+import build.jenesis.maven.MavenPomResolver;
+import build.jenesis.project.DetektModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DetektModuleRunTest {
+
+    private static final String VERSION = "1.23.7";
+
+    private static final String CONFIG = """
+            style:
+              active: true
+              MaxLineLength:
+                active: true
+                maxLineLength: 10
+            """;
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void downloads_the_pinned_detekt_and_writes_a_report() throws IOException {
+        SequencedProperties versions = new SequencedProperties();
+        versions.setProperty("detekt/maven/io.gitlab.arturbosch.detekt/detekt-cli", VERSION);
+        versions.store(project.resolve(BuildStep.VERSIONS));
+        Files.writeString(project.resolve("detekt.yml"), CONFIG);
+        Path sampleDir = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample"));
+        Files.writeString(sampleDir.resolve("Sample.kt"), """
+                package sample
+                fun greetTheEntireWorld(): Int = 42
+                """);
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule(
+                "detekt",
+                new DetektModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver())),
+                "project");
+        executor.execute();
+
+        Path resolved = root.resolve("detekt").resolve("dependencies").resolve("output").resolve("resolved");
+        try (Stream<Path> jars = Files.list(resolved)) {
+            assertThat(jars.map(jar -> jar.getFileName().toString()))
+                    .as("the pinned detekt version resolves")
+                    .anyMatch(name -> name.contains("detekt-cli") && name.contains(VERSION));
+        }
+        Path report = root.resolve("detekt").resolve("check").resolve("output").resolve("detekt-report.xml");
+        assertThat(report).isNotEmptyFile();
+        assertThat(report).content().contains("MaxLineLength");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+
+    private static Repository mavenCentral() {
+        Path local = Path.of(System.getProperty("user.home"), ".m2", "repository");
+        return new MavenDefaultRepository(
+                URI.create("https://repo1.maven.org/maven2/"),
+                Files.isDirectory(local) ? local : null,
+                Map.of(),
+                _ -> {});
+    }
+}

--- a/tests/build/jenesis/test/project/DetektModuleTest.java
+++ b/tests/build/jenesis/test/project/DetektModuleTest.java
@@ -1,0 +1,40 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.DetektModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DetektModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void requires_step_emits_the_detekt_maven_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("detekt", new DetektModule(Map.of(), Map.of()), "project");
+        executor.execute("detekt/required");
+
+        Path requiredOutput = root.resolve("detekt").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("detekt/runtime/maven/io.gitlab.arturbosch.detekt/detekt-cli/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/InferredByteCodeQualityModuleTest.java
+++ b/tests/build/jenesis/test/project/InferredByteCodeQualityModuleTest.java
@@ -1,0 +1,54 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.InferredByteCodeQualityModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InferredByteCodeQualityModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void wires_spotbugs_when_its_filter_file_is_present() throws IOException {
+        Files.writeString(project.resolve("spotbugs-exclude.xml"), "<FindBugsFilter/>");
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("quality", new InferredByteCodeQualityModule(Map.of(), Map.of()), "project");
+        executor.execute("quality/spotbugs/required");
+
+        Path requiredOutput = root.resolve("quality").resolve("spotbugs").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("spotbugs/runtime/maven/com.github.spotbugs/spotbugs/RELEASE");
+    }
+
+    @Test
+    public void skips_spotbugs_when_no_filter_file_is_present() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("quality", new InferredByteCodeQualityModule(Map.of(), Map.of()), "project");
+        executor.execute();
+
+        assertThat(root.resolve("quality").resolve("spotbugs"))
+                .as("SpotBugs is not wired when neither spotbugs-exclude.xml nor spotbugs.xml is present")
+                .doesNotExist();
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/InferredSourceCodeQualityModuleTest.java
+++ b/tests/build/jenesis/test/project/InferredSourceCodeQualityModuleTest.java
@@ -1,0 +1,54 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.InferredSourceCodeQualityModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InferredSourceCodeQualityModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void wires_checkstyle_when_its_config_file_is_present() throws IOException {
+        Files.writeString(project.resolve("checkstyle.xml"), "<module name=\"Checker\"/>");
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("quality", new InferredSourceCodeQualityModule(Map.of(), Map.of()), "project");
+        executor.execute("quality/checkstyle/required");
+
+        Path requiredOutput = root.resolve("quality").resolve("checkstyle").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("checkstyle/runtime/maven/com.puppycrawl.tools/checkstyle/RELEASE");
+    }
+
+    @Test
+    public void skips_checkstyle_when_its_config_file_is_absent() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("quality", new InferredSourceCodeQualityModule(Map.of(), Map.of()), "project");
+        executor.execute();
+
+        assertThat(root.resolve("quality").resolve("checkstyle"))
+                .as("Checkstyle is not wired when checkstyle.xml is absent from the project")
+                .doesNotExist();
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/KtlintModuleRunTest.java
+++ b/tests/build/jenesis/test/project/KtlintModuleRunTest.java
@@ -1,0 +1,78 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.SequencedProperties;
+import build.jenesis.maven.MavenDefaultRepository;
+import build.jenesis.maven.MavenPomResolver;
+import build.jenesis.project.KtlintModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KtlintModuleRunTest {
+
+    private static final String VERSION = "1.5.0";
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void downloads_the_pinned_ktlint_and_writes_a_report() throws IOException {
+        SequencedProperties versions = new SequencedProperties();
+        versions.setProperty("ktlint/maven/com.pinterest.ktlint/ktlint-cli", VERSION);
+        versions.store(project.resolve(BuildStep.VERSIONS));
+        Files.writeString(project.resolve(".editorconfig"), """
+                root = true
+                [*.kt]
+                indent_size = 4
+                """);
+        Path sampleDir = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample"));
+        Files.writeString(sampleDir.resolve("Sample.kt"), """
+                package sample
+                fun main() {
+                println("hello")
+                }
+                """);
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule(
+                "ktlint",
+                new KtlintModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver())),
+                "project");
+        executor.execute();
+
+        Path resolved = root.resolve("ktlint").resolve("dependencies").resolve("output").resolve("resolved");
+        try (Stream<Path> jars = Files.list(resolved)) {
+            assertThat(jars.map(jar -> jar.getFileName().toString()))
+                    .as("the pinned ktlint version resolves")
+                    .anyMatch(name -> name.contains("ktlint-cli") && name.contains(VERSION));
+        }
+        Path report = root.resolve("ktlint").resolve("check").resolve("output").resolve("ktlint-report.xml");
+        assertThat(report).isNotEmptyFile();
+        assertThat(report).content().contains("Sample.kt");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+
+    private static Repository mavenCentral() {
+        Path local = Path.of(System.getProperty("user.home"), ".m2", "repository");
+        return new MavenDefaultRepository(
+                URI.create("https://repo1.maven.org/maven2/"),
+                Files.isDirectory(local) ? local : null,
+                Map.of(),
+                _ -> {});
+    }
+}

--- a/tests/build/jenesis/test/project/KtlintModuleTest.java
+++ b/tests/build/jenesis/test/project/KtlintModuleTest.java
@@ -1,0 +1,40 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.KtlintModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KtlintModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void requires_step_emits_the_ktlint_maven_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("ktlint", new KtlintModule(Map.of(), Map.of()), "project");
+        executor.execute("ktlint/required");
+
+        Path requiredOutput = root.resolve("ktlint").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("ktlint/runtime/maven/com.pinterest.ktlint/ktlint-cli/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/PmdModuleRunTest.java
+++ b/tests/build/jenesis/test/project/PmdModuleRunTest.java
@@ -1,0 +1,84 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.SequencedProperties;
+import build.jenesis.maven.MavenDefaultRepository;
+import build.jenesis.maven.MavenPomResolver;
+import build.jenesis.project.PmdModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PmdModuleRunTest {
+
+    private static final String VERSION = "7.7.0";
+
+    private static final String CONFIG = """
+            <?xml version="1.0"?>
+            <ruleset name="test"
+                     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0">
+                <rule ref="category/java/bestpractices.xml/SystemPrintln"/>
+            </ruleset>
+            """;
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void downloads_the_pinned_pmd_and_writes_a_report() throws IOException {
+        SequencedProperties versions = new SequencedProperties();
+        versions.setProperty("pmd/maven/net.sourceforge.pmd/pmd-dist", VERSION);
+        versions.store(project.resolve(BuildStep.VERSIONS));
+        Files.writeString(project.resolve("pmd.xml"), CONFIG);
+        Path sampleDir = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample"));
+        Files.writeString(sampleDir.resolve("Sample.java"), """
+                package sample;
+                public class Sample {
+                    public void run() {
+                        System.out.println("hello");
+                    }
+                }
+                """);
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule(
+                "pmd",
+                new PmdModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver())),
+                "project");
+        executor.execute();
+
+        Path resolved = root.resolve("pmd").resolve("dependencies").resolve("output").resolve("resolved");
+        try (Stream<Path> jars = Files.list(resolved)) {
+            assertThat(jars.map(jar -> jar.getFileName().toString()))
+                    .as("the pinned PMD version resolves")
+                    .anyMatch(name -> name.contains("pmd-core") && name.contains(VERSION));
+        }
+        Path report = root.resolve("pmd").resolve("check").resolve("output").resolve("pmd-report.xml");
+        assertThat(report).isNotEmptyFile();
+        assertThat(report).content().contains("SystemPrintln");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+
+    private static Repository mavenCentral() {
+        Path local = Path.of(System.getProperty("user.home"), ".m2", "repository");
+        return new MavenDefaultRepository(
+                URI.create("https://repo1.maven.org/maven2/"),
+                Files.isDirectory(local) ? local : null,
+                Map.of(),
+                _ -> {});
+    }
+}

--- a/tests/build/jenesis/test/project/PmdModuleTest.java
+++ b/tests/build/jenesis/test/project/PmdModuleTest.java
@@ -1,0 +1,40 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.PmdModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PmdModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void requires_step_emits_the_pmd_maven_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("pmd", new PmdModule(Map.of(), Map.of()), "project");
+        executor.execute("pmd/required");
+
+        Path requiredOutput = root.resolve("pmd").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("pmd/runtime/maven/net.sourceforge.pmd/pmd-dist/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/ScalafmtModuleRunTest.java
+++ b/tests/build/jenesis/test/project/ScalafmtModuleRunTest.java
@@ -11,26 +11,18 @@ import build.jenesis.Repository;
 import build.jenesis.SequencedProperties;
 import build.jenesis.maven.MavenDefaultRepository;
 import build.jenesis.maven.MavenPomResolver;
-import build.jenesis.project.CheckstyleModule;
+import build.jenesis.project.ScalafmtModule;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class CheckstyleModuleRunTest {
+public class ScalafmtModuleRunTest {
 
-    private static final String VERSION = "10.21.0";
+    private static final String VERSION = "3.8.3";
 
     private static final String CONFIG = """
-            <?xml version="1.0"?>
-            <!DOCTYPE module PUBLIC
-                "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
-                "https://checkstyle.org/dtds/configuration_1_3.dtd">
-            <module name="Checker">
-                <property name="severity" value="error"/>
-                <module name="TreeWalker">
-                    <module name="TypeName"/>
-                </module>
-            </module>
+            version = "3.8.3"
+            runner.dialect = scala213
             """;
 
     @TempDir
@@ -39,47 +31,43 @@ public class CheckstyleModuleRunTest {
     @BeforeEach
     public void writeProject() throws IOException {
         SequencedProperties versions = new SequencedProperties();
-        versions.setProperty("checkstyle/maven/com.puppycrawl.tools/checkstyle", VERSION);
+        versions.setProperty("scalafmt/maven/org.scalameta/scalafmt-cli_2.13", VERSION);
         versions.store(project.resolve(BuildStep.VERSIONS));
-        Files.writeString(project.resolve("checkstyle.xml"), CONFIG);
+        Files.writeString(project.resolve(".scalafmt.conf"), CONFIG);
         Path sampleDir = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample"));
-        Files.writeString(sampleDir.resolve("badName.java"), """
-                package sample;
-                public class badName {
-                }
-                """);
+        Files.writeString(sampleDir.resolve("Sample.scala"), "package sample\nclass Sample {   def  f( ) :Int=42 }\n");
     }
 
     @Test
-    public void writes_a_report_without_failing_the_build_in_report_only_mode() throws IOException {
+    public void report_only_runs_the_pinned_scalafmt_and_flags_the_misformatted_file() throws IOException {
         BuildExecutor executor = newExecutor();
         executor.addSource("project", project);
         executor.addModule(
-                "checkstyle",
-                new CheckstyleModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver())),
+                "scalafmt",
+                new ScalafmtModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver())),
                 "project");
         executor.execute();
 
-        Path resolved = root.resolve("checkstyle").resolve("dependencies").resolve("output").resolve("resolved");
+        Path resolved = root.resolve("scalafmt").resolve("dependencies").resolve("output").resolve("resolved");
         try (Stream<Path> jars = Files.list(resolved)) {
             assertThat(jars.map(jar -> jar.getFileName().toString()))
-                    .as("the pinned Checkstyle version is the one that resolves, not a floated RELEASE")
-                    .anyMatch(name -> name.contains("checkstyle") && name.contains(VERSION));
+                    .as("the pinned scalafmt version resolves")
+                    .anyMatch(name -> name.contains("scalafmt-cli") && name.contains(VERSION));
         }
-        Path report = root.resolve("checkstyle").resolve("check").resolve("output").resolve("checkstyle-report.xml");
-        assertThat(report)
-                .as("report-only run still produces the Checkstyle XML report")
-                .isNotEmptyFile();
-        assertThat(report).content().contains("badName");
+        Path supplement = root.resolve("scalafmt").resolve("check").resolve("supplement");
+        String captured = Files.readString(supplement.resolve("output")) + Files.readString(supplement.resolve("error"));
+        assertThat(captured)
+                .as("scalafmt --test reports the misformatted file")
+                .contains("Sample.scala");
     }
 
     @Test
-    public void strict_mode_fails_the_build_on_a_violation() throws IOException {
+    public void strict_mode_fails_the_build_on_a_misformatted_file() throws IOException {
         BuildExecutor executor = newExecutor();
         executor.addSource("project", project);
         executor.addModule(
-                "checkstyle",
-                new CheckstyleModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver()))
+                "scalafmt",
+                new ScalafmtModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver()))
                         .strict(true),
                 "project");
 

--- a/tests/build/jenesis/test/project/ScalafmtModuleTest.java
+++ b/tests/build/jenesis/test/project/ScalafmtModuleTest.java
@@ -1,0 +1,40 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.ScalafmtModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ScalafmtModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void requires_step_emits_the_scalafmt_maven_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("scalafmt", new ScalafmtModule(Map.of(), Map.of()), "project");
+        executor.execute("scalafmt/required");
+
+        Path requiredOutput = root.resolve("scalafmt").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("scalafmt/runtime/maven/org.scalameta/scalafmt-cli_2.13/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/ScalastyleModuleRunTest.java
+++ b/tests/build/jenesis/test/project/ScalastyleModuleRunTest.java
@@ -1,0 +1,85 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.SequencedProperties;
+import build.jenesis.maven.MavenDefaultRepository;
+import build.jenesis.maven.MavenPomResolver;
+import build.jenesis.project.ScalastyleModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ScalastyleModuleRunTest {
+
+    private static final String VERSION = "1.5.1";
+
+    private static final String CONFIG = """
+            <scalastyle>
+                <name>test</name>
+                <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+                    <parameters>
+                        <parameter name="maxLineLength">10</parameter>
+                    </parameters>
+                </check>
+            </scalastyle>
+            """;
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void downloads_the_pinned_scalastyle_and_writes_a_report() throws IOException {
+        SequencedProperties versions = new SequencedProperties();
+        versions.setProperty("scalastyle/maven/com.beautiful-scala/scalastyle_2.13", VERSION);
+        versions.store(project.resolve(BuildStep.VERSIONS));
+        Files.writeString(project.resolve("scalastyle-config.xml"), CONFIG);
+        Path sampleDir = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample"));
+        Files.writeString(sampleDir.resolve("Sample.scala"), """
+                package sample
+                class Sample {
+                  def greetTheEntireWorld(): Int = 42
+                }
+                """);
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule(
+                "scalastyle",
+                new ScalastyleModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver())),
+                "project");
+        executor.execute();
+
+        Path resolved = root.resolve("scalastyle").resolve("dependencies").resolve("output").resolve("resolved");
+        try (Stream<Path> jars = Files.list(resolved)) {
+            assertThat(jars.map(jar -> jar.getFileName().toString()))
+                    .as("the pinned Scalastyle version resolves")
+                    .anyMatch(name -> name.contains("scalastyle") && name.contains(VERSION));
+        }
+        Path report = root.resolve("scalastyle").resolve("check").resolve("output").resolve("scalastyle-report.xml");
+        assertThat(report).isNotEmptyFile();
+        assertThat(report).content().contains("FileLineLengthChecker");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+
+    private static Repository mavenCentral() {
+        Path local = Path.of(System.getProperty("user.home"), ".m2", "repository");
+        return new MavenDefaultRepository(
+                URI.create("https://repo1.maven.org/maven2/"),
+                Files.isDirectory(local) ? local : null,
+                Map.of(),
+                _ -> {});
+    }
+}

--- a/tests/build/jenesis/test/project/ScalastyleModuleTest.java
+++ b/tests/build/jenesis/test/project/ScalastyleModuleTest.java
@@ -1,0 +1,40 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.ScalastyleModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ScalastyleModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void requires_step_emits_the_scalastyle_maven_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("scalastyle", new ScalastyleModule(Map.of(), Map.of()), "project");
+        executor.execute("scalastyle/required");
+
+        Path requiredOutput = root.resolve("scalastyle").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("scalastyle/runtime/maven/com.beautiful-scala/scalastyle_2.13/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/SpotBugsModuleRunTest.java
+++ b/tests/build/jenesis/test/project/SpotBugsModuleRunTest.java
@@ -1,0 +1,81 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.SequencedProperties;
+import build.jenesis.maven.MavenDefaultRepository;
+import build.jenesis.maven.MavenPomResolver;
+import build.jenesis.project.SpotBugsModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpotBugsModuleRunTest {
+
+    private static final String VERSION = "4.9.6";
+
+    @TempDir
+    private Path root, project, sources;
+
+    @Test
+    public void downloads_the_pinned_spotbugs_and_writes_a_report() throws IOException {
+        SequencedProperties versions = new SequencedProperties();
+        versions.setProperty("spotbugs/maven/com.github.spotbugs/spotbugs", VERSION);
+        versions.store(project.resolve(BuildStep.VERSIONS));
+        Files.writeString(project.resolve("spotbugs-exclude.xml"), "<FindBugsFilter/>");
+
+        Path source = Files.createDirectories(sources.resolve("sample")).resolve("Sample.java");
+        Files.writeString(source, """
+                package sample;
+                public class Sample {
+                    public boolean check(String value) {
+                        return value == "expected";
+                    }
+                }
+                """);
+        Path classes = Files.createDirectories(project.resolve(BuildStep.CLASSES));
+        int rc = javax.tools.ToolProvider.getSystemJavaCompiler()
+                .run(null, null, null, "-d", classes.toString(), "--release", "17", source.toString());
+        assertThat(rc).as("the sample compiles").isZero();
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule(
+                "spotbugs",
+                new SpotBugsModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver())),
+                "project");
+        executor.execute();
+
+        Path resolved = root.resolve("spotbugs").resolve("dependencies").resolve("output").resolve("resolved");
+        try (Stream<Path> jars = Files.list(resolved)) {
+            assertThat(jars.map(jar -> jar.getFileName().toString()))
+                    .as("the pinned SpotBugs version resolves")
+                    .anyMatch(name -> name.contains("spotbugs") && name.contains(VERSION));
+        }
+        Path report = root.resolve("spotbugs").resolve("check").resolve("output").resolve("spotbugs-report.xml");
+        assertThat(report).isNotEmptyFile();
+        assertThat(report).content().contains("ES_COMPARING");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+
+    private static Repository mavenCentral() {
+        Path local = Path.of(System.getProperty("user.home"), ".m2", "repository");
+        return new MavenDefaultRepository(
+                URI.create("https://repo1.maven.org/maven2/"),
+                Files.isDirectory(local) ? local : null,
+                Map.of(),
+                _ -> {});
+    }
+}

--- a/tests/build/jenesis/test/project/SpotBugsModuleTest.java
+++ b/tests/build/jenesis/test/project/SpotBugsModuleTest.java
@@ -1,0 +1,40 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.SpotBugsModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpotBugsModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void requires_step_emits_the_spotbugs_maven_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("spotbugs", new SpotBugsModule(Map.of(), Map.of()), "project");
+        executor.execute("spotbugs/required");
+
+        Path requiredOutput = root.resolve("spotbugs").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("spotbugs/runtime/maven/com.github.spotbugs/spotbugs/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}


### PR DESCRIPTION
## What

Adds config-file-inferred code-quality plugins, bringing the same zero-config activation Jenesis already has for compilers to static-analysis and formatting tools. Drop a tool's conventional config file in the project and the matching tool runs with zero further setup, downloading its own dependencies and writing a report.

Two discovery modules, split by what they inspect:

- **`InferredByteCodeQualityModule`** - tools over compiled **class files**: SpotBugs.
- **`InferredSourceCodeQualityModule`** - tools over **source files**: Checkstyle, PMD, detekt, ktlint, Scalastyle, scalafmt, CodeNarc.

Activation is **config-file-only**: a tool is wired if, and only if, its trigger file is present (each module inspects its inherited input folders, so no extra wiring or source-tree knowledge is needed).

| Trigger file | Tool | Inspects |
|---|---|---|
| `spotbugs-exclude.xml` / `spotbugs.xml` | SpotBugs | class files |
| `checkstyle.xml` | Checkstyle | Java sources |
| `pmd.xml` | PMD | Java sources |
| `detekt.yml` | detekt | Kotlin |
| `.editorconfig` | ktlint | Kotlin |
| `scalastyle-config.xml` | Scalastyle | Scala |
| `.scalafmt.conf` | scalafmt | Scala |
| `codenarc.xml` | CodeNarc | Groovy |

## How

Each tool is a self-contained `BuildExecutorModule` mirroring the compiler modules (`required` -> `dependencies` -> `check`): it resolves in its **own dependency group** (so its runtime never mixes with the project's compile classpath), floats `RELEASE` (pinnable via `@jenesis.pin`), and runs in a forked JVM against `classes/` or `sources/`. The run step holds only `String`/`boolean` fields (the config file is reached via the input folder by filename, never a captured `Path`) to stay serialization-safe. Report-only by default; per-tool `.strict()` flips `acceptableExitCode` to fail the build on a non-zero tool exit.

## Tests

- 13 offline wiring tests (one per module, fast via `mvn -o test -Dtest=<Tool>ModuleTest`): assert the inference (present file wires the tool, absent does not) and the exact requires-coordinate.
- `CheckstyleModuleRunTest`: end-to-end against Maven Central - report-only writes the XML report and succeeds; `.strict()` fails the build on a violation.

## Notes / follow-ups

- Only **Checkstyle is verified end-to-end** so far; the other tools' run commands (main classes, CLI flags) are best-effort pending a network self-build. Pinned end-to-end tests for the remaining tools are in progress.
- **detekt** main class is version-sensitive (`io.gitlab.arturbosch.detekt.cli.Main` in 1.x, `dev.detekt.cli.Main` in 2.x); floated `RELEASE` may pull a pre-release.
- **Wiring into the default layouts is deferred**; today the modules are constructed explicitly or exercised in tests.
- Java source formatting (Spotless, google-java-format) is intentionally out of scope - neither exposes a project-root config file to infer from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)