### PR TITLE
Test that a consumed undefined property still fails resolution

### DIFF
--- a/tests/build/jenesis/test/maven/MavenPomResolverTest.java
+++ b/tests/build/jenesis/test/maven/MavenPomResolverTest.java
@@ -306,6 +306,56 @@ public class MavenPomResolverTest {
     }
 
     @Test
+    public void undefined_managed_version_applied_to_a_consumed_dependency_still_fails() throws IOException {
+        addToRepository("group", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>other</groupId>
+                                <artifactId>artifact</artifactId>
+                                <version>${undefined.property}</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                    <dependencies>
+                        <dependency>
+                            <groupId>other</groupId>
+                            <artifactId>artifact</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        assertThatThrownBy(() -> mavenPomResolver.dependencies(
+                Runnable::run, mavenRepository, "group", "artifact", "1", null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to resolve other:artifact:${undefined.property}");
+    }
+
+    @Test
+    public void undefined_property_in_a_consumed_dependency_still_fails() throws IOException {
+        addToRepository("group", "artifact", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <dependencies>
+                        <dependency>
+                            <groupId>other</groupId>
+                            <artifactId>artifact</artifactId>
+                            <version>${undefined.property}</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+        assertThatThrownBy(() -> mavenPomResolver.dependencies(
+                Runnable::run, mavenRepository, "group", "artifact", "1", null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to resolve other:artifact:${undefined.property}");
+    }
+
+    @Test
     public void can_resolve_dependencies_with_nested_property() throws IOException {
         addToRepository("group", "artifact", "1", """
                 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Follow-up to #20. The lenient-property change there leaves an undefined `${...}` as a literal so POMs like `log4j-core:2.25.1` resolve. The merged suite only covered the *tolerated* half (an undefined property in a `dependencyManagement` entry nothing consumes).

This adds the other half of the contract: when an unresolved `${...}` version describes a dependency that is **actually fetched**, resolution fails with `Failed to resolve <coordinate>` (the literal surfaces in the message), rather than silently using the literal. Two cases:

- `undefined_property_in_a_consumed_dependency_still_fails` - version declared directly on the dependency.
- `undefined_managed_version_applied_to_a_consumed_dependency_still_fails` - version supplied through `dependencyManagement` to a version-less dependency (a distinct merge/management path).

Tests only; no production change.