### PR TITLE
Add inferred code-formatting tool modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,10 +385,31 @@ Two callbacks govern how the build is assembled, and they are pluggable independ
   `.kt` sources), so an unrelated trigger file never forces analysis. Each tool is a self-contained
   `BuildExecutorModule` following the compiler-module shape (`required` -> `dependencies` -> `check`). Wiring
   these chains into the default layouts is deferred; today they are added explicitly in a build script or
-  exercised directly in tests. Java source formatting (Spotless, google-java-format) is intentionally left out
-  for now because neither exposes a project-root configuration file to infer from. The detekt runner targets the
+  exercised directly in tests. Source formatting is covered by the separate inferred formatting chain described
+  below. The detekt runner targets the
   1.x main class (`io.gitlab.arturbosch.detekt.cli.Main`); detekt 2.x relocates it to `dev.detekt.cli.Main`, so
   the floated `RELEASE` and runner main class want confirming against the resolved jar.
+- The **inferred formatting chain** (`InferredSourceFormattingModule`) is the rewriting counterpart to the
+  code-quality chains: where a linter reads sources and writes a report, a formatter reads sources and rewrites
+  them in place. It covers `google-java-format` and `palantir-java-format` for Java (selected with
+  `.javaFormatter(GOOGLE)` / `.javaFormatter(PALANTIR)`), `ktlint -F` for Kotlin, and `scalafmt` for Scala. The
+  chain is opt-in: wiring it in (and choosing a Java formatter) is the feature flag. ktlint and scalafmt then
+  activate from the same config files as their linters (`.editorconfig`, `.scalafmt.conf`), while the chosen Java
+  formatter, which has no project-root config file, runs whenever `.java` sources are present and self-skips
+  otherwise. Each tool resolves in its own dependency group, floats `RELEASE`, and runs in a forked JVM; the two
+  Java formatters pass the `--add-exports jdk.compiler/...` set they need on a modern JDK (palantir additionally
+  exports `com.sun.tools.javac.main`).
+  Because a formatter mutates the developer's source tree, it cannot lean on the build's normal bound-input change
+  detection (which would re-format the whole tree on any edit and never converge). Instead each format step keeps
+  its own `formatted.properties` in its persistent step folder, recording a SHA-256 per source file as of the last
+  format. On each run it re-formats only the files whose content differs from that record and then rewrites it; a
+  file already in formatted state is skipped without forking the tool, and a file the formatter cannot change (a
+  parse error) is recorded as-is and not retried until it next changes. `.verify(true)` turns a formatter into a CI
+  gate instead: google-java-format and palantir use `--dry-run --set-exit-if-changed`, ktlint drops `-F`, and
+  scalafmt uses `--test`, so a file that is not already formatted fails the build while no source file (and no hash
+  state) is written. Groovy formatting is deferred: no `RELEASE`-floatable Maven JAR formatter exists for it
+  (CodeNarc is a linter, npm-groovy-lint is Node-based, and the groovy-eclipse formatter is only a community
+  single-file `-in`/`-out` jar).
 
 Layouts always combine their built-in repositories and resolvers (e.g. a Maven default for `MAVEN`, a chained
 Jenesis module repository for `MODULAR`) with any user-provided ones. The merged map then has each sub-module's `assign`

--- a/sources/build/jenesis/HashDigestFunction.java
+++ b/sources/build/jenesis/HashDigestFunction.java
@@ -13,7 +13,12 @@ public record HashDigestFunction(String algorithm) implements HashFunction, Seri
             throw new IllegalStateException(e);
         }
         try (FileChannel channel = FileChannel.open(file)) {
-            digest.update(channel.map(FileChannel.MapMode.READ_ONLY, channel.position(), channel.size()));
+            ByteBuffer buffer = ByteBuffer.allocate(1 << 16);
+            while (channel.read(buffer) != -1) {
+                buffer.flip();
+                digest.update(buffer);
+                buffer.clear();
+            }
         }
         return digest.digest();
     }

--- a/sources/build/jenesis/project/GoogleJavaFormatModule.java
+++ b/sources/build/jenesis/project/GoogleJavaFormatModule.java
@@ -1,0 +1,126 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Dependencies;
+import build.jenesis.step.FormatBuildStep;
+
+public class GoogleJavaFormatModule implements BuildExecutorModule {
+
+    public static final String FORMAT = "format";
+    private static final String REQUIRED = "required", DEPENDENCIES = "dependencies";
+
+    private static final String MAVEN_GROUP = "com.google.googlejavaformat";
+    private static final String MAVEN_ARTIFACT = "google-java-format";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String group;
+    private final boolean verify;
+
+    public GoogleJavaFormatModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "google-java-format", false);
+    }
+
+    private GoogleJavaFormatModule(Map<String, Repository> repositories,
+                                   Map<String, Resolver> resolvers,
+                                   Pinning pinning,
+                                   String group,
+                                   boolean verify) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.group = group;
+        this.verify = verify;
+    }
+
+    public GoogleJavaFormatModule pinning(Pinning pinning) {
+        return new GoogleJavaFormatModule(repositories, resolvers, pinning, group, verify);
+    }
+
+    public GoogleJavaFormatModule group(String group) {
+        return new GoogleJavaFormatModule(repositories, resolvers, pinning, group, verify);
+    }
+
+    public GoogleJavaFormatModule verify(boolean verify) {
+        return new GoogleJavaFormatModule(repositories, resolvers, pinning, group, verify);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        buildExecutor.addStep(REQUIRED, new Requires(group), inherited.sequencedKeySet());
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(DEPENDENCIES,
+                new Dependencies(repositories, resolvers).pinning(pinning),
+                resolveInputs);
+        SequencedSet<String> formatInputs = new LinkedHashSet<>();
+        formatInputs.add(DEPENDENCIES);
+        formatInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(FORMAT, new Format(group, verify), formatInputs);
+    }
+
+    private record Requires(String group) implements BuildStep {
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return false;
+        }
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(group + "/runtime/maven/" + MAVEN_GROUP + "/" + MAVEN_ARTIFACT + "/RELEASE", "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private static class Format extends FormatBuildStep {
+
+        private Format(String group, boolean verify) {
+            super(group, verify);
+        }
+
+        @Override
+        protected boolean isFormattable(Path file) {
+            return file.toString().endsWith(".java")
+                    && !file.getFileName().toString().equals("module-info.java");
+        }
+
+        @Override
+        protected List<String> command(List<String> jars, Path config, List<String> files, boolean verify) {
+            List<String> commands = new ArrayList<>(List.of(
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+                    "-cp", String.join(File.pathSeparator, jars),
+                    "com.google.googlejavaformat.java.Main"));
+            if (verify) {
+                commands.add("--dry-run");
+                commands.add("--set-exit-if-changed");
+            } else {
+                commands.add("--replace");
+            }
+            commands.addAll(files);
+            return commands;
+        }
+    }
+}

--- a/sources/build/jenesis/project/InferredSourceFormattingModule.java
+++ b/sources/build/jenesis/project/InferredSourceFormattingModule.java
@@ -1,0 +1,76 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+
+public class InferredSourceFormattingModule implements BuildExecutorModule {
+
+    public enum JavaFormatter {
+        NONE, GOOGLE, PALANTIR
+    }
+
+    public static final String GOOGLE_JAVA_FORMAT = "google-java-format", PALANTIR_JAVA_FORMAT = "palantir-java-format",
+            KTLINT = "ktlint-format", SCALAFMT = "scalafmt-format";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final JavaFormatter javaFormatter;
+    private final boolean verify;
+
+    public InferredSourceFormattingModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, JavaFormatter.NONE, false);
+    }
+
+    private InferredSourceFormattingModule(Map<String, Repository> repositories,
+                                           Map<String, Resolver> resolvers,
+                                           Pinning pinning,
+                                           JavaFormatter javaFormatter,
+                                           boolean verify) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.javaFormatter = javaFormatter;
+        this.verify = verify;
+    }
+
+    public InferredSourceFormattingModule pinning(Pinning pinning) {
+        return new InferredSourceFormattingModule(repositories, resolvers, pinning, javaFormatter, verify);
+    }
+
+    public InferredSourceFormattingModule javaFormatter(JavaFormatter javaFormatter) {
+        return new InferredSourceFormattingModule(repositories, resolvers, pinning, javaFormatter, verify);
+    }
+
+    public InferredSourceFormattingModule verify(boolean verify) {
+        return new InferredSourceFormattingModule(repositories, resolvers, pinning, javaFormatter, verify);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        switch (javaFormatter) {
+            case GOOGLE -> buildExecutor.addModule(GOOGLE_JAVA_FORMAT,
+                    new GoogleJavaFormatModule(repositories, resolvers).pinning(pinning).verify(verify),
+                    inherited.sequencedKeySet());
+            case PALANTIR -> buildExecutor.addModule(PALANTIR_JAVA_FORMAT,
+                    new PalantirJavaFormatModule(repositories, resolvers).pinning(pinning).verify(verify),
+                    inherited.sequencedKeySet());
+            case NONE -> {
+            }
+        }
+        if (KtlintFormatModule.isConfigured(inherited)) {
+            buildExecutor.addModule(KTLINT,
+                    new KtlintFormatModule(repositories, resolvers).pinning(pinning).verify(verify),
+                    inherited.sequencedKeySet());
+        }
+        if (ScalafmtFormatModule.isConfigured(inherited)) {
+            buildExecutor.addModule(SCALAFMT,
+                    new ScalafmtFormatModule(repositories, resolvers).pinning(pinning).verify(verify),
+                    inherited.sequencedKeySet());
+        }
+    }
+}

--- a/sources/build/jenesis/project/InferredSourceFormattingModule.java
+++ b/sources/build/jenesis/project/InferredSourceFormattingModule.java
@@ -10,7 +10,7 @@ import build.jenesis.Resolver;
 public class InferredSourceFormattingModule implements BuildExecutorModule {
 
     public enum JavaFormatter {
-        NONE, GOOGLE, PALANTIR
+        GOOGLE, PALANTIR
     }
 
     public static final String GOOGLE_JAVA_FORMAT = "google-java-format", PALANTIR_JAVA_FORMAT = "palantir-java-format",
@@ -23,7 +23,7 @@ public class InferredSourceFormattingModule implements BuildExecutorModule {
     private final boolean verify;
 
     public InferredSourceFormattingModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
-        this(repositories, resolvers, null, JavaFormatter.NONE, false);
+        this(repositories, resolvers, null, null, false);
     }
 
     private InferredSourceFormattingModule(Map<String, Repository> repositories,
@@ -52,14 +52,14 @@ public class InferredSourceFormattingModule implements BuildExecutorModule {
 
     @Override
     public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
-        switch (javaFormatter) {
-            case GOOGLE -> buildExecutor.addModule(GOOGLE_JAVA_FORMAT,
-                    new GoogleJavaFormatModule(repositories, resolvers).pinning(pinning).verify(verify),
-                    inherited.sequencedKeySet());
-            case PALANTIR -> buildExecutor.addModule(PALANTIR_JAVA_FORMAT,
-                    new PalantirJavaFormatModule(repositories, resolvers).pinning(pinning).verify(verify),
-                    inherited.sequencedKeySet());
-            case NONE -> {
+        if (javaFormatter != null) {
+            switch (javaFormatter) {
+                case GOOGLE -> buildExecutor.addModule(GOOGLE_JAVA_FORMAT,
+                        new GoogleJavaFormatModule(repositories, resolvers).pinning(pinning).verify(verify),
+                        inherited.sequencedKeySet());
+                case PALANTIR -> buildExecutor.addModule(PALANTIR_JAVA_FORMAT,
+                        new PalantirJavaFormatModule(repositories, resolvers).pinning(pinning).verify(verify),
+                        inherited.sequencedKeySet());
             }
         }
         if (KtlintFormatModule.isConfigured(inherited)) {

--- a/sources/build/jenesis/project/KtlintFormatModule.java
+++ b/sources/build/jenesis/project/KtlintFormatModule.java
@@ -1,0 +1,125 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Dependencies;
+import build.jenesis.step.FormatBuildStep;
+
+public class KtlintFormatModule implements BuildExecutorModule {
+
+    public static final String FORMAT = "format";
+    private static final String REQUIRED = "required", DEPENDENCIES = "dependencies";
+
+    private static final String MAVEN_GROUP = "com.pinterest.ktlint";
+    private static final String MAVEN_ARTIFACT = "ktlint-cli";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String group;
+    private final boolean verify;
+
+    public KtlintFormatModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "ktlint-format", false);
+    }
+
+    private KtlintFormatModule(Map<String, Repository> repositories,
+                               Map<String, Resolver> resolvers,
+                               Pinning pinning,
+                               String group,
+                               boolean verify) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.group = group;
+        this.verify = verify;
+    }
+
+    public static boolean isConfigured(SequencedMap<String, Path> inherited) {
+        for (Path folder : inherited.values()) {
+            if (Files.isRegularFile(folder.resolve(".editorconfig"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public KtlintFormatModule pinning(Pinning pinning) {
+        return new KtlintFormatModule(repositories, resolvers, pinning, group, verify);
+    }
+
+    public KtlintFormatModule group(String group) {
+        return new KtlintFormatModule(repositories, resolvers, pinning, group, verify);
+    }
+
+    public KtlintFormatModule verify(boolean verify) {
+        return new KtlintFormatModule(repositories, resolvers, pinning, group, verify);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        buildExecutor.addStep(REQUIRED, new Requires(group), inherited.sequencedKeySet());
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(DEPENDENCIES,
+                new Dependencies(repositories, resolvers).pinning(pinning),
+                resolveInputs);
+        SequencedSet<String> formatInputs = new LinkedHashSet<>();
+        formatInputs.add(DEPENDENCIES);
+        formatInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(FORMAT, new Format(group, verify), formatInputs);
+    }
+
+    private record Requires(String group) implements BuildStep {
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return false;
+        }
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(group + "/runtime/maven/" + MAVEN_GROUP + "/" + MAVEN_ARTIFACT + "/RELEASE", "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private static class Format extends FormatBuildStep {
+
+        private Format(String group, boolean verify) {
+            super(group, verify);
+        }
+
+        @Override
+        protected boolean isFormattable(Path file) {
+            return file.toString().endsWith(".kt");
+        }
+
+        @Override
+        protected List<String> command(List<String> jars, Path config, List<String> files, boolean verify) {
+            List<String> commands = new ArrayList<>(List.of(
+                    "-cp", String.join(File.pathSeparator, jars),
+                    "com.pinterest.ktlint.Main"));
+            if (!verify) {
+                commands.add("-F");
+            }
+            commands.addAll(files);
+            return commands;
+        }
+    }
+}

--- a/sources/build/jenesis/project/PalantirJavaFormatModule.java
+++ b/sources/build/jenesis/project/PalantirJavaFormatModule.java
@@ -1,0 +1,127 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Dependencies;
+import build.jenesis.step.FormatBuildStep;
+
+public class PalantirJavaFormatModule implements BuildExecutorModule {
+
+    public static final String FORMAT = "format";
+    private static final String REQUIRED = "required", DEPENDENCIES = "dependencies";
+
+    private static final String MAVEN_GROUP = "com.palantir.javaformat";
+    private static final String MAVEN_ARTIFACT = "palantir-java-format";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String group;
+    private final boolean verify;
+
+    public PalantirJavaFormatModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "palantir-java-format", false);
+    }
+
+    private PalantirJavaFormatModule(Map<String, Repository> repositories,
+                                     Map<String, Resolver> resolvers,
+                                     Pinning pinning,
+                                     String group,
+                                     boolean verify) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.group = group;
+        this.verify = verify;
+    }
+
+    public PalantirJavaFormatModule pinning(Pinning pinning) {
+        return new PalantirJavaFormatModule(repositories, resolvers, pinning, group, verify);
+    }
+
+    public PalantirJavaFormatModule group(String group) {
+        return new PalantirJavaFormatModule(repositories, resolvers, pinning, group, verify);
+    }
+
+    public PalantirJavaFormatModule verify(boolean verify) {
+        return new PalantirJavaFormatModule(repositories, resolvers, pinning, group, verify);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        buildExecutor.addStep(REQUIRED, new Requires(group), inherited.sequencedKeySet());
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(DEPENDENCIES,
+                new Dependencies(repositories, resolvers).pinning(pinning),
+                resolveInputs);
+        SequencedSet<String> formatInputs = new LinkedHashSet<>();
+        formatInputs.add(DEPENDENCIES);
+        formatInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(FORMAT, new Format(group, verify), formatInputs);
+    }
+
+    private record Requires(String group) implements BuildStep {
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return false;
+        }
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(group + "/runtime/maven/" + MAVEN_GROUP + "/" + MAVEN_ARTIFACT + "/RELEASE", "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private static class Format extends FormatBuildStep {
+
+        private Format(String group, boolean verify) {
+            super(group, verify);
+        }
+
+        @Override
+        protected boolean isFormattable(Path file) {
+            return file.toString().endsWith(".java")
+                    && !file.getFileName().toString().equals("module-info.java");
+        }
+
+        @Override
+        protected List<String> command(List<String> jars, Path config, List<String> files, boolean verify) {
+            List<String> commands = new ArrayList<>(List.of(
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+                    "-cp", String.join(File.pathSeparator, jars),
+                    "com.palantir.javaformat.java.Main"));
+            if (verify) {
+                commands.add("--dry-run");
+                commands.add("--set-exit-if-changed");
+            } else {
+                commands.add("--replace");
+            }
+            commands.addAll(files);
+            return commands;
+        }
+    }
+}

--- a/sources/build/jenesis/project/ScalafmtFormatModule.java
+++ b/sources/build/jenesis/project/ScalafmtFormatModule.java
@@ -1,0 +1,145 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Dependencies;
+import build.jenesis.step.FormatBuildStep;
+
+public class ScalafmtFormatModule implements BuildExecutorModule {
+
+    public static final String FORMAT = "format";
+    private static final String REQUIRED = "required", DEPENDENCIES = "dependencies";
+
+    private static final String MAVEN_GROUP = "org.scalameta";
+    private static final String MAVEN_ARTIFACT = "scalafmt-cli_2.13";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String group;
+    private final String configFile;
+    private final boolean verify;
+
+    public ScalafmtFormatModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "scalafmt-format", ".scalafmt.conf", false);
+    }
+
+    private ScalafmtFormatModule(Map<String, Repository> repositories,
+                                 Map<String, Resolver> resolvers,
+                                 Pinning pinning,
+                                 String group,
+                                 String configFile,
+                                 boolean verify) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.group = group;
+        this.configFile = configFile;
+        this.verify = verify;
+    }
+
+    public static boolean isConfigured(SequencedMap<String, Path> inherited) {
+        for (Path folder : inherited.values()) {
+            if (Files.isRegularFile(folder.resolve(".scalafmt.conf"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public ScalafmtFormatModule pinning(Pinning pinning) {
+        return new ScalafmtFormatModule(repositories, resolvers, pinning, group, configFile, verify);
+    }
+
+    public ScalafmtFormatModule group(String group) {
+        return new ScalafmtFormatModule(repositories, resolvers, pinning, group, configFile, verify);
+    }
+
+    public ScalafmtFormatModule configFile(String configFile) {
+        return new ScalafmtFormatModule(repositories, resolvers, pinning, group, configFile, verify);
+    }
+
+    public ScalafmtFormatModule verify(boolean verify) {
+        return new ScalafmtFormatModule(repositories, resolvers, pinning, group, configFile, verify);
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        buildExecutor.addStep(REQUIRED, new Requires(group), inherited.sequencedKeySet());
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(DEPENDENCIES,
+                new Dependencies(repositories, resolvers).pinning(pinning),
+                resolveInputs);
+        SequencedSet<String> formatInputs = new LinkedHashSet<>();
+        formatInputs.add(DEPENDENCIES);
+        formatInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(FORMAT, new Format(group, configFile, verify), formatInputs);
+    }
+
+    private record Requires(String group) implements BuildStep {
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return false;
+        }
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(group + "/runtime/maven/" + MAVEN_GROUP + "/" + MAVEN_ARTIFACT + "/RELEASE", "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private static class Format extends FormatBuildStep {
+
+        private final String configFile;
+
+        private Format(String group, String configFile, boolean verify) {
+            super(group, verify);
+            this.configFile = configFile;
+        }
+
+        @Override
+        protected boolean isFormattable(Path file) {
+            return file.toString().endsWith(".scala");
+        }
+
+        @Override
+        protected Path config(Path folder) {
+            Path candidate = folder.resolve(configFile);
+            return Files.isRegularFile(candidate) ? candidate : null;
+        }
+
+        @Override
+        protected List<String> command(List<String> jars, Path config, List<String> files, boolean verify) {
+            if (config == null) {
+                throw new IllegalStateException("No " + configFile + " found among the inputs of the scalafmt step");
+            }
+            List<String> commands = new ArrayList<>(List.of(
+                    "-cp", String.join(File.pathSeparator, jars),
+                    "org.scalafmt.cli.Cli",
+                    "--config", config.toString()));
+            if (verify) {
+                commands.add("--test");
+            }
+            commands.addAll(files);
+            return commands;
+        }
+    }
+}

--- a/sources/build/jenesis/step/FormatBuildStep.java
+++ b/sources/build/jenesis/step/FormatBuildStep.java
@@ -1,0 +1,124 @@
+package build.jenesis.step;
+
+import module java.base;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.HashFunction;
+
+public abstract class FormatBuildStep extends JdkProcessBuildStep {
+
+    private static final String FORMATTED = "formatted.properties";
+
+    private final String group;
+    private final boolean verify;
+
+    protected FormatBuildStep(String group, boolean verify) {
+        super(group, ProcessHandler.OfProcess.ofJavaHome("bin/java"));
+        this.group = group;
+        this.verify = verify;
+    }
+
+    protected abstract boolean isFormattable(Path file);
+
+    protected abstract List<String> command(List<String> jars, Path config, List<String> files, boolean verify);
+
+    protected Path config(Path folder) {
+        return null;
+    }
+
+    @Override
+    public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+        return true;
+    }
+
+    @Override
+    public boolean acceptableExitCode(int code,
+                                      Executor executor,
+                                      BuildStepContext context,
+                                      SequencedMap<String, BuildStepArgument> arguments) {
+        return !verify || code == 0;
+    }
+
+    @Override
+    protected CompletionStage<List<String>> process(Executor executor,
+                                                    BuildStepContext context,
+                                                    SequencedMap<String, BuildStepArgument> arguments,
+                                                    SequencedMap<String, SequencedMap<String, String>> properties)
+            throws IOException {
+        HashFunction hash = new HashDigestFunction("SHA-256");
+        List<String> jars = new ArrayList<>();
+        Path config = null;
+        Map<Path, byte[]> current = new LinkedHashMap<>();
+        for (BuildStepArgument argument : arguments.values()) {
+            for (Path jar : Dependencies.select(argument.folder(), group, "runtime")) {
+                jars.add(jar.toString());
+            }
+            Path candidate = config(argument.folder());
+            if (candidate != null) {
+                config = candidate;
+            }
+            current.putAll(formattable(argument.folder(), hash));
+        }
+        if (current.isEmpty()) {
+            return CompletableFuture.completedStage(null);
+        }
+        Map<Path, byte[]> stored = context.previous() != null && Files.exists(context.previous().resolve(FORMATTED))
+                ? HashFunction.read(context.previous().resolve(FORMATTED))
+                : Map.of();
+        List<String> files = new ArrayList<>();
+        for (Map.Entry<Path, byte[]> entry : current.entrySet()) {
+            byte[] prior = stored.get(entry.getKey());
+            if (prior == null || !Arrays.equals(prior, entry.getValue())) {
+                files.add(entry.getKey().toString());
+            }
+        }
+        if (files.isEmpty()) {
+            return CompletableFuture.completedStage(null);
+        }
+        if (jars.isEmpty()) {
+            throw new IllegalStateException("No " + group + " jars resolved upstream of the " + group + " step");
+        }
+        files.sort(null);
+        return CompletableFuture.completedStage(command(jars, config, files, verify));
+    }
+
+    @Override
+    public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                  BuildStepContext context,
+                                                  SequencedMap<String, BuildStepArgument> arguments)
+            throws IOException {
+        return super.apply(executor, context, arguments).thenCompose(result -> {
+            if (!result.next() || verify) {
+                return CompletableFuture.completedStage(result);
+            }
+            try {
+                HashFunction hash = new HashDigestFunction("SHA-256");
+                Map<Path, byte[]> after = new LinkedHashMap<>();
+                for (BuildStepArgument argument : arguments.values()) {
+                    after.putAll(formattable(argument.folder(), hash));
+                }
+                HashFunction.write(context.next().resolve(FORMATTED), after);
+                return CompletableFuture.completedStage(result);
+            } catch (IOException e) {
+                return CompletableFuture.failedStage(e);
+            }
+        });
+    }
+
+    private Map<Path, byte[]> formattable(Path folder, HashFunction hash) throws IOException {
+        Path sources = folder.resolve(Bind.SOURCES);
+        if (!Files.isDirectory(sources)) {
+            return Map.of();
+        }
+        Map<Path, byte[]> formattable = new LinkedHashMap<>();
+        for (Map.Entry<Path, byte[]> entry : HashFunction.read(sources, hash).entrySet()) {
+            Path file = sources.resolve(entry.getKey());
+            if (isFormattable(file)) {
+                formattable.put(file, entry.getValue());
+            }
+        }
+        return formattable;
+    }
+}

--- a/tests/build/jenesis/test/project/GoogleJavaFormatModuleRunTest.java
+++ b/tests/build/jenesis/test/project/GoogleJavaFormatModuleRunTest.java
@@ -1,0 +1,100 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.SequencedProperties;
+import build.jenesis.maven.MavenDefaultRepository;
+import build.jenesis.maven.MavenPomResolver;
+import build.jenesis.project.GoogleJavaFormatModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class GoogleJavaFormatModuleRunTest {
+
+    private static final String VERSION = "1.35.0";
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void formats_in_place_then_skips_an_unchanged_file_on_a_second_run() throws IOException {
+        SequencedProperties versions = new SequencedProperties();
+        versions.setProperty("google-java-format/maven/com.google.googlejavaformat/google-java-format", VERSION);
+        versions.store(project.resolve(BuildStep.VERSIONS));
+        Path sample = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample")).resolve("Sample.java");
+        Files.writeString(sample, "package sample;class Sample{int f(){return 42;}}\n");
+
+        newExecutor(false).execute();
+
+        Path resolved = root.resolve("google-java-format").resolve("dependencies").resolve("output").resolve("resolved");
+        try (Stream<Path> jars = Files.list(resolved)) {
+            assertThat(jars.map(jar -> jar.getFileName().toString()))
+                    .as("the pinned google-java-format version resolves")
+                    .anyMatch(name -> name.contains("google-java-format") && name.contains(VERSION));
+        }
+        String formatted = Files.readString(sample);
+        assertThat(formatted)
+                .as("the source is reformatted in place")
+                .contains("class Sample {")
+                .contains("int f() {");
+        Path command = root.resolve("google-java-format").resolve("format").resolve("supplement").resolve("command");
+        assertThat(command).as("the first run forks the formatter").exists();
+        Path hashes = root.resolve("google-java-format").resolve("format").resolve("output").resolve("formatted.properties");
+        assertThat(hashes).isNotEmptyFile();
+
+        newExecutor(false).execute();
+
+        assertThat(Files.readString(sample)).as("the already-formatted file is left byte-identical").isEqualTo(formatted);
+        assertThat(command).as("the formatter is not forked again when nothing changed").doesNotExist();
+    }
+
+    @Test
+    public void verify_mode_fails_the_build_and_leaves_the_file_untouched() throws IOException {
+        SequencedProperties versions = new SequencedProperties();
+        versions.setProperty("google-java-format/maven/com.google.googlejavaformat/google-java-format", VERSION);
+        versions.store(project.resolve(BuildStep.VERSIONS));
+        Path sample = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample")).resolve("Sample.java");
+        String unformatted = "package sample;class Sample{int f(){return 42;}}\n";
+        Files.writeString(sample, unformatted);
+
+        assertThatThrownBy(newExecutor(true)::execute)
+                .hasRootCauseInstanceOf(IllegalStateException.class)
+                .rootCause()
+                .hasMessageContaining("Unexpected exit code");
+        assertThat(Files.readString(sample)).as("verify mode never rewrites the source").isEqualTo(unformatted);
+        assertThat(root.resolve("google-java-format").resolve("format").resolve("output").resolve("formatted.properties"))
+                .as("verify mode does not persist the incremental hash state")
+                .doesNotExist();
+    }
+
+    private BuildExecutor newExecutor(boolean verify) throws IOException {
+        BuildExecutor executor = BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+        executor.addSource("project", project);
+        executor.addModule(
+                "google-java-format",
+                new GoogleJavaFormatModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver()))
+                        .verify(verify),
+                "project");
+        return executor;
+    }
+
+    private static Repository mavenCentral() {
+        Path local = Path.of(System.getProperty("user.home"), ".m2", "repository");
+        return new MavenDefaultRepository(
+                URI.create("https://repo1.maven.org/maven2/"),
+                Files.isDirectory(local) ? local : null,
+                Map.of(),
+                _ -> {});
+    }
+}

--- a/tests/build/jenesis/test/project/GoogleJavaFormatModuleTest.java
+++ b/tests/build/jenesis/test/project/GoogleJavaFormatModuleTest.java
@@ -1,0 +1,40 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.GoogleJavaFormatModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GoogleJavaFormatModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void requires_step_emits_the_google_java_format_maven_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("google-java-format", new GoogleJavaFormatModule(Map.of(), Map.of()), "project");
+        executor.execute("google-java-format/required");
+
+        Path requiredOutput = root.resolve("google-java-format").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("google-java-format/runtime/maven/com.google.googlejavaformat/google-java-format/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/InferredSourceFormattingModuleTest.java
+++ b/tests/build/jenesis/test/project/InferredSourceFormattingModuleTest.java
@@ -1,0 +1,111 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.InferredSourceFormattingModule;
+import build.jenesis.project.InferredSourceFormattingModule.JavaFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InferredSourceFormattingModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void wires_ktlint_format_when_editorconfig_is_present() throws IOException {
+        Files.writeString(project.resolve(".editorconfig"), "root = true\n");
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("format", new InferredSourceFormattingModule(Map.of(), Map.of()), "project");
+        executor.execute("format/ktlint-format/required");
+
+        assertThat(coordinates("ktlint-format"))
+                .containsExactly("ktlint-format/runtime/maven/com.pinterest.ktlint/ktlint-cli/RELEASE");
+    }
+
+    @Test
+    public void wires_scalafmt_format_when_scalafmt_conf_is_present() throws IOException {
+        Files.writeString(project.resolve(".scalafmt.conf"), "version = \"3.8.3\"\n");
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("format", new InferredSourceFormattingModule(Map.of(), Map.of()), "project");
+        executor.execute("format/scalafmt-format/required");
+
+        assertThat(coordinates("scalafmt-format"))
+                .containsExactly("scalafmt-format/runtime/maven/org.scalameta/scalafmt-cli_2.13/RELEASE");
+    }
+
+    @Test
+    public void wires_the_selected_google_java_formatter() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("format",
+                new InferredSourceFormattingModule(Map.of(), Map.of()).javaFormatter(JavaFormatter.GOOGLE),
+                "project");
+        executor.execute("format/google-java-format/required");
+
+        assertThat(coordinates("google-java-format"))
+                .containsExactly("google-java-format/runtime/maven/com.google.googlejavaformat/google-java-format/RELEASE");
+    }
+
+    @Test
+    public void wires_the_selected_palantir_java_formatter() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("format",
+                new InferredSourceFormattingModule(Map.of(), Map.of()).javaFormatter(JavaFormatter.PALANTIR),
+                "project");
+        executor.execute("format/palantir-java-format/required");
+
+        assertThat(coordinates("palantir-java-format"))
+                .containsExactly("palantir-java-format/runtime/maven/com.palantir.javaformat/palantir-java-format/RELEASE");
+    }
+
+    @Test
+    public void does_not_wire_a_java_formatter_by_default() throws IOException {
+        Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample"));
+        Files.writeString(project.resolve(BuildStep.SOURCES + "sample").resolve("Sample.java"), "package sample; class Sample {}");
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("format", new InferredSourceFormattingModule(Map.of(), Map.of()), "project");
+        executor.execute();
+
+        assertThat(root.resolve("format").resolve("google-java-format"))
+                .as("no Java formatter is wired unless one is selected, even when Java sources exist")
+                .doesNotExist();
+        assertThat(root.resolve("format").resolve("palantir-java-format")).doesNotExist();
+    }
+
+    @Test
+    public void does_not_wire_ktlint_format_when_editorconfig_is_absent() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("format", new InferredSourceFormattingModule(Map.of(), Map.of()), "project");
+        executor.execute();
+
+        assertThat(root.resolve("format").resolve("ktlint-format")).doesNotExist();
+    }
+
+    private Iterable<String> coordinates(String group) throws IOException {
+        Path output = root.resolve("format").resolve(group).resolve("required").resolve("output");
+        return SequencedProperties.ofFiles(output.resolve(BuildStep.REQUIRES)).stringPropertyNames();
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/KtlintFormatModuleRunTest.java
+++ b/tests/build/jenesis/test/project/KtlintFormatModuleRunTest.java
@@ -1,0 +1,89 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.SequencedProperties;
+import build.jenesis.maven.MavenDefaultRepository;
+import build.jenesis.maven.MavenPomResolver;
+import build.jenesis.project.KtlintFormatModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KtlintFormatModuleRunTest {
+
+    private static final String VERSION = "1.5.0";
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void formats_in_place_then_skips_an_unchanged_file_on_a_second_run() throws IOException {
+        SequencedProperties versions = new SequencedProperties();
+        versions.setProperty("ktlint-format/maven/com.pinterest.ktlint/ktlint-cli", VERSION);
+        versions.store(project.resolve(BuildStep.VERSIONS));
+        Files.writeString(project.resolve(".editorconfig"), """
+                root = true
+                [*.kt]
+                indent_size = 4
+                """);
+        Path sample = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample")).resolve("Sample.kt");
+        Files.writeString(sample, """
+                package sample
+
+                fun main() {
+                println("hello")
+                }
+                """);
+
+        newExecutor().execute();
+
+        Path resolved = root.resolve("ktlint-format").resolve("dependencies").resolve("output").resolve("resolved");
+        try (Stream<Path> jars = Files.list(resolved)) {
+            assertThat(jars.map(jar -> jar.getFileName().toString()))
+                    .as("the pinned ktlint version resolves")
+                    .anyMatch(name -> name.contains("ktlint-cli") && name.contains(VERSION));
+        }
+        String formatted = Files.readString(sample);
+        assertThat(formatted)
+                .as("the source is reformatted in place")
+                .contains("    println(\"hello\")");
+        Path command = root.resolve("ktlint-format").resolve("format").resolve("supplement").resolve("command");
+        assertThat(command).as("the first run forks the formatter").exists();
+        Path hashes = root.resolve("ktlint-format").resolve("format").resolve("output").resolve("formatted.properties");
+        assertThat(hashes).isNotEmptyFile();
+
+        newExecutor().execute();
+
+        assertThat(Files.readString(sample)).as("the already-formatted file is left byte-identical").isEqualTo(formatted);
+        assertThat(command).as("the formatter is not forked again when nothing changed").doesNotExist();
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        BuildExecutor executor = BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+        executor.addSource("project", project);
+        executor.addModule(
+                "ktlint-format",
+                new KtlintFormatModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver())),
+                "project");
+        return executor;
+    }
+
+    private static Repository mavenCentral() {
+        Path local = Path.of(System.getProperty("user.home"), ".m2", "repository");
+        return new MavenDefaultRepository(
+                URI.create("https://repo1.maven.org/maven2/"),
+                Files.isDirectory(local) ? local : null,
+                Map.of(),
+                _ -> {});
+    }
+}

--- a/tests/build/jenesis/test/project/KtlintFormatModuleTest.java
+++ b/tests/build/jenesis/test/project/KtlintFormatModuleTest.java
@@ -1,0 +1,40 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.KtlintFormatModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KtlintFormatModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void requires_step_emits_the_ktlint_maven_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("ktlint-format", new KtlintFormatModule(Map.of(), Map.of()), "project");
+        executor.execute("ktlint-format/required");
+
+        Path requiredOutput = root.resolve("ktlint-format").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("ktlint-format/runtime/maven/com.pinterest.ktlint/ktlint-cli/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/PalantirJavaFormatModuleRunTest.java
+++ b/tests/build/jenesis/test/project/PalantirJavaFormatModuleRunTest.java
@@ -1,0 +1,79 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.SequencedProperties;
+import build.jenesis.maven.MavenDefaultRepository;
+import build.jenesis.maven.MavenPomResolver;
+import build.jenesis.project.PalantirJavaFormatModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PalantirJavaFormatModuleRunTest {
+
+    private static final String VERSION = "2.91.0";
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void formats_in_place_then_skips_an_unchanged_file_on_a_second_run() throws IOException {
+        SequencedProperties versions = new SequencedProperties();
+        versions.setProperty("palantir-java-format/maven/com.palantir.javaformat/palantir-java-format", VERSION);
+        versions.store(project.resolve(BuildStep.VERSIONS));
+        Path sample = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample")).resolve("Sample.java");
+        Files.writeString(sample, "package sample;class Sample{int f(){return 42;}}\n");
+
+        newExecutor().execute();
+
+        Path resolved = root.resolve("palantir-java-format").resolve("dependencies").resolve("output").resolve("resolved");
+        try (Stream<Path> jars = Files.list(resolved)) {
+            assertThat(jars.map(jar -> jar.getFileName().toString()))
+                    .as("the pinned palantir-java-format version resolves")
+                    .anyMatch(name -> name.contains("palantir-java-format") && name.contains(VERSION));
+        }
+        String formatted = Files.readString(sample);
+        assertThat(formatted)
+                .as("the source is reformatted in place")
+                .contains("class Sample {")
+                .contains("int f() {");
+        Path command = root.resolve("palantir-java-format").resolve("format").resolve("supplement").resolve("command");
+        assertThat(command).as("the first run forks the formatter").exists();
+        Path hashes = root.resolve("palantir-java-format").resolve("format").resolve("output").resolve("formatted.properties");
+        assertThat(hashes).isNotEmptyFile();
+
+        newExecutor().execute();
+
+        assertThat(Files.readString(sample)).as("the already-formatted file is left byte-identical").isEqualTo(formatted);
+        assertThat(command).as("the formatter is not forked again when nothing changed").doesNotExist();
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        BuildExecutor executor = BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+        executor.addSource("project", project);
+        executor.addModule(
+                "palantir-java-format",
+                new PalantirJavaFormatModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver())),
+                "project");
+        return executor;
+    }
+
+    private static Repository mavenCentral() {
+        Path local = Path.of(System.getProperty("user.home"), ".m2", "repository");
+        return new MavenDefaultRepository(
+                URI.create("https://repo1.maven.org/maven2/"),
+                Files.isDirectory(local) ? local : null,
+                Map.of(),
+                _ -> {});
+    }
+}

--- a/tests/build/jenesis/test/project/PalantirJavaFormatModuleTest.java
+++ b/tests/build/jenesis/test/project/PalantirJavaFormatModuleTest.java
@@ -1,0 +1,40 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.PalantirJavaFormatModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PalantirJavaFormatModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void requires_step_emits_the_palantir_java_format_maven_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("palantir-java-format", new PalantirJavaFormatModule(Map.of(), Map.of()), "project");
+        executor.execute("palantir-java-format/required");
+
+        Path requiredOutput = root.resolve("palantir-java-format").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("palantir-java-format/runtime/maven/com.palantir.javaformat/palantir-java-format/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/ScalafmtFormatModuleRunTest.java
+++ b/tests/build/jenesis/test/project/ScalafmtFormatModuleRunTest.java
@@ -1,0 +1,82 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.SequencedProperties;
+import build.jenesis.maven.MavenDefaultRepository;
+import build.jenesis.maven.MavenPomResolver;
+import build.jenesis.project.ScalafmtFormatModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ScalafmtFormatModuleRunTest {
+
+    private static final String VERSION = "3.8.3";
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void formats_in_place_then_skips_an_unchanged_file_on_a_second_run() throws IOException {
+        SequencedProperties versions = new SequencedProperties();
+        versions.setProperty("scalafmt-format/maven/org.scalameta/scalafmt-cli_2.13", VERSION);
+        versions.store(project.resolve(BuildStep.VERSIONS));
+        Files.writeString(project.resolve(".scalafmt.conf"), """
+                version = "3.8.3"
+                runner.dialect = scala213
+                """);
+        Path sample = Files.createDirectories(project.resolve(BuildStep.SOURCES + "sample")).resolve("Sample.scala");
+        Files.writeString(sample, "package sample\nclass Sample {   def  f( ) :Int=42 }\n");
+
+        newExecutor().execute();
+
+        Path resolved = root.resolve("scalafmt-format").resolve("dependencies").resolve("output").resolve("resolved");
+        try (Stream<Path> jars = Files.list(resolved)) {
+            assertThat(jars.map(jar -> jar.getFileName().toString()))
+                    .as("the pinned scalafmt version resolves")
+                    .anyMatch(name -> name.contains("scalafmt-cli") && name.contains(VERSION));
+        }
+        String formatted = Files.readString(sample);
+        assertThat(formatted)
+                .as("the source is reformatted in place")
+                .contains("def f(): Int = 42");
+        Path command = root.resolve("scalafmt-format").resolve("format").resolve("supplement").resolve("command");
+        assertThat(command).as("the first run forks the formatter").exists();
+        Path hashes = root.resolve("scalafmt-format").resolve("format").resolve("output").resolve("formatted.properties");
+        assertThat(hashes).isNotEmptyFile();
+
+        newExecutor().execute();
+
+        assertThat(Files.readString(sample)).as("the already-formatted file is left byte-identical").isEqualTo(formatted);
+        assertThat(command).as("the formatter is not forked again when nothing changed").doesNotExist();
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        BuildExecutor executor = BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+        executor.addSource("project", project);
+        executor.addModule(
+                "scalafmt-format",
+                new ScalafmtFormatModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver())),
+                "project");
+        return executor;
+    }
+
+    private static Repository mavenCentral() {
+        Path local = Path.of(System.getProperty("user.home"), ".m2", "repository");
+        return new MavenDefaultRepository(
+                URI.create("https://repo1.maven.org/maven2/"),
+                Files.isDirectory(local) ? local : null,
+                Map.of(),
+                _ -> {});
+    }
+}

--- a/tests/build/jenesis/test/project/ScalafmtFormatModuleTest.java
+++ b/tests/build/jenesis/test/project/ScalafmtFormatModuleTest.java
@@ -1,0 +1,40 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.ScalafmtFormatModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ScalafmtFormatModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void requires_step_emits_the_scalafmt_maven_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("scalafmt-format", new ScalafmtFormatModule(Map.of(), Map.of()), "project");
+        executor.execute("scalafmt-format/required");
+
+        Path requiredOutput = root.resolve("scalafmt-format").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("scalafmt-format/runtime/maven/org.scalameta/scalafmt-cli_2.13/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a source-formatting chain that mirrors the inferred code-quality modules but rewrites sources in place rather than emitting reports.

- **Java**: `google-java-format` and `palantir-java-format` (selectable via `.javaFormatter(GOOGLE|PALANTIR)`)
- **Kotlin**: `ktlint -F`
- **Scala**: `scalafmt` (no `--test`)
- **Groovy**: deferred (no `RELEASE`-floatable Maven JAR formatter exists)

Wired through `InferredSourceFormattingModule`. ktlint and scalafmt activate from the same config files as their linters (`.editorconfig`, `.scalafmt.conf`); the chosen Java formatter has no project-root config and runs whenever `.java` sources are present, self-skipping otherwise. Each tool resolves in its own dependency group and floats `RELEASE`. The two Java formatters pass the `--add-exports jdk.compiler/...` set they need on a modern JDK (palantir additionally exports `com.sun.tools.javac.main`).

## Incremental formatting

A formatter mutates the developer's real source tree, so it cannot lean on the build's bound-input change detection (which would re-format the whole tree on any edit and never converge). Instead the shared `FormatBuildStep`:

- keeps its own `formatted.properties` (SHA-256 per source file) in its persistent step folder,
- re-formats only files whose content differs from that record, skipping the rest without forking the tool,
- rewrites the record after a successful format.

A file already in formatted state is skipped; a file the formatter cannot change (parse error) is recorded as-is and not retried until it next changes. `.verify(true)` turns a formatter into a CI gate instead (`--dry-run --set-exit-if-changed` / drop `-F` / `--test`): an unformatted file fails the build and no source or hash state is written.

## Tests

15 tests, all green:
- 4 coordinate unit tests + a 6-case `InferredSourceFormattingModuleTest` wiring/gating test (offline)
- 5 network-gated `*RunTest`s proving in-place reformat then a second-run incremental skip (no re-fork) for all four tools, plus a verify-mode build-failure case

Default-layout wiring is deferred, consistent with the existing code-quality chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)