### PR TITLE
Discover IT-named classes in the default test selector

### DIFF
--- a/sources/build/jenesis/project/TestModule.java
+++ b/sources/build/jenesis/project/TestModule.java
@@ -38,7 +38,9 @@ public class TestModule implements BuildExecutorModule {
     private final String dependencyGroup;
 
     public TestModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
-        List<Pattern> patterns = Stream.of(".*\\.Test[a-zA-Z0-9$]*", ".*\\..*Test", ".*\\..*Tests", ".*\\..*TestCase")
+        List<Pattern> patterns = Stream.of(
+                        ".*\\.Test[a-zA-Z0-9$]*", ".*\\..*Test", ".*\\..*Tests", ".*\\..*TestCase",
+                        ".*\\.IT[a-zA-Z0-9$]*", ".*\\..*IT", ".*\\..*ITCase")
                 .map(Pattern::compile)
                 .toList();
         this(null,


### PR DESCRIPTION
## Summary

The default test-class selector in `TestModule` matched only the surefire naming set (`Test*`, `*Test`, `*Tests`, `*TestCase`), so integration tests named `IT*`, `*IT`, or `*ITCase` were **silently never discovered or run**. This adds those three patterns so a project that keeps integration tests in the same module has them picked up alongside its unit tests.

```java
".*\\.IT[a-zA-Z0-9$]*", ".*\\..*IT", ".*\\..*ITCase"
```

## Why only this, and nothing else

There is deliberately no Maven-style surefire/failsafe split here:

- **Run against the artifact** — Jenesis tests already run against the assembled jars, so failsafe's reason for living in the post-`package` phase doesn't apply.
- **Guaranteed teardown** — modern integration tests let the framework own resource lifecycle (Testcontainers' JUnit extension / reaper), which is exactly what failsafe's defer-to-`verify` hack was invented to work around.
- **Phases vs DAG** — like Gradle (which separates by source set + task, not phase), Jenesis expresses an integration-test tier as wiring (a separate test step keyed to its own inputs), not a subsystem. How to organize or gate slower tests is left to the user.

So this is the one piece worth adopting from the failsafe convention: recognizing the `IT` names so those classes actually run.

## Tests

`TestModuleTest` (21 cases) passes; its cases override the selection predicate via `.isTest(...)`, so widening the defaults does not affect them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)