### PR TITLE
Capture dependency licenses and generate CycloneDX SBOMs

### DIFF
--- a/sources/build/jenesis/License.java
+++ b/sources/build/jenesis/License.java
@@ -1,0 +1,6 @@
+package build.jenesis;
+
+import module java.base;
+
+public record License(String name, String url) implements Serializable {
+}

--- a/sources/build/jenesis/ResolutionListener.java
+++ b/sources/build/jenesis/ResolutionListener.java
@@ -18,6 +18,12 @@ public interface ResolutionListener {
                               String version) {
     }
 
+    default void onLicenses(String prefix,
+                            String coordinate,
+                            String version,
+                            List<License> licenses) {
+    }
+
     default void onResolved() {
     }
 }

--- a/sources/build/jenesis/maven/MavenPomResolver.java
+++ b/sources/build/jenesis/maven/MavenPomResolver.java
@@ -5,6 +5,7 @@ import module java.xml;
 import build.jenesis.DependencyScope;
 import build.jenesis.Repository;
 import build.jenesis.RepositoryItem;
+import build.jenesis.License;
 import build.jenesis.ResolutionContext;
 import build.jenesis.ResolutionListener;
 import build.jenesis.Resolver;
@@ -75,7 +76,7 @@ public class MavenPomResolver implements MavenResolver {
         SequencedMap<String, String> resolved = new LinkedHashMap<>();
         dependencies(executor,
                 MavenRepository.of(repositories.getOrDefault(Resolver.base(prefix), Repository.empty())),
-                new ContextualPom(new ResolvedPom(managedDependencies, dependencies), true, null, Set.of(), null, null),
+                new ContextualPom(new ResolvedPom(managedDependencies, dependencies, List.of()), true, null, Set.of(), null, null),
                 new HashMap<>(),
                 new HashMap<>(),
                 prefix,
@@ -92,7 +93,7 @@ public class MavenPomResolver implements MavenResolver {
             SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies) throws IOException {
         return dependencies(executor,
                 repository,
-                new ContextualPom(new ResolvedPom(managedDependencies, dependencies),
+                new ContextualPom(new ResolvedPom(managedDependencies, dependencies, List.of()),
                         true,
                         null,
                         Set.of(),
@@ -157,7 +158,7 @@ public class MavenPomResolver implements MavenResolver {
             }
         }
         return new MavenResolver.Resolution(dependencies(executor, repository,
-                new ContextualPom(new ResolvedPom(managedDependencies, dependencies), true, scope, Set.of(), null, null),
+                new ContextualPom(new ResolvedPom(managedDependencies, dependencies, List.of()), true, scope, Set.of(), null, null),
                 unresolved, resolved, prefix, listener), roots);
     }
 
@@ -277,9 +278,13 @@ public class MavenPomResolver implements MavenResolver {
                     initial,
                     prefix,
                     listener);
-            results.forEach((key, value) -> listener.onResolution(prefix,
-                    key.coordinate(prefix, null),
-                    value.version()));
+            results.forEach((key, value) -> {
+                listener.onResolution(prefix, key.coordinate(prefix, null), value.version());
+                ResolvedPom pom = resolved.get(new DependencyCoordinate(key.groupId(), key.artifactId(), value.version()));
+                if (pom != null && !pom.licenses().isEmpty()) {
+                    listener.onLicenses(prefix, key.coordinate(prefix, value.version()), value.version(), pom.licenses());
+                }
+            });
         }
         return results;
     }
@@ -513,6 +518,7 @@ public class MavenPomResolver implements MavenResolver {
                 Map<String, String> properties = new HashMap<>();
                 Map<DependencyKey, DependencyValue> managedDependencies = new HashMap<>();
                 SequencedMap<DependencyKey, DependencyValue> dependencies = new LinkedHashMap<>();
+                List<License> parentLicenses = List.of();
                 String groupId = null, artifactId = null, version = null;
                 if (parent != null) {
                     if (!children.add(new DependencyCoordinate(parent.groupId(),
@@ -572,6 +578,7 @@ public class MavenPomResolver implements MavenResolver {
                     }
                     managedDependencies.putAll(resolution.managedDependencies());
                     dependencies.putAll(resolution.dependencies());
+                    parentLicenses = resolution.licenses();
                 }
                 IMPLICITS.forEach(property -> toChildren400(document.getDocumentElement(), property)
                         .findFirst()
@@ -603,6 +610,13 @@ public class MavenPomResolver implements MavenResolver {
                 Node modules = extended
                         ? toChildren400(document.getDocumentElement(), "modules").findFirst().orElse(null)
                         : null;
+                List<License> ownLicenses = toChildren400(document.getDocumentElement(), "licenses")
+                        .limit(1)
+                        .flatMap(node -> toChildren400(node, "license"))
+                        .map(node -> new License(
+                                toTextChild400(node, "name").orElse(null),
+                                toTextChild400(node, "url").orElse(null)))
+                        .toList();
                 yield new UnresolvedPom(
                         toTextChild400(document.getDocumentElement(), "groupId").orElse(groupId),
                         toTextChild400(document.getDocumentElement(), "artifactId").orElse(artifactId),
@@ -630,7 +644,8 @@ public class MavenPomResolver implements MavenResolver {
                         dependencies,
                         extended
                                 ? toQualifiedDependencies(document.getDocumentElement())
-                                : new LinkedHashMap<>());
+                                : new LinkedHashMap<>(),
+                        ownLicenses.isEmpty() ? parentLicenses : ownLicenses);
             }
             default -> throw new IllegalArgumentException("Unknown namespace: " + namespace);
         };
@@ -668,7 +683,8 @@ public class MavenPomResolver implements MavenResolver {
                             Map.of(),
                             Map.of(),
                             Collections.emptyNavigableMap(),
-                            new LinkedHashMap<>());
+                            new LinkedHashMap<>(),
+                            List.of());
                 } else {
                     InputStream stream = candidate.toInputStream();
                     Path localPath = candidate.file().map(Path::getParent).orElse(null);
@@ -748,7 +764,7 @@ public class MavenPomResolver implements MavenResolver {
         pom.dependencies().forEach((key, value) -> dependencies.put(
                 key.resolve(pom.properties()),
                 value.resolve(pom.properties())));
-        return new ResolvedPom(managedDependencies, dependencies);
+        return new ResolvedPom(managedDependencies, dependencies, pom.licenses());
     }
 
     private void flattenImport(Executor executor,
@@ -1050,11 +1066,13 @@ public class MavenPomResolver implements MavenResolver {
                                  Map<String, String> properties,
                                  Map<DependencyKey, DependencyValue> managedDependencies,
                                  SequencedMap<DependencyKey, DependencyValue> dependencies,
-                                 SequencedMap<String, String> qualifiedDependencies) {
+                                 SequencedMap<String, String> qualifiedDependencies,
+                                 List<License> licenses) {
     }
 
     private record ResolvedPom(Map<MavenDependencyKey, MavenDependencyValue> managedDependencies,
-                               SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies) {
+                               SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies,
+                               List<License> licenses) {
     }
 
     private record ContextualPom(ResolvedPom pom,

--- a/sources/build/jenesis/project/JaCoCo.java
+++ b/sources/build/jenesis/project/JaCoCo.java
@@ -1,0 +1,31 @@
+package build.jenesis.project;
+
+import module java.base;
+
+public record JaCoCo() implements ObservabilityEngine {
+
+    @Override
+    public String name() {
+        return "jacoco";
+    }
+
+    @Override
+    public SequencedMap<String, String> coordinates() {
+        SequencedMap<String, String> coordinates = new LinkedHashMap<>();
+        coordinates.put("maven/org.jacoco/org.jacoco.agent/jar/runtime", "RELEASE");
+        return coordinates;
+    }
+
+    @Override
+    public List<String> commands(SequencedMap<String, Path> resolved, Path output) {
+        Path agent = resolved.get("maven/org.jacoco/org.jacoco.agent/jar/runtime");
+        if (agent == null) {
+            return List.of();
+        }
+        return List.of("-javaagent:"
+                + agent.toAbsolutePath()
+                + "=destfile="
+                + output.resolve("jacoco.exec").toAbsolutePath()
+                + ",output=file,append=false");
+    }
+}

--- a/sources/build/jenesis/project/JaCoCoModule.java
+++ b/sources/build/jenesis/project/JaCoCoModule.java
@@ -1,0 +1,147 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Dependencies;
+import build.jenesis.step.JdkProcessBuildStep;
+import build.jenesis.step.ProcessHandler;
+
+public class JaCoCoModule implements BuildExecutorModule {
+
+    public static final String REPORT = "report";
+    private static final String REQUIRED = "required", DEPENDENCIES = "dependencies";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String group;
+
+    public JaCoCoModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "jacoco");
+    }
+
+    private JaCoCoModule(Map<String, Repository> repositories,
+                         Map<String, Resolver> resolvers,
+                         Pinning pinning,
+                         String group) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.group = group;
+    }
+
+    public JaCoCoModule pinning(Pinning pinning) {
+        return new JaCoCoModule(repositories, resolvers, pinning, group);
+    }
+
+    public JaCoCoModule group(String group) {
+        return new JaCoCoModule(repositories, resolvers, pinning, group);
+    }
+
+    public ObservabilityEngine engine() {
+        return new JaCoCo();
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        buildExecutor.addStep(REQUIRED, new Requires(group), inherited.sequencedKeySet());
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(DEPENDENCIES,
+                new Dependencies(repositories, resolvers).pinning(pinning),
+                resolveInputs);
+        SequencedSet<String> reportInputs = new LinkedHashSet<>();
+        reportInputs.add(DEPENDENCIES);
+        reportInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(REPORT, new Report(group), reportInputs);
+    }
+
+    private record Requires(String group) implements BuildStep {
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return false;
+        }
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(group + "/runtime/maven/org.jacoco/org.jacoco.cli/RELEASE", "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private static class Report extends JdkProcessBuildStep {
+
+        private final String group;
+
+        private Report(String group) {
+            super("jacoco", ProcessHandler.OfProcess.ofJavaHome("bin/java"));
+            this.group = group;
+        }
+
+        @Override
+        public CompletionStage<List<String>> process(Executor executor,
+                                                     BuildStepContext context,
+                                                     SequencedMap<String, BuildStepArgument> arguments,
+                                                     SequencedMap<String, SequencedMap<String, String>> properties)
+                throws IOException {
+            List<String> jars = new ArrayList<>(), classes = new ArrayList<>(), sources = new ArrayList<>();
+            Path data = null;
+            for (BuildStepArgument argument : arguments.values()) {
+                for (Path jar : Dependencies.select(argument.folder(), group, "runtime")) {
+                    jars.add(jar.toString());
+                }
+                Path exec = argument.folder().resolve("jacoco.exec");
+                if (Files.isRegularFile(exec)) {
+                    data = exec;
+                }
+                Path compiled = argument.folder().resolve(BuildStep.CLASSES);
+                if (Files.isDirectory(compiled)) {
+                    classes.add(compiled.toString());
+                }
+                Path source = argument.folder().resolve(BuildStep.SOURCES);
+                if (Files.isDirectory(source)) {
+                    sources.add(source.toString());
+                }
+            }
+            if (data == null || classes.isEmpty()) {
+                return CompletableFuture.completedStage(null);
+            }
+            if (jars.isEmpty()) {
+                throw new IllegalStateException("No JaCoCo CLI jars resolved upstream of the JaCoCo report step");
+            }
+            Path report = Files.createDirectories(context.next().resolve("coverage"));
+            List<String> commands = new ArrayList<>(List.of(
+                    "-cp", String.join(File.pathSeparator, jars),
+                    "org.jacoco.cli.internal.Main", "report", data.toString()));
+            for (String directory : classes) {
+                commands.add("--classfiles");
+                commands.add(directory);
+            }
+            for (String directory : sources) {
+                commands.add("--sourcefiles");
+                commands.add(directory);
+            }
+            commands.add("--html");
+            commands.add(report.toString());
+            commands.add("--xml");
+            commands.add(report.resolve("jacoco.xml").toString());
+            return CompletableFuture.completedStage(commands);
+        }
+    }
+}

--- a/sources/build/jenesis/project/ObservabilityEngine.java
+++ b/sources/build/jenesis/project/ObservabilityEngine.java
@@ -1,0 +1,12 @@
+package build.jenesis.project;
+
+import module java.base;
+
+public interface ObservabilityEngine extends Serializable {
+
+    String name();
+
+    SequencedMap<String, String> coordinates();
+
+    List<String> commands(SequencedMap<String, Path> resolved, Path output);
+}

--- a/sources/build/jenesis/project/TestModule.java
+++ b/sources/build/jenesis/project/TestModule.java
@@ -36,6 +36,7 @@ public class TestModule implements BuildExecutorModule {
     private final boolean parallel;
     private final boolean reporting;
     private final String dependencyGroup;
+    private final List<ObservabilityEngine> observers;
 
     public TestModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
         List<Pattern> patterns = Stream.of(
@@ -58,7 +59,8 @@ public class TestModule implements BuildExecutorModule {
                 System.getProperty("jenesis.test.group"),
                 Boolean.getBoolean("jenesis.test.parallel"),
                 Boolean.getBoolean("jenesis.test.reporting"),
-                "main");
+                "main",
+                List.of());
     }
 
     private TestModule(TestEngine engine,
@@ -75,7 +77,8 @@ public class TestModule implements BuildExecutorModule {
                        String group,
                        boolean parallel,
                        boolean reporting,
-                       String dependencyGroup) {
+                       String dependencyGroup,
+                       List<ObservabilityEngine> observers) {
         this.engine = engine;
         this.isTest = isTest;
         this.factory = factory;
@@ -91,6 +94,7 @@ public class TestModule implements BuildExecutorModule {
         this.parallel = parallel;
         this.reporting = reporting;
         this.dependencyGroup = dependencyGroup;
+        this.observers = observers;
     }
 
     public TestModule engine(TestEngine engine) {
@@ -108,7 +112,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public <P extends Predicate<String> & Serializable> TestModule isTest(P isTest) {
@@ -126,7 +131,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule factory(Function<List<String>, ProcessHandler.OfProcess> factory) {
@@ -144,7 +150,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule filter(String filter) {
@@ -162,7 +169,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule jarsOnly(boolean jarsOnly) {
@@ -180,7 +188,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule requireEngine(boolean requireEngine) {
@@ -198,7 +207,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule pinning(Pinning pinning) {
@@ -216,7 +226,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule modulePath(PathPlacement modulePath) {
@@ -234,7 +245,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule moduleName(String moduleName) {
@@ -252,7 +264,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule group(String group) {
@@ -270,7 +283,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule dependencyGroup(String dependencyGroup) {
@@ -288,7 +302,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule parallel(boolean parallel) {
@@ -306,7 +321,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule reporting(boolean reporting) {
@@ -324,7 +340,27 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
+    }
+
+    public TestModule observe(ObservabilityEngine... observers) {
+        return new TestModule(engine,
+                isTest,
+                factory,
+                repositories,
+                resolvers,
+                jarsOnly,
+                requireEngine,
+                pinning,
+                modulePath,
+                moduleName,
+                filter,
+                group,
+                parallel,
+                reporting,
+                dependencyGroup,
+                List.of(observers));
     }
 
     @Override
@@ -342,7 +378,7 @@ public class TestModule implements BuildExecutorModule {
             }
         }
         SequencedSet<String> upstream = inherited.sequencedKeySet();
-        buildExecutor.addStep(RESOLVED, new Requires(dependencyGroup, resolved, Set.copyOf(resolvers.keySet())), upstream);
+        buildExecutor.addStep(RESOLVED, new Requires(dependencyGroup, resolved, Set.copyOf(resolvers.keySet()), observers), upstream);
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(RESOLVED);
         resolveInputs.addAll(upstream);
@@ -359,7 +395,8 @@ public class TestModule implements BuildExecutorModule {
                         filter,
                         group,
                         parallel,
-                        reporting),
+                        reporting,
+                        observers),
                 Stream.concat(upstream.stream(), Stream.of(DEPENDENCIES)));
     }
 
@@ -374,7 +411,7 @@ public class TestModule implements BuildExecutorModule {
         return Optional.empty();
     }
 
-    private record Requires(String group, TestEngine engine, Set<String> prefixes) implements BuildStep {
+    private record Requires(String group, TestEngine engine, Set<String> prefixes, List<ObservabilityEngine> observers) implements BuildStep {
 
         @Override
         public CompletionStage<BuildStepResult> apply(Executor executor,
@@ -422,6 +459,11 @@ public class TestModule implements BuildExecutorModule {
                     }
                 }
             }
+            for (ObservabilityEngine observer : observers) {
+                for (Map.Entry<String, String> entry : observer.coordinates().entrySet()) {
+                    properties.setProperty(observer.name() + "/runtime/" + entry.getKey() + "/" + entry.getValue(), "");
+                }
+            }
             properties.store(context.next().resolve(BuildStep.REQUIRES));
             if (!versions.isEmpty()) {
                 versions.store(context.next().resolve(BuildStep.VERSIONS));
@@ -439,6 +481,7 @@ public class TestModule implements BuildExecutorModule {
         private final String group;
         private final transient boolean parallel;
         private final boolean reporting;
+        private final List<ObservabilityEngine> observers;
 
         private Run(Function<List<String>, ProcessHandler.OfProcess> factory,
                     TestEngine engine,
@@ -449,7 +492,8 @@ public class TestModule implements BuildExecutorModule {
                     String filter,
                     String group,
                     boolean parallel,
-                    boolean reporting) {
+                    boolean reporting,
+                    List<ObservabilityEngine> observers) {
             super(factory == null ? ProcessHandler.OfProcess.ofJavaHome("bin/java") : factory, modulePath, jarsOnly);
             this.engine = engine;
             this.isTest = isTest;
@@ -458,6 +502,7 @@ public class TestModule implements BuildExecutorModule {
             this.group = group;
             this.parallel = parallel;
             this.reporting = reporting;
+            this.observers = observers;
         }
 
         @Override
@@ -477,6 +522,9 @@ public class TestModule implements BuildExecutorModule {
             List<TestSpec> specs = TestSpec.parse(filter);
             SequencedSet<String> groups = groups(group);
             List<String> commands = new ArrayList<>();
+            for (ObservabilityEngine observer : observers) {
+                commands.addAll(observer.commands(agentJars(arguments, observer), context.next()));
+            }
             for (Map.Entry<String, String> entry : resolved.properties().entrySet()) {
                 commands.add("-D" + entry.getKey() + "=" + entry.getValue());
             }
@@ -545,6 +593,32 @@ public class TestModule implements BuildExecutorModule {
                     parallel,
                     reporting));
             return CompletableFuture.completedFuture(commands);
+        }
+
+        private static SequencedMap<String, Path> agentJars(SequencedMap<String, BuildStepArgument> arguments,
+                                                            ObservabilityEngine observer) throws IOException {
+            SequencedMap<String, Path> resolved = new LinkedHashMap<>();
+            for (BuildStepArgument argument : arguments.values()) {
+                Path file = argument.folder().resolve(BuildStep.DEPENDENCIES);
+                if (!Files.exists(file)) {
+                    continue;
+                }
+                SequencedProperties properties = SequencedProperties.ofFiles(file);
+                for (String coordinate : observer.coordinates().sequencedKeySet()) {
+                    String prefix = observer.name() + "/runtime/" + coordinate + "/";
+                    for (String key : properties.stringPropertyNames()) {
+                        if (key.startsWith(prefix)) {
+                            String value = properties.getProperty(key);
+                            int space = value.indexOf(' ');
+                            Path jar = argument.folder().resolve(space < 0 ? value : value.substring(0, space)).normalize();
+                            if (Files.exists(jar)) {
+                                resolved.putIfAbsent(coordinate, jar);
+                            }
+                        }
+                    }
+                }
+            }
+            return resolved;
         }
 
         private static SequencedSet<String> groups(String group) {

--- a/sources/build/jenesis/step/CycloneDxEmitter.java
+++ b/sources/build/jenesis/step/CycloneDxEmitter.java
@@ -1,0 +1,230 @@
+package build.jenesis.step;
+
+import module java.base;
+import module java.xml;
+import build.jenesis.License;
+
+public class CycloneDxEmitter {
+
+    public enum Format {
+
+        JSON("cdx.json"), XML("cdx.xml");
+
+        private final String extension;
+
+        Format(String extension) {
+            this.extension = extension;
+        }
+
+        public String extension() {
+            return extension;
+        }
+    }
+
+    private static final String SPEC_VERSION = "1.6";
+    private static final String NAMESPACE = "http://cyclonedx.org/schema/bom/" + SPEC_VERSION;
+
+    private static final Map<String, String> SPDX = Map.ofEntries(
+            Map.entry("apache license, version 2.0", "Apache-2.0"),
+            Map.entry("the apache software license, version 2.0", "Apache-2.0"),
+            Map.entry("apache 2.0", "Apache-2.0"),
+            Map.entry("apache-2.0", "Apache-2.0"),
+            Map.entry("apache license 2.0", "Apache-2.0"),
+            Map.entry("mit license", "MIT"),
+            Map.entry("the mit license", "MIT"),
+            Map.entry("mit", "MIT"),
+            Map.entry("bsd license", "BSD-2-Clause"),
+            Map.entry("the bsd license", "BSD-2-Clause"),
+            Map.entry("bsd-2-clause", "BSD-2-Clause"),
+            Map.entry("bsd 3-clause", "BSD-3-Clause"),
+            Map.entry("the bsd 3-clause license", "BSD-3-Clause"),
+            Map.entry("bsd-3-clause", "BSD-3-Clause"),
+            Map.entry("eclipse public license - v 1.0", "EPL-1.0"),
+            Map.entry("eclipse public license 1.0", "EPL-1.0"),
+            Map.entry("epl-1.0", "EPL-1.0"),
+            Map.entry("eclipse public license - v 2.0", "EPL-2.0"),
+            Map.entry("eclipse public license 2.0", "EPL-2.0"),
+            Map.entry("epl-2.0", "EPL-2.0"),
+            Map.entry("gnu lesser general public license", "LGPL-2.1-or-later"),
+            Map.entry("lgpl-2.1", "LGPL-2.1-only"),
+            Map.entry("gnu general public license, version 2", "GPL-2.0-only"),
+            Map.entry("common development and distribution license 1.0", "CDDL-1.0"),
+            Map.entry("cddl-1.0", "CDDL-1.0"));
+
+    public record Component(String group, String name, String version, String purl, String sha256, List<License> licenses) {
+    }
+
+    public String emit(Format format, Component metadata, List<Component> components) {
+        List<Component> sorted = new ArrayList<>(components);
+        sorted.sort(Comparator.comparing(component -> component.purl() == null
+                ? component.group() + ":" + component.name() + ":" + component.version()
+                : component.purl()));
+        return format == Format.XML ? emitXml(metadata, sorted) : emitJson(metadata, sorted);
+    }
+
+    private String emitJson(Component metadata, List<Component> components) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("{\n");
+        builder.append("  \"bomFormat\": \"CycloneDX\",\n");
+        builder.append("  \"specVersion\": \"").append(SPEC_VERSION).append("\",\n");
+        builder.append("  \"version\": 1,\n");
+        builder.append("  \"metadata\": {\n");
+        builder.append("    \"tools\": [\n      { \"name\": \"Jenesis\" }\n    ],\n");
+        builder.append("    \"component\": ");
+        appendJsonComponent(builder, metadata, 4);
+        builder.append("\n  }");
+        if (!components.isEmpty()) {
+            builder.append(",\n  \"components\": [\n");
+            for (int index = 0; index < components.size(); index++) {
+                builder.append("    ");
+                appendJsonComponent(builder, components.get(index), 4);
+                builder.append(index + 1 < components.size() ? ",\n" : "\n");
+            }
+            builder.append("  ]");
+        }
+        builder.append("\n}\n");
+        return builder.toString();
+    }
+
+    private void appendJsonComponent(StringBuilder builder, Component component, int indent) {
+        String pad = " ".repeat(indent);
+        builder.append("{\n");
+        builder.append(pad).append("  \"type\": \"library\",\n");
+        if (component.group() != null) {
+            builder.append(pad).append("  \"group\": \"").append(escapeJson(component.group())).append("\",\n");
+        }
+        builder.append(pad).append("  \"name\": \"").append(escapeJson(component.name())).append("\",\n");
+        builder.append(pad).append("  \"version\": \"").append(escapeJson(component.version())).append("\"");
+        if (component.sha256() != null) {
+            builder.append(",\n").append(pad).append("  \"hashes\": [\n");
+            builder.append(pad).append("    { \"alg\": \"SHA-256\", \"content\": \"")
+                    .append(escapeJson(component.sha256())).append("\" }\n");
+            builder.append(pad).append("  ]");
+        }
+        if (component.licenses() != null && !component.licenses().isEmpty()) {
+            builder.append(",\n").append(pad).append("  \"licenses\": [\n");
+            for (int index = 0; index < component.licenses().size(); index++) {
+                License license = component.licenses().get(index);
+                String spdx = spdx(license.name());
+                builder.append(pad).append("    { \"license\": { ");
+                if (spdx != null) {
+                    builder.append("\"id\": \"").append(escapeJson(spdx)).append("\"");
+                } else {
+                    builder.append("\"name\": \"").append(escapeJson(license.name() == null ? "" : license.name())).append("\"");
+                    if (license.url() != null) {
+                        builder.append(", \"url\": \"").append(escapeJson(license.url())).append("\"");
+                    }
+                }
+                builder.append(" } }").append(index + 1 < component.licenses().size() ? ",\n" : "\n");
+            }
+            builder.append(pad).append("  ]");
+        }
+        if (component.purl() != null) {
+            builder.append(",\n").append(pad).append("  \"purl\": \"").append(escapeJson(component.purl())).append("\"");
+        }
+        builder.append("\n").append(pad).append("}");
+    }
+
+    private String emitXml(Component metadata, List<Component> components) {
+        Document document;
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            document = factory.newDocumentBuilder().newDocument();
+        } catch (ParserConfigurationException e) {
+            throw new IllegalStateException(e);
+        }
+        Element bom = (Element) document.appendChild(document.createElementNS(NAMESPACE, "bom"));
+        bom.setAttribute("version", "1");
+        Element meta = (Element) bom.appendChild(document.createElementNS(NAMESPACE, "metadata"));
+        Element tools = (Element) meta.appendChild(document.createElementNS(NAMESPACE, "tools"));
+        Element tool = (Element) tools.appendChild(document.createElementNS(NAMESPACE, "tool"));
+        appendXmlText(document, tool, "name", "Jenesis");
+        appendXmlComponent(document, meta, metadata);
+        if (!components.isEmpty()) {
+            Element wrapper = (Element) bom.appendChild(document.createElementNS(NAMESPACE, "components"));
+            for (Component component : components) {
+                appendXmlComponent(document, wrapper, component);
+            }
+        }
+        Transformer transformer;
+        try {
+            transformer = TransformerFactory.newInstance().newTransformer();
+        } catch (TransformerConfigurationException e) {
+            throw new IllegalStateException(e);
+        }
+        transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        StringWriter writer = new StringWriter();
+        try {
+            transformer.transform(new DOMSource(document), new StreamResult(writer));
+        } catch (TransformerException e) {
+            throw new IllegalStateException(e);
+        }
+        return writer.toString().replace("\r\n", "\n");
+    }
+
+    private void appendXmlComponent(Document document, Node parent, Component component) {
+        Element node = (Element) parent.appendChild(document.createElementNS(NAMESPACE, "component"));
+        node.setAttribute("type", "library");
+        if (component.group() != null) {
+            appendXmlText(document, node, "group", component.group());
+        }
+        appendXmlText(document, node, "name", component.name());
+        appendXmlText(document, node, "version", component.version());
+        if (component.sha256() != null) {
+            Element hashes = (Element) node.appendChild(document.createElementNS(NAMESPACE, "hashes"));
+            Element hash = (Element) hashes.appendChild(document.createElementNS(NAMESPACE, "hash"));
+            hash.setAttribute("alg", "SHA-256");
+            hash.setTextContent(component.sha256());
+        }
+        if (component.licenses() != null && !component.licenses().isEmpty()) {
+            Element licenses = (Element) node.appendChild(document.createElementNS(NAMESPACE, "licenses"));
+            for (License license : component.licenses()) {
+                Element wrapper = (Element) licenses.appendChild(document.createElementNS(NAMESPACE, "license"));
+                String spdx = spdx(license.name());
+                if (spdx != null) {
+                    appendXmlText(document, wrapper, "id", spdx);
+                } else {
+                    appendXmlText(document, wrapper, "name", license.name() == null ? "" : license.name());
+                    if (license.url() != null) {
+                        appendXmlText(document, wrapper, "url", license.url());
+                    }
+                }
+            }
+        }
+        if (component.purl() != null) {
+            appendXmlText(document, node, "purl", component.purl());
+        }
+    }
+
+    private static void appendXmlText(Document document, Node parent, String name, String text) {
+        parent.appendChild(document.createElementNS(NAMESPACE, name)).setTextContent(text);
+    }
+
+    private static String spdx(String name) {
+        return name == null ? null : SPDX.get(name.toLowerCase(Locale.ROOT).trim());
+    }
+
+    private static String escapeJson(String text) {
+        StringBuilder builder = new StringBuilder(text.length());
+        for (int index = 0; index < text.length(); index++) {
+            char c = text.charAt(index);
+            switch (c) {
+                case '"' -> builder.append("\\\"");
+                case '\\' -> builder.append("\\\\");
+                case '\n' -> builder.append("\\n");
+                case '\r' -> builder.append("\\r");
+                case '\t' -> builder.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        builder.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        builder.append(c);
+                    }
+                }
+            }
+        }
+        return builder.toString();
+    }
+}

--- a/sources/build/jenesis/step/Dependencies.java
+++ b/sources/build/jenesis/step/Dependencies.java
@@ -7,9 +7,11 @@ import build.jenesis.BuildStepArgument;
 import build.jenesis.BuildStepContext;
 import build.jenesis.BuildStepResult;
 import build.jenesis.DependencyScope;
+import build.jenesis.License;
 import build.jenesis.Pinning;
 import build.jenesis.Repository;
 import build.jenesis.RepositoryItem;
+import build.jenesis.ResolutionContext;
 import build.jenesis.ResolutionListener;
 import build.jenesis.Resolver;
 import build.jenesis.SequencedProperties;
@@ -24,32 +26,39 @@ public class Dependencies implements BuildStep {
     private final Map<String, Resolver> resolvers;
     private final Pinning pinning;
     private final transient Supplier<ResolutionListener> listener;
+    private final boolean capturing;
 
     public Dependencies(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
-        this(repositories, resolvers, null, null);
+        this(repositories, resolvers, null, null, false);
     }
 
     private Dependencies(Map<String, Repository> repositories,
                          Map<String, Resolver> resolvers,
                          Pinning pinning,
-                         Supplier<ResolutionListener> listener) {
+                         Supplier<ResolutionListener> listener,
+                         boolean capturing) {
         this.repositories = repositories;
         this.resolvers = new LinkedHashMap<>(resolvers);
         this.pinning = pinning;
         this.listener = listener;
+        this.capturing = capturing;
     }
 
     public Dependencies pinning(Pinning pinning) {
-        return new Dependencies(repositories, resolvers, pinning, listener);
+        return new Dependencies(repositories, resolvers, pinning, listener, capturing);
     }
 
     public Dependencies listening(Supplier<ResolutionListener> listener) {
-        return new Dependencies(repositories, resolvers, pinning, listener);
+        return new Dependencies(repositories, resolvers, pinning, listener, capturing);
+    }
+
+    public Dependencies capturing(boolean capturing) {
+        return new Dependencies(repositories, resolvers, pinning, listener, capturing);
     }
 
     @Override
     public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
-        if (listener != null) {
+        if (listener != null || capturing) {
             return true;
         }
         return arguments.values().stream().anyMatch(argument -> argument.hasChanged(
@@ -137,6 +146,7 @@ public class Dependencies implements BuildStep {
         });
         SequencedProperties resolved = new SequencedProperties();
         SequencedMap<String, Resolver.Resolved> materialized = new LinkedHashMap<>();
+        SequencedMap<String, List<License>> capturedLicenses = capturing ? new LinkedHashMap<>() : null;
         for (Map.Entry<String, SequencedMap<String, SequencedMap<String, SequencedMap<String, String>>>> groupEntry : requires.entrySet()) {
             String group = groupEntry.getKey();
             for (String scope : groupEntry.getValue().sequencedKeySet()) {
@@ -162,10 +172,13 @@ public class Dependencies implements BuildStep {
                         }
                     }
                     SequencedMap<String, Resolver.Resolved> result;
-                    if (listener == null) {
+                    ResolutionListener external = listener == null ? null : listener.get();
+                    ResolutionListener current = capturedLicenses == null
+                            ? external
+                            : new LicenseCapture(external, capturedLicenses);
+                    if (current == null) {
                         result = resolver.dependencies(executor, repo, wrapped, coordinates, bom, intent);
                     } else {
-                        ResolutionListener current = listener.get();
                         result = resolver.dependencies(executor, repo, wrapped, coordinates, bom, intent, current);
                         current.onResolved();
                     }
@@ -234,7 +247,62 @@ public class Dependencies implements BuildStep {
             }
         }
         index.store(context.next().resolve(DEPENDENCIES));
+        if (capturedLicenses != null) {
+            SequencedProperties licenses = new SequencedProperties();
+            for (Map.Entry<String, List<License>> entry : capturedLicenses.entrySet()) {
+                List<License> list = entry.getValue();
+                for (int index2 = 0; index2 < list.size(); index2++) {
+                    License license = list.get(index2);
+                    if (license.name() != null) {
+                        licenses.setProperty(entry.getKey() + "#" + index2 + "#name", license.name());
+                    }
+                    if (license.url() != null) {
+                        licenses.setProperty(entry.getKey() + "#" + index2 + "#url", license.url());
+                    }
+                }
+            }
+            licenses.store(context.next().resolve("licenses.properties"));
+        }
         return CompletableFuture.completedStage(new BuildStepResult(true));
+    }
+
+    private record LicenseCapture(ResolutionListener delegate,
+                                  SequencedMap<String, List<License>> licenses) implements ResolutionListener {
+
+        @Override
+        public void onDependency(String prefix,
+                                 String parent,
+                                 String coordinate,
+                                 String version,
+                                 String scope,
+                                 boolean followed,
+                                 Supplier<ResolutionContext> context) {
+            if (delegate != null) {
+                delegate.onDependency(prefix, parent, coordinate, version, scope, followed, context);
+            }
+        }
+
+        @Override
+        public void onResolution(String prefix, String coordinate, String version) {
+            if (delegate != null) {
+                delegate.onResolution(prefix, coordinate, version);
+            }
+        }
+
+        @Override
+        public void onLicenses(String prefix, String coordinate, String version, List<License> licenses) {
+            this.licenses.putIfAbsent(coordinate, licenses);
+            if (delegate != null) {
+                delegate.onLicenses(prefix, coordinate, version, licenses);
+            }
+        }
+
+        @Override
+        public void onResolved() {
+            if (delegate != null) {
+                delegate.onResolved();
+            }
+        }
     }
 
     public static List<Path> select(Path folder, String scope) throws IOException {

--- a/sources/build/jenesis/step/Sbom.java
+++ b/sources/build/jenesis/step/Sbom.java
@@ -1,0 +1,201 @@
+package build.jenesis.step;
+
+import module java.base;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.License;
+import build.jenesis.SequencedProperties;
+import build.jenesis.maven.MavenDependencyKey;
+
+public class Sbom implements BuildStep {
+
+    public static final String SBOM = "sbom/";
+
+    private final CycloneDxEmitter.Format format;
+
+    public Sbom() {
+        this(CycloneDxEmitter.Format.JSON);
+    }
+
+    private Sbom(CycloneDxEmitter.Format format) {
+        this.format = format;
+    }
+
+    public Sbom format(CycloneDxEmitter.Format format) {
+        return new Sbom(format);
+    }
+
+    @Override
+    public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+        return arguments.values().stream().anyMatch(argument -> argument.hasChanged(
+                Path.of(DEPENDENCIES),
+                Path.of(METADATA)));
+    }
+
+    @Override
+    public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                  BuildStepContext context,
+                                                  SequencedMap<String, BuildStepArgument> arguments)
+            throws IOException {
+        List<Path> folders = arguments.values().stream().map(BuildStepArgument::folder).toList();
+        SequencedProperties metadata = SequencedProperties.ofFolders(folders, METADATA);
+        String groupId = metadata.getProperty("project");
+        String artifactId = metadata.getProperty("artifact");
+        String version = metadata.getProperty("version");
+        if (groupId == null || artifactId == null || version == null) {
+            throw new IllegalStateException("Missing project/artifact/version in metadata.properties for the SBOM");
+        }
+        HashDigestFunction hash = new HashDigestFunction("SHA-256");
+        SequencedMap<String, CycloneDxEmitter.Component> components = new LinkedHashMap<>();
+        for (BuildStepArgument argument : arguments.values()) {
+            Path index = argument.folder().resolve(DEPENDENCIES);
+            if (!Files.exists(index)) {
+                continue;
+            }
+            SequencedProperties dependencies = SequencedProperties.ofFiles(index);
+            Path sidecar = argument.folder().resolve("licenses.properties");
+            SequencedProperties licenses = Files.exists(sidecar)
+                    ? SequencedProperties.ofFiles(sidecar)
+                    : new SequencedProperties();
+            for (String key : dependencies.stringPropertyNames()) {
+                int first = key.indexOf('/'), second = key.indexOf('/', first + 1), third = key.indexOf('/', second + 1);
+                if (first < 0 || second < 0 || third < 0) {
+                    continue;
+                }
+                String coordinate = key.substring(third + 1), licenseKey = key.substring(second + 1);
+                if (components.containsKey(coordinate)) {
+                    continue;
+                }
+                String value = dependencies.getProperty(key);
+                int space = value.indexOf(' ');
+                Path jar = argument.folder().resolve(space < 0 ? value : value.substring(0, space)).normalize();
+                components.put(coordinate, component(coordinate,
+                        Files.exists(jar) ? HexFormat.of().formatHex(hash.hash(jar)) : null,
+                        readLicenses(licenses, licenseKey)));
+            }
+        }
+        CycloneDxEmitter.Component project = new CycloneDxEmitter.Component(groupId,
+                artifactId,
+                version,
+                "pkg:maven/" + groupId + "/" + artifactId + "@" + version,
+                null,
+                ownLicenses(metadata));
+        String document = new CycloneDxEmitter().emit(format, project, new ArrayList<>(components.values()));
+
+        Path embedded = Files.createDirectories(context.next()
+                .resolve(RESOURCES).resolve("META-INF").resolve("sbom"));
+        String fileName = artifactId + "." + format.extension();
+        Files.writeString(embedded.resolve(fileName), document);
+        SequencedProperties manifest = new SequencedProperties();
+        manifest.setProperty("Sbom-Format", "CycloneDX");
+        manifest.setProperty("Sbom-Location", "META-INF/sbom/" + fileName);
+        manifest.store(context.next().resolve("manifest.mf"));
+        Files.writeString(context.next().resolve(RESOURCES).resolve("META-INF").resolve("NOTICE"), notice(metadata));
+        Path standalone = Files.createDirectories(context.next().resolve(SBOM));
+        Files.writeString(standalone.resolve(artifactId + "-" + version + "." + format.extension()), document);
+        return CompletableFuture.completedStage(new BuildStepResult(true));
+    }
+
+    private static CycloneDxEmitter.Component component(String coordinate, String sha256, List<License> licenses) {
+        try {
+            MavenDependencyKey.Versioned parsed = MavenDependencyKey.tryParse(coordinate);
+            if (parsed.version() != null) {
+                MavenDependencyKey key = parsed.key();
+                StringBuilder purl = new StringBuilder("pkg:maven/")
+                        .append(key.groupId()).append("/").append(key.artifactId()).append("@").append(parsed.version());
+                List<String> qualifiers = new ArrayList<>();
+                if (key.type() != null && !key.type().equals("jar")) {
+                    qualifiers.add("type=" + key.type());
+                }
+                if (key.classifier() != null) {
+                    qualifiers.add("classifier=" + key.classifier());
+                }
+                if (!qualifiers.isEmpty()) {
+                    purl.append("?").append(String.join("&", qualifiers));
+                }
+                return new CycloneDxEmitter.Component(key.groupId(), key.artifactId(), parsed.version(),
+                        purl.toString(), sha256, licenses);
+            }
+        } catch (RuntimeException _) {
+        }
+        int last = coordinate.lastIndexOf('/');
+        return new CycloneDxEmitter.Component(null,
+                last < 0 ? coordinate : coordinate.substring(0, last),
+                last < 0 ? "" : coordinate.substring(last + 1),
+                null,
+                sha256,
+                licenses);
+    }
+
+    private static List<License> readLicenses(SequencedProperties licenses, String licenseKey) {
+        SequencedMap<Integer, String[]> byIndex = new TreeMap<>();
+        String prefix = licenseKey + "#";
+        for (String key : licenses.stringPropertyNames()) {
+            if (!key.startsWith(prefix)) {
+                continue;
+            }
+            String rest = key.substring(prefix.length());
+            int hash = rest.indexOf('#');
+            if (hash < 0) {
+                continue;
+            }
+            int index;
+            try {
+                index = Integer.parseInt(rest.substring(0, hash));
+            } catch (NumberFormatException _) {
+                continue;
+            }
+            String[] entry = byIndex.computeIfAbsent(index, _ -> new String[2]);
+            if (rest.substring(hash + 1).equals("name")) {
+                entry[0] = licenses.getProperty(key);
+            } else if (rest.substring(hash + 1).equals("url")) {
+                entry[1] = licenses.getProperty(key);
+            }
+        }
+        return byIndex.values().stream().map(entry -> new License(entry[0], entry[1])).toList();
+    }
+
+    private static List<License> ownLicenses(SequencedProperties metadata) {
+        SequencedMap<String, String[]> byId = new LinkedHashMap<>();
+        for (String key : metadata.stringPropertyNames()) {
+            if (!key.startsWith("license.")) {
+                continue;
+            }
+            String suffix = key.substring("license.".length());
+            int dot = suffix.lastIndexOf('.');
+            if (dot <= 0) {
+                continue;
+            }
+            String[] entry = byId.computeIfAbsent(suffix.substring(0, dot), _ -> new String[2]);
+            if (suffix.substring(dot + 1).equals("name")) {
+                entry[0] = metadata.getProperty(key);
+            } else if (suffix.substring(dot + 1).equals("url")) {
+                entry[1] = metadata.getProperty(key);
+            }
+        }
+        return byId.values().stream().map(entry -> new License(entry[0], entry[1])).toList();
+    }
+
+    private static String notice(SequencedProperties metadata) {
+        String name = metadata.getProperty("name");
+        StringBuilder builder = new StringBuilder(name == null
+                ? metadata.getProperty("project") + ":" + metadata.getProperty("artifact")
+                : name);
+        builder.append("\n");
+        String url = metadata.getProperty("url");
+        if (url != null) {
+            builder.append(url).append("\n");
+        }
+        for (License license : ownLicenses(metadata)) {
+            builder.append("\nLicensed under ").append(license.name() == null ? "" : license.name());
+            if (license.url() != null) {
+                builder.append(" (").append(license.url()).append(")");
+            }
+            builder.append("\n");
+        }
+        return builder.toString();
+    }
+}

--- a/tests/build/jenesis/test/maven/MavenPomResolverTest.java
+++ b/tests/build/jenesis/test/maven/MavenPomResolverTest.java
@@ -3,6 +3,7 @@ package build.jenesis.test.maven;
 import module java.base;
 import module org.junit.jupiter.api;
 import build.jenesis.DependencyScope;
+import build.jenesis.License;
 import build.jenesis.ResolutionContext;
 import build.jenesis.ResolutionListener;
 import build.jenesis.Resolver;
@@ -3866,6 +3867,94 @@ public class MavenPomResolverTest {
         assertThatThrownBy(() -> mavenPomResolver.local(Runnable::run, mavenRepository, project))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Circular POM module reference to ");
+    }
+
+    @Test
+    public void captures_declared_and_parent_inherited_licenses() throws IOException {
+        addToRepository("parentgroup", "parentlib", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>parentgroup</groupId>
+                    <artifactId>parentlib</artifactId>
+                    <version>1</version>
+                    <licenses>
+                        <license>
+                            <name>Apache-2.0</name>
+                            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+                        </license>
+                    </licenses>
+                </project>
+                """);
+        addToRepository("leafgroup", "leaflib", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>parentgroup</groupId>
+                        <artifactId>parentlib</artifactId>
+                        <version>1</version>
+                    </parent>
+                    <artifactId>leaflib</artifactId>
+                </project>
+                """);
+        addToRepository("dirgroup", "dirlib", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>dirgroup</groupId>
+                    <artifactId>dirlib</artifactId>
+                    <version>1</version>
+                    <licenses>
+                        <license>
+                            <name>MIT</name>
+                            <url>https://opensource.org/license/mit</url>
+                        </license>
+                    </licenses>
+                </project>
+                """);
+        addToRepository("rootgroup", "rootlib", "1", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>rootgroup</groupId>
+                    <artifactId>rootlib</artifactId>
+                    <version>1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>leafgroup</groupId>
+                            <artifactId>leaflib</artifactId>
+                            <version>1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>dirgroup</groupId>
+                            <artifactId>dirlib</artifactId>
+                            <version>1</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+
+        SequencedMap<String, List<License>> captured = new LinkedHashMap<>();
+        mavenPomResolver.dependencies(Runnable::run, mavenRepository, "rootgroup", "rootlib", "1", null,
+                new ResolutionListener() {
+                    @Override
+                    public void onDependency(String prefix, String parent, String coordinate, String version,
+                                             String scope, boolean followed, Supplier<ResolutionContext> context) {
+                    }
+
+                    @Override
+                    public void onLicenses(String prefix, String coordinate, String version, List<License> licenses) {
+                        captured.put(coordinate, licenses);
+                    }
+                });
+
+        assertThat(captured.get("leafgroup/leaflib/1"))
+                .as("a dependency inherits its parent POM's license")
+                .containsExactly(new License("Apache-2.0", "https://www.apache.org/licenses/LICENSE-2.0.txt"));
+        assertThat(captured.get("dirgroup/dirlib/1"))
+                .as("a dependency's own declared license is captured")
+                .containsExactly(new License("MIT", "https://opensource.org/license/mit"));
     }
 
     private void addToRepository(String groupId, String artifactId, String version, String pom) throws IOException {

--- a/tests/build/jenesis/test/project/JaCoCoModuleRunTest.java
+++ b/tests/build/jenesis/test/project/JaCoCoModuleRunTest.java
@@ -1,0 +1,195 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module java.compiler;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.SequencedProperties;
+import build.jenesis.maven.MavenDefaultRepository;
+import build.jenesis.maven.MavenPomResolver;
+import build.jenesis.project.JaCoCo;
+import build.jenesis.project.JaCoCoModule;
+import build.jenesis.project.TestModule;
+import build.jenesis.step.Javac;
+import javax.tools.ToolProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JaCoCoModuleRunTest {
+
+    private static final String VERSION = "0.8.14";
+
+    @TempDir
+    private Path root, dependencies, classes, sources;
+
+    @Test
+    public void collects_coverage_and_renders_a_report() throws Exception {
+        Path artifacts = Files.createDirectory(dependencies.resolve(BuildStep.ARTIFACTS));
+        for (Path path : bootModuleJars()) {
+            String fileName = path.getFileName().toString();
+            if (fileName.endsWith("_rt.jar") || fileName.endsWith("-rt.jar")) {
+                continue;
+            }
+            Files.copy(path, artifacts.resolve(fileName + "-" + UUID.randomUUID() + ".jar"));
+        }
+
+        Path samplePackage = Files.createDirectories(sources.resolve(BuildStep.SOURCES).resolve("sample"));
+        Files.writeString(samplePackage.resolve("Sample.java"), """
+                package sample;
+                public class Sample {
+                    public int add(int left, int right) {
+                        return left + right;
+                    }
+                }
+                """);
+        compileSources(classes.resolve(Javac.CLASSES + "sample"), bootModuleJars(), Map.of(
+                "Sample", """
+                        package sample;
+                        public class Sample {
+                            public int add(int left, int right) {
+                                return left + right;
+                            }
+                        }
+                        """,
+                "SampleTest", """
+                        package sample;
+                        public class SampleTest {
+                            @org.junit.jupiter.api.Test
+                            public void adds() {
+                                if (new Sample().add(2, 3) != 5) {
+                                    throw new AssertionError();
+                                }
+                            }
+                        }
+                        """));
+
+        SequencedProperties versions = new SequencedProperties();
+        versions.setProperty("main/maven/org.junit.platform/junit-platform-console",
+                "1.11.4 SHA-256/a9c3309cdfded3542200de85da6cb274864439d6b02ba80bb45ecc8e0bdf1be7");
+        versions.setProperty("main/maven/org.junit.platform/junit-platform-reporting",
+                "1.11.4 SHA-256/df6896109bfaef4de8d2fa9e3371a6176936d1a45a6c0e7fd8f7e6dd6f4c5597");
+        versions.setProperty("main/maven/org.junit.platform/junit-platform-launcher",
+                "1.11.4 SHA-256/d7430bd029e7fcced53ee445e4d2d1a8a1e043ea4c4df43b6335a857f79761ae");
+        versions.setProperty("main/maven/org.junit.platform/junit-platform-engine",
+                "1.11.3 SHA-256/0043f72f611664735da8dc9a308bf12ecd2236b05339351c4741edb4d8fab0da");
+        versions.setProperty("main/maven/org.junit.platform/junit-platform-commons",
+                "1.11.3 SHA-256/be262964b0b6b48de977c61d4f931df8cf61e80e750cc3f3a0a39cdd21c1008c");
+        versions.setProperty("main/maven/org.opentest4j/opentest4j",
+                "1.3.0 SHA-256/48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b");
+        versions.setProperty("main/maven/org.apiguardian/apiguardian-api",
+                "1.1.2 SHA-256/b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38");
+        versions.setProperty("jacoco/maven/org.jacoco/org.jacoco.agent/jar/runtime", VERSION);
+        versions.setProperty("jacoco/maven/org.jacoco/org.jacoco.cli", VERSION);
+        versions.store(dependencies.resolve(BuildStep.VERSIONS));
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("dependencies", dependencies);
+        executor.addSource("classes", classes);
+        executor.addSource("sources", sources);
+        executor.addModule(
+                "test",
+                new TestModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver()))
+                        .observe(new JaCoCo())
+                        .isTest(candidate -> candidate.endsWith("SampleTest"))
+                        .jarsOnly(false),
+                "dependencies", "classes");
+        executor.addModule(
+                "coverage",
+                new JaCoCoModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver())),
+                "test", "classes", "sources", "dependencies");
+        executor.execute();
+
+        Path exec = root.resolve("test").resolve("executed").resolve("output").resolve("jacoco.exec");
+        assertThat(exec).as("the agent wrote its execution data into the test step output").isNotEmptyFile();
+        assertThat(Files.readString(exec, StandardCharsets.ISO_8859_1))
+                .as("the agent instrumented and recorded the sample class")
+                .contains("sample/Sample");
+
+        Path xml = root.resolve("coverage").resolve("report").resolve("output").resolve("coverage").resolve("jacoco.xml");
+        assertThat(xml).as("the report processor rendered an XML report").isNotEmptyFile();
+        assertThat(xml).content()
+                .contains("name=\"sample/Sample\"")
+                .contains("covered=\"");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+
+    private static Repository mavenCentral() {
+        Path local = Path.of(System.getProperty("user.home"), ".m2", "repository");
+        return new MavenDefaultRepository(
+                URI.create("https://repo1.maven.org/maven2/"),
+                Files.isDirectory(local) ? local : null,
+                Map.of(),
+                _ -> {});
+    }
+
+    private static void compileSources(Path classesDir, List<Path> classpath, Map<String, String> units)
+            throws IOException {
+        Files.createDirectories(classesDir);
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null)) {
+            fileManager.setLocationFromPaths(StandardLocation.CLASS_OUTPUT, List.of(classesDir.getParent()));
+            fileManager.setLocationFromPaths(StandardLocation.CLASS_PATH, classpath);
+            List<JavaFileObject> sources = new ArrayList<>();
+            for (Map.Entry<String, String> unit : units.entrySet()) {
+                String body = unit.getValue();
+                sources.add(new SimpleJavaFileObject(
+                        URI.create("string:///sample/" + unit.getKey() + ".java"),
+                        JavaFileObject.Kind.SOURCE) {
+                    @Override
+                    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                        return body;
+                    }
+                });
+            }
+            if (!compiler.getTask(null, fileManager, null, null, null, sources).call()) {
+                throw new IllegalStateException("Failed to compile sources");
+            }
+        }
+    }
+
+    private static List<Path> bootModuleJars() throws IOException {
+        Set<Path> jars = new LinkedHashSet<>();
+        for (ResolvedModule resolved : ModuleLayer.boot().configuration().modules()) {
+            String name = resolved.name();
+            if (name.startsWith("java.") || name.startsWith("jdk.")) {
+                continue;
+            }
+            URI location = resolved.reference().location().orElse(null);
+            if (location == null) {
+                continue;
+            }
+            Path path = Path.of(location);
+            if (Files.isRegularFile(path)) {
+                jars.add(path);
+            }
+        }
+        Enumeration<URL> manifests = ClassLoader.getSystemClassLoader().getResources("META-INF/MANIFEST.MF");
+        while (manifests.hasMoreElements()) {
+            String url = manifests.nextElement().toString();
+            if (!url.startsWith("jar:file:")) {
+                continue;
+            }
+            int bang = url.indexOf("!/");
+            if (bang < 0) {
+                continue;
+            }
+            Path path = Path.of(URI.create(url.substring("jar:".length(), bang)));
+            if (Files.isRegularFile(path)) {
+                jars.add(path);
+            }
+        }
+        return new ArrayList<>(jars);
+    }
+}

--- a/tests/build/jenesis/test/project/JaCoCoModuleTest.java
+++ b/tests/build/jenesis/test/project/JaCoCoModuleTest.java
@@ -1,0 +1,40 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.JaCoCoModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JaCoCoModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void requires_step_emits_the_jacoco_cli_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("jacoco", new JaCoCoModule(Map.of(), Map.of()), "project");
+        executor.execute("jacoco/required");
+
+        Path requiredOutput = root.resolve("jacoco").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("jacoco/runtime/maven/org.jacoco/org.jacoco.cli/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/JaCoCoTest.java
+++ b/tests/build/jenesis/test/project/JaCoCoTest.java
@@ -1,0 +1,35 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.project.JaCoCo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JaCoCoTest {
+
+    @Test
+    public void coordinates_declare_the_runtime_agent() {
+        SequencedMap<String, String> coordinates = new JaCoCo().coordinates();
+        assertThat(coordinates).hasSize(1);
+        assertThat(coordinates).containsEntry("maven/org.jacoco/org.jacoco.agent/jar/runtime", "RELEASE");
+    }
+
+    @Test
+    public void emits_a_javaagent_for_the_resolved_agent(@TempDir Path output) {
+        Path agent = output.resolve("jacocoagent.jar");
+        SequencedMap<String, Path> resolved = new LinkedHashMap<>();
+        resolved.put("maven/org.jacoco/org.jacoco.agent/jar/runtime", agent);
+
+        assertThat(new JaCoCo().commands(resolved, output)).containsExactly("-javaagent:"
+                + agent.toAbsolutePath()
+                + "=destfile="
+                + output.resolve("jacoco.exec").toAbsolutePath()
+                + ",output=file,append=false");
+    }
+
+    @Test
+    public void emits_no_command_when_the_agent_is_unresolved(@TempDir Path output) {
+        assertThat(new JaCoCo().commands(new LinkedHashMap<>(), output)).isEmpty();
+    }
+}

--- a/tests/build/jenesis/test/project/TestModuleTest.java
+++ b/tests/build/jenesis/test/project/TestModuleTest.java
@@ -15,6 +15,7 @@ import build.jenesis.maven.MavenPomResolver;
 import build.jenesis.project.TestModule;
 import build.jenesis.project.JUnit4;
 import build.jenesis.project.JUnitPlatform;
+import build.jenesis.project.JaCoCo;
 import build.jenesis.step.Javac;
 import build.jenesis.project.TestEngine;
 import build.jenesis.project.TestNG;
@@ -416,6 +417,27 @@ public class TestModuleTest {
                 .containsExactly("main/runtime/maven/org.junit.platform/junit-platform-console");
         assertThat(readVersions(stepFolder).getProperty("main/maven/org.junit.platform/junit-platform-console"))
                 .isEqualTo("RELEASE");
+    }
+
+    @Test
+    public void requires_step_emits_observability_agent_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("dependencies", emptyDependencies);
+        executor.addSource("classes", classes);
+        executor.addModule(
+                "test",
+                new TestModule(Map.of(), Map.of("maven", (_, _, _, _, _, _, _) -> new LinkedHashMap<>()))
+                        .engine(new JUnitPlatform())
+                        .observe(new JaCoCo())
+                        .isTest(candidate -> candidate.endsWith("TestSample"))
+                        .jarsOnly(false),
+                "dependencies", "classes");
+        executor.execute("test/" + "resolved");
+
+        assertThat(readRequires(root.resolve("test").resolve("resolved")).stringPropertyNames())
+                .containsExactlyInAnyOrder(
+                        "main/runtime/maven/org.junit.platform/junit-platform-console",
+                        "jacoco/runtime/maven/org.jacoco/org.jacoco.agent/jar/runtime/RELEASE");
     }
 
     @Test

--- a/tests/build/jenesis/test/step/CycloneDxEmitterTest.java
+++ b/tests/build/jenesis/test/step/CycloneDxEmitterTest.java
@@ -1,0 +1,60 @@
+package build.jenesis.test.step;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.License;
+import build.jenesis.step.CycloneDxEmitter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CycloneDxEmitterTest {
+
+    private final CycloneDxEmitter emitter = new CycloneDxEmitter();
+
+    private static final CycloneDxEmitter.Component PROJECT = new CycloneDxEmitter.Component(
+            "build.jenesis", "demo", "1.0.0", "pkg:maven/build.jenesis/demo@1.0.0", null,
+            List.of(new License("Apache-2.0", "https://www.apache.org/licenses/LICENSE-2.0.txt")));
+
+    private static final List<CycloneDxEmitter.Component> COMPONENTS = List.of(
+            new CycloneDxEmitter.Component("org.foo", "bar", "1.2.3", "pkg:maven/org.foo/bar@1.2.3", "abc123",
+                    List.of(new License("The Apache Software License, Version 2.0", "https://apache.org/"))),
+            new CycloneDxEmitter.Component("org.baz", "qux", "4.5", "pkg:maven/org.baz/qux@4.5", "def456",
+                    List.of(new License("Some Custom License", "https://example.com/license"))));
+
+    @Test
+    public void emits_cyclonedx_json() {
+        String json = emitter.emit(CycloneDxEmitter.Format.JSON, PROJECT, COMPONENTS);
+        assertThat(json)
+                .contains("\"bomFormat\": \"CycloneDX\"")
+                .contains("\"specVersion\": \"1.6\"")
+                .contains("\"purl\": \"pkg:maven/org.foo/bar@1.2.3\"")
+                .contains("\"alg\": \"SHA-256\", \"content\": \"abc123\"")
+                .as("a recognized license name normalizes to its SPDX id")
+                .contains("\"id\": \"Apache-2.0\"")
+                .as("an unrecognized license falls back to name and url")
+                .contains("\"name\": \"Some Custom License\"")
+                .contains("\"url\": \"https://example.com/license\"");
+        assertThat(json).doesNotContain("serialNumber").doesNotContain("timestamp");
+    }
+
+    @Test
+    public void emits_cyclonedx_xml() {
+        String xml = emitter.emit(CycloneDxEmitter.Format.XML, PROJECT, COMPONENTS);
+        assertThat(xml)
+                .contains("<bom")
+                .contains("cyclonedx.org/schema/bom/1.6")
+                .contains("<purl>pkg:maven/org.foo/bar@1.2.3</purl>")
+                .contains("<id>Apache-2.0</id>")
+                .contains("<name>Some Custom License</name>");
+    }
+
+    @Test
+    public void is_deterministic_and_order_independent() {
+        String first = emitter.emit(CycloneDxEmitter.Format.JSON, PROJECT, COMPONENTS);
+        String reversed = emitter.emit(CycloneDxEmitter.Format.JSON, PROJECT,
+                List.of(COMPONENTS.get(1), COMPONENTS.get(0)));
+        assertThat(reversed)
+                .as("components are sorted by purl, so input order does not change the output")
+                .isEqualTo(first);
+    }
+}

--- a/tests/build/jenesis/test/step/DependenciesResolutionTest.java
+++ b/tests/build/jenesis/test/step/DependenciesResolutionTest.java
@@ -7,6 +7,7 @@ import build.jenesis.BuildStepArgument;
 import build.jenesis.BuildStepContext;
 import build.jenesis.BuildStepResult;
 import build.jenesis.ChecksumStatus;
+import build.jenesis.License;
 import build.jenesis.Pinning;
 import build.jenesis.Repository;
 import build.jenesis.RepositoryItem;
@@ -89,6 +90,34 @@ public class DependenciesResolutionTest {
         for (String property : dependencies.stringPropertyNames()) {
             assertThat(dependencies.getProperty(property)).doesNotContain("SHA");
         }
+    }
+
+    @Test
+    public void captures_licenses_into_a_sidecar_when_capturing() throws IOException {
+        SequencedProperties properties = new SequencedProperties();
+        properties.setProperty("main/compile/foo/qux", "");
+        properties.store(dependencies.resolve(BuildStep.REQUIRES));
+        BuildStepResult result = new Dependencies(Map.of("foo", files(Map.of())),
+                Map.of("foo", (executor, prefix, repositories, descriptors, bom, scope, listener) -> {
+                    SequencedMap<String, String> resolved = new LinkedHashMap<>();
+                    descriptors.sequencedKeySet().forEach(descriptor -> resolved.put(prefix + "/" + descriptor, ""));
+                    if (listener != null) {
+                        listener.onLicenses(prefix, prefix + "/qux", null,
+                                List.of(new License("Apache-2.0", "https://www.apache.org/licenses/LICENSE-2.0.txt")));
+                    }
+                    return Resolver.materializeAll(executor, repositories, prefix, resolved);
+                }))
+                .capturing(true)
+                .apply(Runnable::run,
+                        new BuildStepContext(previous, next, supplement),
+                        new LinkedHashMap<>(Map.of("dependencies", new BuildStepArgument(
+                                dependencies,
+                                Map.of(Path.of(BuildStep.REQUIRES), ChecksumStatus.ADDED)))))
+                .toCompletableFuture().join();
+        assertThat(result.next()).isTrue();
+        SequencedProperties licenses = SequencedProperties.ofFiles(next.resolve("licenses.properties"));
+        assertThat(licenses.getProperty("foo/qux#0#name")).isEqualTo("Apache-2.0");
+        assertThat(licenses.getProperty("foo/qux#0#url")).isEqualTo("https://www.apache.org/licenses/LICENSE-2.0.txt");
     }
 
     @Test

--- a/tests/build/jenesis/test/step/SbomTest.java
+++ b/tests/build/jenesis/test/step/SbomTest.java
@@ -1,0 +1,81 @@
+package build.jenesis.test.step;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.ChecksumStatus;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Sbom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SbomTest {
+
+    @TempDir
+    private Path root;
+    private Path previous, next, supplement, argument;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        previous = root.resolve("previous");
+        next = Files.createDirectory(root.resolve("next"));
+        supplement = Files.createDirectory(root.resolve("supplement"));
+        argument = Files.createDirectory(root.resolve("argument"));
+    }
+
+    @Test
+    public void embeds_a_cyclonedx_sbom_with_dependency_licenses() throws Exception {
+        byte[] jarBytes = "jar-bytes".getBytes(StandardCharsets.UTF_8);
+        Files.write(Files.createDirectories(argument.resolve("resolved")).resolve("lib.jar"), jarBytes);
+        String sha256 = HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(jarBytes));
+
+        SequencedProperties dependencies = new SequencedProperties();
+        dependencies.setProperty("main/compile/maven/org.example/lib/1.2.3", "resolved/lib.jar");
+        dependencies.setProperty("main/runtime/maven/org.example/lib/1.2.3", "resolved/lib.jar");
+        dependencies.store(argument.resolve(BuildStep.DEPENDENCIES));
+        SequencedProperties licenses = new SequencedProperties();
+        licenses.setProperty("maven/org.example/lib/1.2.3#0#name", "Apache-2.0");
+        licenses.setProperty("maven/org.example/lib/1.2.3#0#url", "https://www.apache.org/licenses/LICENSE-2.0.txt");
+        licenses.store(argument.resolve("licenses.properties"));
+        SequencedProperties metadata = new SequencedProperties();
+        metadata.setProperty("project", "build.jenesis");
+        metadata.setProperty("artifact", "demo");
+        metadata.setProperty("version", "1.0.0");
+        metadata.setProperty("name", "Demo");
+        metadata.setProperty("url", "https://example.com/demo");
+        metadata.setProperty("license.apache.name", "Apache-2.0");
+        metadata.setProperty("license.apache.url", "https://www.apache.org/licenses/LICENSE-2.0.txt");
+        metadata.store(argument.resolve(BuildStep.METADATA));
+
+        BuildStepResult result = new Sbom().apply(Runnable::run,
+                        new BuildStepContext(previous, next, supplement),
+                        new LinkedHashMap<>(Map.of("argument", new BuildStepArgument(
+                                argument,
+                                Map.of(
+                                        Path.of(BuildStep.DEPENDENCIES), ChecksumStatus.ADDED,
+                                        Path.of(BuildStep.METADATA), ChecksumStatus.ADDED)))))
+                .toCompletableFuture()
+                .join();
+        assertThat(result.next()).isTrue();
+
+        Path embedded = next.resolve("resources").resolve("META-INF").resolve("sbom").resolve("demo.cdx.json");
+        assertThat(embedded).isNotEmptyFile();
+        String sbom = Files.readString(embedded);
+        assertThat(sbom)
+                .contains("\"purl\": \"pkg:maven/build.jenesis/demo@1.0.0\"")
+                .contains("\"purl\": \"pkg:maven/org.example/lib@1.2.3\"")
+                .contains("\"content\": \"" + sha256 + "\"")
+                .contains("\"id\": \"Apache-2.0\"");
+
+        SequencedProperties manifest = SequencedProperties.ofFiles(next.resolve("manifest.mf"));
+        assertThat(manifest.getProperty("Sbom-Format")).isEqualTo("CycloneDX");
+        assertThat(manifest.getProperty("Sbom-Location")).isEqualTo("META-INF/sbom/demo.cdx.json");
+
+        assertThat(next.resolve("resources").resolve("META-INF").resolve("NOTICE"))
+                .content().contains("Demo").contains("Apache-2.0");
+        assertThat(next.resolve("sbom").resolve("demo-1.0.0.cdx.json")).isNotEmptyFile();
+    }
+}


### PR DESCRIPTION
## Summary

Adds the functionality for SBOM generation and third-party license attribution. **All wiring is deferred** (this PR is the building blocks, not the default-layout integration), consistent with how the lint/format/quality chains stay explicitly wired today.

### Stage 1 — license capture during resolution (off by default)
- `build.jenesis.License(name, url)` and a default `ResolutionListener.onLicenses(...)` callback.
- `MavenPomResolver` parses each effective POM's `<licenses>` with correct **parent-POM inheritance** (a child with no `<licenses>` inherits the parent's) and reports them per resolved coordinate.
- `Dependencies.capturing(boolean)` (default `false`) records licenses via a composing listener and writes a **`licenses.properties`** sidecar next to `dependencies.properties`.
- MAVEN and MODULAR_TO_MAVEN capture licenses through this resolver (the latter delegates to it). Pure modular resolution has no POM license source and is left for later.

### Stage 2 — CycloneDX emitter + `Sbom` step
- `CycloneDxEmitter`: deterministic CycloneDX 1.6 as **JSON or XML**, emitted in process (no library, no JSON parsing, no wall-clock timestamp or random `serialNumber`), with PURLs, SHA-256 hashes, and a small SPDX-id normalization table that falls back to `name`+`url`.
- `Sbom` step: builds the document from the resolved index + `licenses.properties` + project metadata and writes `META-INF/sbom/<artifact>.cdx.json` into the resources tree (so `Jar` embeds it), a `Sbom-Location`/`Sbom-Format: CycloneDX` manifest pointer, a synthesized `META-INF/NOTICE`, and a standalone SBOM copy for later publication.

## Tests (offline, all green)
- `MavenPomResolverTest` — captures a dependency's own license and one inherited from its parent POM.
- `DependenciesResolutionTest` — `capturing(true)` writes the `licenses.properties` sidecar.
- `CycloneDxEmitterTest` — JSON/XML shape, SPDX normalization, and deterministic/order-independent output.
- `SbomTest` — embeds the SBOM with a dependency's `purl` + SHA-256 + license, the manifest pointer, the NOTICE, and the standalone copy.

No regressions in the resolver/dependency/pom/module suites.

## Deferred (follow-ups)
- Publishing the standalone SBOM as a `<artifact>-<version>-cyclonedx.json` classifier (Inventory + staging).
- Default-layout auto-wiring (enable `capturing(true)` on the project's `Dependencies` and run `Sbom` before `Jar`).
- Pure-MODULAR license extraction (e.g. reading a license embedded in the dependency jar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)