### PR TITLE
Add JaCoCo coverage via a generic ObservabilityEngine

### DIFF
--- a/sources/build/jenesis/project/JaCoCo.java
+++ b/sources/build/jenesis/project/JaCoCo.java
@@ -1,0 +1,31 @@
+package build.jenesis.project;
+
+import module java.base;
+
+public record JaCoCo() implements ObservabilityEngine {
+
+    @Override
+    public String name() {
+        return "jacoco";
+    }
+
+    @Override
+    public SequencedMap<String, String> coordinates() {
+        SequencedMap<String, String> coordinates = new LinkedHashMap<>();
+        coordinates.put("maven/org.jacoco/org.jacoco.agent/jar/runtime", "RELEASE");
+        return coordinates;
+    }
+
+    @Override
+    public List<String> commands(SequencedMap<String, Path> resolved, Path output) {
+        Path agent = resolved.get("maven/org.jacoco/org.jacoco.agent/jar/runtime");
+        if (agent == null) {
+            return List.of();
+        }
+        return List.of("-javaagent:"
+                + agent.toAbsolutePath()
+                + "=destfile="
+                + output.resolve("jacoco.exec").toAbsolutePath()
+                + ",output=file,append=false");
+    }
+}

--- a/sources/build/jenesis/project/JaCoCoModule.java
+++ b/sources/build/jenesis/project/JaCoCoModule.java
@@ -1,0 +1,147 @@
+package build.jenesis.project;
+
+import module java.base;
+import build.jenesis.Pinning;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorModule;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.Repository;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Dependencies;
+import build.jenesis.step.JdkProcessBuildStep;
+import build.jenesis.step.ProcessHandler;
+
+public class JaCoCoModule implements BuildExecutorModule {
+
+    public static final String REPORT = "report";
+    private static final String REQUIRED = "required", DEPENDENCIES = "dependencies";
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, Resolver> resolvers;
+    private final Pinning pinning;
+    private final String group;
+
+    public JaCoCoModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
+        this(repositories, resolvers, null, "jacoco");
+    }
+
+    private JaCoCoModule(Map<String, Repository> repositories,
+                         Map<String, Resolver> resolvers,
+                         Pinning pinning,
+                         String group) {
+        this.repositories = repositories;
+        this.resolvers = resolvers;
+        this.pinning = pinning;
+        this.group = group;
+    }
+
+    public JaCoCoModule pinning(Pinning pinning) {
+        return new JaCoCoModule(repositories, resolvers, pinning, group);
+    }
+
+    public JaCoCoModule group(String group) {
+        return new JaCoCoModule(repositories, resolvers, pinning, group);
+    }
+
+    public ObservabilityEngine engine() {
+        return new JaCoCo();
+    }
+
+    @Override
+    public void accept(BuildExecutor buildExecutor, SequencedMap<String, Path> inherited) {
+        buildExecutor.addStep(REQUIRED, new Requires(group), inherited.sequencedKeySet());
+        SequencedSet<String> resolveInputs = new LinkedHashSet<>();
+        resolveInputs.add(REQUIRED);
+        resolveInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(DEPENDENCIES,
+                new Dependencies(repositories, resolvers).pinning(pinning),
+                resolveInputs);
+        SequencedSet<String> reportInputs = new LinkedHashSet<>();
+        reportInputs.add(DEPENDENCIES);
+        reportInputs.addAll(inherited.sequencedKeySet());
+        buildExecutor.addStep(REPORT, new Report(group), reportInputs);
+    }
+
+    private record Requires(String group) implements BuildStep {
+
+        @Override
+        public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+            return false;
+        }
+
+        @Override
+        public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                      BuildStepContext context,
+                                                      SequencedMap<String, BuildStepArgument> arguments)
+                throws IOException {
+            SequencedProperties requires = new SequencedProperties();
+            requires.setProperty(group + "/runtime/maven/org.jacoco/org.jacoco.cli/RELEASE", "");
+            requires.store(context.next().resolve(BuildStep.REQUIRES));
+            return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+    }
+
+    private static class Report extends JdkProcessBuildStep {
+
+        private final String group;
+
+        private Report(String group) {
+            super("jacoco", ProcessHandler.OfProcess.ofJavaHome("bin/java"));
+            this.group = group;
+        }
+
+        @Override
+        public CompletionStage<List<String>> process(Executor executor,
+                                                     BuildStepContext context,
+                                                     SequencedMap<String, BuildStepArgument> arguments,
+                                                     SequencedMap<String, SequencedMap<String, String>> properties)
+                throws IOException {
+            List<String> jars = new ArrayList<>(), classes = new ArrayList<>(), sources = new ArrayList<>();
+            Path data = null;
+            for (BuildStepArgument argument : arguments.values()) {
+                for (Path jar : Dependencies.select(argument.folder(), group, "runtime")) {
+                    jars.add(jar.toString());
+                }
+                Path exec = argument.folder().resolve("jacoco.exec");
+                if (Files.isRegularFile(exec)) {
+                    data = exec;
+                }
+                Path compiled = argument.folder().resolve(BuildStep.CLASSES);
+                if (Files.isDirectory(compiled)) {
+                    classes.add(compiled.toString());
+                }
+                Path source = argument.folder().resolve(BuildStep.SOURCES);
+                if (Files.isDirectory(source)) {
+                    sources.add(source.toString());
+                }
+            }
+            if (data == null || classes.isEmpty()) {
+                return CompletableFuture.completedStage(null);
+            }
+            if (jars.isEmpty()) {
+                throw new IllegalStateException("No JaCoCo CLI jars resolved upstream of the JaCoCo report step");
+            }
+            Path report = Files.createDirectories(context.next().resolve("coverage"));
+            List<String> commands = new ArrayList<>(List.of(
+                    "-cp", String.join(File.pathSeparator, jars),
+                    "org.jacoco.cli.internal.Main", "report", data.toString()));
+            for (String directory : classes) {
+                commands.add("--classfiles");
+                commands.add(directory);
+            }
+            for (String directory : sources) {
+                commands.add("--sourcefiles");
+                commands.add(directory);
+            }
+            commands.add("--html");
+            commands.add(report.toString());
+            commands.add("--xml");
+            commands.add(report.resolve("jacoco.xml").toString());
+            return CompletableFuture.completedStage(commands);
+        }
+    }
+}

--- a/sources/build/jenesis/project/ObservabilityEngine.java
+++ b/sources/build/jenesis/project/ObservabilityEngine.java
@@ -1,0 +1,12 @@
+package build.jenesis.project;
+
+import module java.base;
+
+public interface ObservabilityEngine extends Serializable {
+
+    String name();
+
+    SequencedMap<String, String> coordinates();
+
+    List<String> commands(SequencedMap<String, Path> resolved, Path output);
+}

--- a/sources/build/jenesis/project/TestModule.java
+++ b/sources/build/jenesis/project/TestModule.java
@@ -36,6 +36,7 @@ public class TestModule implements BuildExecutorModule {
     private final boolean parallel;
     private final boolean reporting;
     private final String dependencyGroup;
+    private final List<ObservabilityEngine> observers;
 
     public TestModule(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
         List<Pattern> patterns = Stream.of(
@@ -58,7 +59,8 @@ public class TestModule implements BuildExecutorModule {
                 System.getProperty("jenesis.test.group"),
                 Boolean.getBoolean("jenesis.test.parallel"),
                 Boolean.getBoolean("jenesis.test.reporting"),
-                "main");
+                "main",
+                List.of());
     }
 
     private TestModule(TestEngine engine,
@@ -75,7 +77,8 @@ public class TestModule implements BuildExecutorModule {
                        String group,
                        boolean parallel,
                        boolean reporting,
-                       String dependencyGroup) {
+                       String dependencyGroup,
+                       List<ObservabilityEngine> observers) {
         this.engine = engine;
         this.isTest = isTest;
         this.factory = factory;
@@ -91,6 +94,7 @@ public class TestModule implements BuildExecutorModule {
         this.parallel = parallel;
         this.reporting = reporting;
         this.dependencyGroup = dependencyGroup;
+        this.observers = observers;
     }
 
     public TestModule engine(TestEngine engine) {
@@ -108,7 +112,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public <P extends Predicate<String> & Serializable> TestModule isTest(P isTest) {
@@ -126,7 +131,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule factory(Function<List<String>, ProcessHandler.OfProcess> factory) {
@@ -144,7 +150,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule filter(String filter) {
@@ -162,7 +169,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule jarsOnly(boolean jarsOnly) {
@@ -180,7 +188,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule requireEngine(boolean requireEngine) {
@@ -198,7 +207,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule pinning(Pinning pinning) {
@@ -216,7 +226,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule modulePath(PathPlacement modulePath) {
@@ -234,7 +245,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule moduleName(String moduleName) {
@@ -252,7 +264,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule group(String group) {
@@ -270,7 +283,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule dependencyGroup(String dependencyGroup) {
@@ -288,7 +302,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule parallel(boolean parallel) {
@@ -306,7 +321,8 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
     }
 
     public TestModule reporting(boolean reporting) {
@@ -324,7 +340,27 @@ public class TestModule implements BuildExecutorModule {
                 group,
                 parallel,
                 reporting,
-                dependencyGroup);
+                dependencyGroup,
+                observers);
+    }
+
+    public TestModule observe(ObservabilityEngine... observers) {
+        return new TestModule(engine,
+                isTest,
+                factory,
+                repositories,
+                resolvers,
+                jarsOnly,
+                requireEngine,
+                pinning,
+                modulePath,
+                moduleName,
+                filter,
+                group,
+                parallel,
+                reporting,
+                dependencyGroup,
+                List.of(observers));
     }
 
     @Override
@@ -342,7 +378,7 @@ public class TestModule implements BuildExecutorModule {
             }
         }
         SequencedSet<String> upstream = inherited.sequencedKeySet();
-        buildExecutor.addStep(RESOLVED, new Requires(dependencyGroup, resolved, Set.copyOf(resolvers.keySet())), upstream);
+        buildExecutor.addStep(RESOLVED, new Requires(dependencyGroup, resolved, Set.copyOf(resolvers.keySet()), observers), upstream);
         SequencedSet<String> resolveInputs = new LinkedHashSet<>();
         resolveInputs.add(RESOLVED);
         resolveInputs.addAll(upstream);
@@ -359,7 +395,8 @@ public class TestModule implements BuildExecutorModule {
                         filter,
                         group,
                         parallel,
-                        reporting),
+                        reporting,
+                        observers),
                 Stream.concat(upstream.stream(), Stream.of(DEPENDENCIES)));
     }
 
@@ -374,7 +411,7 @@ public class TestModule implements BuildExecutorModule {
         return Optional.empty();
     }
 
-    private record Requires(String group, TestEngine engine, Set<String> prefixes) implements BuildStep {
+    private record Requires(String group, TestEngine engine, Set<String> prefixes, List<ObservabilityEngine> observers) implements BuildStep {
 
         @Override
         public CompletionStage<BuildStepResult> apply(Executor executor,
@@ -422,6 +459,11 @@ public class TestModule implements BuildExecutorModule {
                     }
                 }
             }
+            for (ObservabilityEngine observer : observers) {
+                for (Map.Entry<String, String> entry : observer.coordinates().entrySet()) {
+                    properties.setProperty(observer.name() + "/runtime/" + entry.getKey() + "/" + entry.getValue(), "");
+                }
+            }
             properties.store(context.next().resolve(BuildStep.REQUIRES));
             if (!versions.isEmpty()) {
                 versions.store(context.next().resolve(BuildStep.VERSIONS));
@@ -439,6 +481,7 @@ public class TestModule implements BuildExecutorModule {
         private final String group;
         private final transient boolean parallel;
         private final boolean reporting;
+        private final List<ObservabilityEngine> observers;
 
         private Run(Function<List<String>, ProcessHandler.OfProcess> factory,
                     TestEngine engine,
@@ -449,7 +492,8 @@ public class TestModule implements BuildExecutorModule {
                     String filter,
                     String group,
                     boolean parallel,
-                    boolean reporting) {
+                    boolean reporting,
+                    List<ObservabilityEngine> observers) {
             super(factory == null ? ProcessHandler.OfProcess.ofJavaHome("bin/java") : factory, modulePath, jarsOnly);
             this.engine = engine;
             this.isTest = isTest;
@@ -458,6 +502,7 @@ public class TestModule implements BuildExecutorModule {
             this.group = group;
             this.parallel = parallel;
             this.reporting = reporting;
+            this.observers = observers;
         }
 
         @Override
@@ -477,6 +522,9 @@ public class TestModule implements BuildExecutorModule {
             List<TestSpec> specs = TestSpec.parse(filter);
             SequencedSet<String> groups = groups(group);
             List<String> commands = new ArrayList<>();
+            for (ObservabilityEngine observer : observers) {
+                commands.addAll(observer.commands(agentJars(arguments, observer), context.next()));
+            }
             for (Map.Entry<String, String> entry : resolved.properties().entrySet()) {
                 commands.add("-D" + entry.getKey() + "=" + entry.getValue());
             }
@@ -545,6 +593,32 @@ public class TestModule implements BuildExecutorModule {
                     parallel,
                     reporting));
             return CompletableFuture.completedFuture(commands);
+        }
+
+        private static SequencedMap<String, Path> agentJars(SequencedMap<String, BuildStepArgument> arguments,
+                                                            ObservabilityEngine observer) throws IOException {
+            SequencedMap<String, Path> resolved = new LinkedHashMap<>();
+            for (BuildStepArgument argument : arguments.values()) {
+                Path file = argument.folder().resolve(BuildStep.DEPENDENCIES);
+                if (!Files.exists(file)) {
+                    continue;
+                }
+                SequencedProperties properties = SequencedProperties.ofFiles(file);
+                for (String coordinate : observer.coordinates().sequencedKeySet()) {
+                    String prefix = observer.name() + "/runtime/" + coordinate + "/";
+                    for (String key : properties.stringPropertyNames()) {
+                        if (key.startsWith(prefix)) {
+                            String value = properties.getProperty(key);
+                            int space = value.indexOf(' ');
+                            Path jar = argument.folder().resolve(space < 0 ? value : value.substring(0, space)).normalize();
+                            if (Files.exists(jar)) {
+                                resolved.putIfAbsent(coordinate, jar);
+                            }
+                        }
+                    }
+                }
+            }
+            return resolved;
         }
 
         private static SequencedSet<String> groups(String group) {

--- a/tests/build/jenesis/test/project/JaCoCoModuleRunTest.java
+++ b/tests/build/jenesis/test/project/JaCoCoModuleRunTest.java
@@ -1,0 +1,195 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module java.compiler;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.SequencedProperties;
+import build.jenesis.maven.MavenDefaultRepository;
+import build.jenesis.maven.MavenPomResolver;
+import build.jenesis.project.JaCoCo;
+import build.jenesis.project.JaCoCoModule;
+import build.jenesis.project.TestModule;
+import build.jenesis.step.Javac;
+import javax.tools.ToolProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JaCoCoModuleRunTest {
+
+    private static final String VERSION = "0.8.14";
+
+    @TempDir
+    private Path root, dependencies, classes, sources;
+
+    @Test
+    public void collects_coverage_and_renders_a_report() throws Exception {
+        Path artifacts = Files.createDirectory(dependencies.resolve(BuildStep.ARTIFACTS));
+        for (Path path : bootModuleJars()) {
+            String fileName = path.getFileName().toString();
+            if (fileName.endsWith("_rt.jar") || fileName.endsWith("-rt.jar")) {
+                continue;
+            }
+            Files.copy(path, artifacts.resolve(fileName + "-" + UUID.randomUUID() + ".jar"));
+        }
+
+        Path samplePackage = Files.createDirectories(sources.resolve(BuildStep.SOURCES).resolve("sample"));
+        Files.writeString(samplePackage.resolve("Sample.java"), """
+                package sample;
+                public class Sample {
+                    public int add(int left, int right) {
+                        return left + right;
+                    }
+                }
+                """);
+        compileSources(classes.resolve(Javac.CLASSES + "sample"), bootModuleJars(), Map.of(
+                "Sample", """
+                        package sample;
+                        public class Sample {
+                            public int add(int left, int right) {
+                                return left + right;
+                            }
+                        }
+                        """,
+                "SampleTest", """
+                        package sample;
+                        public class SampleTest {
+                            @org.junit.jupiter.api.Test
+                            public void adds() {
+                                if (new Sample().add(2, 3) != 5) {
+                                    throw new AssertionError();
+                                }
+                            }
+                        }
+                        """));
+
+        SequencedProperties versions = new SequencedProperties();
+        versions.setProperty("main/maven/org.junit.platform/junit-platform-console",
+                "1.11.4 SHA-256/a9c3309cdfded3542200de85da6cb274864439d6b02ba80bb45ecc8e0bdf1be7");
+        versions.setProperty("main/maven/org.junit.platform/junit-platform-reporting",
+                "1.11.4 SHA-256/df6896109bfaef4de8d2fa9e3371a6176936d1a45a6c0e7fd8f7e6dd6f4c5597");
+        versions.setProperty("main/maven/org.junit.platform/junit-platform-launcher",
+                "1.11.4 SHA-256/d7430bd029e7fcced53ee445e4d2d1a8a1e043ea4c4df43b6335a857f79761ae");
+        versions.setProperty("main/maven/org.junit.platform/junit-platform-engine",
+                "1.11.3 SHA-256/0043f72f611664735da8dc9a308bf12ecd2236b05339351c4741edb4d8fab0da");
+        versions.setProperty("main/maven/org.junit.platform/junit-platform-commons",
+                "1.11.3 SHA-256/be262964b0b6b48de977c61d4f931df8cf61e80e750cc3f3a0a39cdd21c1008c");
+        versions.setProperty("main/maven/org.opentest4j/opentest4j",
+                "1.3.0 SHA-256/48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b");
+        versions.setProperty("main/maven/org.apiguardian/apiguardian-api",
+                "1.1.2 SHA-256/b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38");
+        versions.setProperty("jacoco/maven/org.jacoco/org.jacoco.agent/jar/runtime", VERSION);
+        versions.setProperty("jacoco/maven/org.jacoco/org.jacoco.cli", VERSION);
+        versions.store(dependencies.resolve(BuildStep.VERSIONS));
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("dependencies", dependencies);
+        executor.addSource("classes", classes);
+        executor.addSource("sources", sources);
+        executor.addModule(
+                "test",
+                new TestModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver()))
+                        .observe(new JaCoCo())
+                        .isTest(candidate -> candidate.endsWith("SampleTest"))
+                        .jarsOnly(false),
+                "dependencies", "classes");
+        executor.addModule(
+                "coverage",
+                new JaCoCoModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver())),
+                "test", "classes", "sources", "dependencies");
+        executor.execute();
+
+        Path exec = root.resolve("test").resolve("executed").resolve("output").resolve("jacoco.exec");
+        assertThat(exec).as("the agent wrote its execution data into the test step output").isNotEmptyFile();
+        assertThat(Files.readString(exec, StandardCharsets.ISO_8859_1))
+                .as("the agent instrumented and recorded the sample class")
+                .contains("sample/Sample");
+
+        Path xml = root.resolve("coverage").resolve("report").resolve("output").resolve("coverage").resolve("jacoco.xml");
+        assertThat(xml).as("the report processor rendered an XML report").isNotEmptyFile();
+        assertThat(xml).content()
+                .contains("name=\"sample/Sample\"")
+                .contains("covered=\"");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+
+    private static Repository mavenCentral() {
+        Path local = Path.of(System.getProperty("user.home"), ".m2", "repository");
+        return new MavenDefaultRepository(
+                URI.create("https://repo1.maven.org/maven2/"),
+                Files.isDirectory(local) ? local : null,
+                Map.of(),
+                _ -> {});
+    }
+
+    private static void compileSources(Path classesDir, List<Path> classpath, Map<String, String> units)
+            throws IOException {
+        Files.createDirectories(classesDir);
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null)) {
+            fileManager.setLocationFromPaths(StandardLocation.CLASS_OUTPUT, List.of(classesDir.getParent()));
+            fileManager.setLocationFromPaths(StandardLocation.CLASS_PATH, classpath);
+            List<JavaFileObject> sources = new ArrayList<>();
+            for (Map.Entry<String, String> unit : units.entrySet()) {
+                String body = unit.getValue();
+                sources.add(new SimpleJavaFileObject(
+                        URI.create("string:///sample/" + unit.getKey() + ".java"),
+                        JavaFileObject.Kind.SOURCE) {
+                    @Override
+                    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                        return body;
+                    }
+                });
+            }
+            if (!compiler.getTask(null, fileManager, null, null, null, sources).call()) {
+                throw new IllegalStateException("Failed to compile sources");
+            }
+        }
+    }
+
+    private static List<Path> bootModuleJars() throws IOException {
+        Set<Path> jars = new LinkedHashSet<>();
+        for (ResolvedModule resolved : ModuleLayer.boot().configuration().modules()) {
+            String name = resolved.name();
+            if (name.startsWith("java.") || name.startsWith("jdk.")) {
+                continue;
+            }
+            URI location = resolved.reference().location().orElse(null);
+            if (location == null) {
+                continue;
+            }
+            Path path = Path.of(location);
+            if (Files.isRegularFile(path)) {
+                jars.add(path);
+            }
+        }
+        Enumeration<URL> manifests = ClassLoader.getSystemClassLoader().getResources("META-INF/MANIFEST.MF");
+        while (manifests.hasMoreElements()) {
+            String url = manifests.nextElement().toString();
+            if (!url.startsWith("jar:file:")) {
+                continue;
+            }
+            int bang = url.indexOf("!/");
+            if (bang < 0) {
+                continue;
+            }
+            Path path = Path.of(URI.create(url.substring("jar:".length(), bang)));
+            if (Files.isRegularFile(path)) {
+                jars.add(path);
+            }
+        }
+        return new ArrayList<>(jars);
+    }
+}

--- a/tests/build/jenesis/test/project/JaCoCoModuleTest.java
+++ b/tests/build/jenesis/test/project/JaCoCoModuleTest.java
@@ -1,0 +1,40 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildExecutor;
+import build.jenesis.BuildExecutorCallback;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepHashFunction;
+import build.jenesis.HashDigestFunction;
+import build.jenesis.SequencedProperties;
+import build.jenesis.project.JaCoCoModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JaCoCoModuleTest {
+
+    @TempDir
+    private Path root, project;
+
+    @Test
+    public void requires_step_emits_the_jacoco_cli_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule("jacoco", new JaCoCoModule(Map.of(), Map.of()), "project");
+        executor.execute("jacoco/required");
+
+        Path requiredOutput = root.resolve("jacoco").resolve("required").resolve("output");
+        SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
+        assertThat(requires.stringPropertyNames())
+                .containsExactly("jacoco/runtime/maven/org.jacoco/org.jacoco.cli/RELEASE");
+    }
+
+    private BuildExecutor newExecutor() throws IOException {
+        return BuildExecutor.of(root,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+    }
+}

--- a/tests/build/jenesis/test/project/JaCoCoTest.java
+++ b/tests/build/jenesis/test/project/JaCoCoTest.java
@@ -1,0 +1,35 @@
+package build.jenesis.test.project;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.project.JaCoCo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JaCoCoTest {
+
+    @Test
+    public void coordinates_declare_the_runtime_agent() {
+        SequencedMap<String, String> coordinates = new JaCoCo().coordinates();
+        assertThat(coordinates).hasSize(1);
+        assertThat(coordinates).containsEntry("maven/org.jacoco/org.jacoco.agent/jar/runtime", "RELEASE");
+    }
+
+    @Test
+    public void emits_a_javaagent_for_the_resolved_agent(@TempDir Path output) {
+        Path agent = output.resolve("jacocoagent.jar");
+        SequencedMap<String, Path> resolved = new LinkedHashMap<>();
+        resolved.put("maven/org.jacoco/org.jacoco.agent/jar/runtime", agent);
+
+        assertThat(new JaCoCo().commands(resolved, output)).containsExactly("-javaagent:"
+                + agent.toAbsolutePath()
+                + "=destfile="
+                + output.resolve("jacoco.exec").toAbsolutePath()
+                + ",output=file,append=false");
+    }
+
+    @Test
+    public void emits_no_command_when_the_agent_is_unresolved(@TempDir Path output) {
+        assertThat(new JaCoCo().commands(new LinkedHashMap<>(), output)).isEmpty();
+    }
+}

--- a/tests/build/jenesis/test/project/TestModuleTest.java
+++ b/tests/build/jenesis/test/project/TestModuleTest.java
@@ -15,6 +15,7 @@ import build.jenesis.maven.MavenPomResolver;
 import build.jenesis.project.TestModule;
 import build.jenesis.project.JUnit4;
 import build.jenesis.project.JUnitPlatform;
+import build.jenesis.project.JaCoCo;
 import build.jenesis.step.Javac;
 import build.jenesis.project.TestEngine;
 import build.jenesis.project.TestNG;
@@ -416,6 +417,27 @@ public class TestModuleTest {
                 .containsExactly("main/runtime/maven/org.junit.platform/junit-platform-console");
         assertThat(readVersions(stepFolder).getProperty("main/maven/org.junit.platform/junit-platform-console"))
                 .isEqualTo("RELEASE");
+    }
+
+    @Test
+    public void requires_step_emits_observability_agent_coordinate() throws IOException {
+        BuildExecutor executor = newExecutor();
+        executor.addSource("dependencies", emptyDependencies);
+        executor.addSource("classes", classes);
+        executor.addModule(
+                "test",
+                new TestModule(Map.of(), Map.of("maven", (_, _, _, _, _, _, _) -> new LinkedHashMap<>()))
+                        .engine(new JUnitPlatform())
+                        .observe(new JaCoCo())
+                        .isTest(candidate -> candidate.endsWith("TestSample"))
+                        .jarsOnly(false),
+                "dependencies", "classes");
+        executor.execute("test/" + "resolved");
+
+        assertThat(readRequires(root.resolve("test").resolve("resolved")).stringPropertyNames())
+                .containsExactlyInAnyOrder(
+                        "main/runtime/maven/org.junit.platform/junit-platform-console",
+                        "jacoco/runtime/maven/org.jacoco/org.jacoco.agent/jar/runtime/RELEASE");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add `ObservabilityEngine`, a `TestEngine`-style contract for attaching a Java agent to the test JVM, with `JaCoCo` as the first implementation.
- `TestModule.observe(ObservabilityEngine...)` resolves each engine's coordinates in its own namespace and prepends the engine's `-javaagent` at the test step's runtime, so the data file lands in the test step's own output (incremental; avoids the temp-dir/move + output-hashing pitfall).
- `JaCoCoModule` yields the engine via `engine()`, resolves `org.jacoco.cli` internally (the processor coordinate is not exposed via the engine), and renders the coverage report over the test output, classes, and sources.
- The agent is only `-javaagent`'d, not placed on the class/module path — verified empirically that module-path placement is inert for the agent (`-javaagent` is what activates the premain).

## Notes
- Default-assembly wiring (into `JavaMultiProjectAssembler`) is deferred, consistent with the SBOM / quality / formatting modules.
- Based on `sbom-license-capture`; retarget to `main` once that merges.

## Test plan
- `JaCoCoTest`, `JaCoCoModuleTest`, and a `TestModuleTest` observe case — network-free.
- `JaCoCoModuleRunTest` (network-gated): real resolution of the runtime-classifier agent + `org.jacoco.cli`, a JUnit test run under `-javaagent`, `jacoco.exec` recording `sample/Sample`, and a `jacoco.xml` report with `covered="…"` counters.
- Full `TestModuleTest` (22 tests) passes — the `observe(...)` field-threading is backward-compatible.