### PR TITLE
Add a GraalVM native-image build step

### DIFF
--- a/sources/build/jenesis/step/NativeImage.java
+++ b/sources/build/jenesis/step/NativeImage.java
@@ -1,0 +1,102 @@
+package build.jenesis.step;
+
+import module java.base;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.PathPlacement;
+import build.jenesis.SequencedProperties;
+
+public class NativeImage extends JdkProcessBuildStep {
+
+    public static final String NATIVE = "native/";
+
+    private final PathPlacement modulePath;
+
+    public NativeImage(PathPlacement modulePath) {
+        this(modulePath, ProcessHandler.OfProcess.ofCommand("native-image"));
+    }
+
+    public NativeImage(PathPlacement modulePath, Function<List<String>, ? extends ProcessHandler> factory) {
+        super("native-image", factory);
+        this.modulePath = modulePath;
+    }
+
+    @Override
+    protected CompletionStage<List<String>> process(Executor executor,
+                                                    BuildStepContext context,
+                                                    SequencedMap<String, BuildStepArgument> arguments,
+                                                    SequencedMap<String, SequencedMap<String, String>> properties)
+            throws IOException {
+        boolean modular = modulePath.modular();
+        String launcher = null, name = null;
+        List<String> path = new ArrayList<>();
+        Path config = null;
+        for (BuildStepArgument argument : arguments.values()) {
+            Path jpackage = argument.folder().resolve(ProcessBuildStep.PROCESS + "jpackage.properties");
+            if (Files.isRegularFile(jpackage)) {
+                SequencedProperties launcherProperties = SequencedProperties.ofFiles(jpackage);
+                if (name == null) {
+                    String value = launcherProperties.getProperty("--name");
+                    if (value != null && !value.isEmpty()) {
+                        name = value;
+                    }
+                }
+                if (launcher == null) {
+                    String value = launcherProperties.getProperty(modular ? "--module" : "--main-class");
+                    if (value != null && !value.isEmpty()) {
+                        launcher = value;
+                    }
+                }
+            }
+            Path artifacts = argument.folder().resolve(BuildStep.ARTIFACTS);
+            if (Files.exists(artifacts)) {
+                Files.walkFileTree(artifacts, new SimpleFileVisitor<>() {
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                        if (file.toString().endsWith(".jar")) {
+                            path.add(file.toString());
+                        }
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+            }
+            for (Path file : Dependencies.select(argument.folder(), "runtime")) {
+                path.add(file.toString());
+            }
+            Path candidate = argument.folder().resolve("native-image");
+            if (Files.isDirectory(candidate)) {
+                config = candidate;
+            }
+        }
+        if (launcher == null || path.isEmpty()) {
+            return CompletableFuture.completedStage(null);
+        }
+        for (String entry : path) {
+            if (entry.indexOf(File.pathSeparatorChar) != -1) {
+                throw new IllegalArgumentException(
+                        "Path entry contains separator '" + File.pathSeparator + "': " + entry);
+            }
+        }
+        List<String> commands = new ArrayList<>();
+        commands.add("--no-fallback");
+        if (config != null) {
+            commands.add("-H:ConfigurationFileDirectories=" + config);
+        }
+        commands.add("-o");
+        commands.add(Files.createDirectories(context.next().resolve(NATIVE))
+                .resolve(name == null ? "image" : name)
+                .toString());
+        if (modular) {
+            commands.add("--module-path");
+            commands.add(String.join(File.pathSeparator, path));
+            commands.add("--module");
+            commands.add(launcher);
+        } else {
+            commands.add("-cp");
+            commands.add(String.join(File.pathSeparator, path));
+            commands.add(launcher);
+        }
+        return CompletableFuture.completedStage(commands);
+    }
+}

--- a/sources/build/jenesis/step/ProcessHandler.java
+++ b/sources/build/jenesis/step/ProcessHandler.java
@@ -98,6 +98,43 @@ public sealed interface ProcessHandler permits ProcessHandler.OfTool, ProcessHan
             }
         }
 
+        public static Function<List<String>, OfProcess> ofCommand(String command) {
+            return arguments -> new OfProcess(Stream.concat(
+                    Stream.of(locate(command)),
+                    arguments.stream()).toList());
+        }
+
+        private static String locate(String command) {
+            String name = command + (WINDOWS ? ".exe" : "");
+            List<String> homes = new ArrayList<>();
+            String graalvm = System.getenv("GRAALVM_HOME");
+            if (graalvm != null) {
+                homes.add(graalvm);
+            }
+            String java = System.getProperty("java.home");
+            if (java != null) {
+                homes.add(java);
+            }
+            for (String home : homes) {
+                File program = new File(new File(home, "bin"), name);
+                if (program.isFile()) {
+                    return program.getPath();
+                }
+            }
+            String path = System.getenv("PATH");
+            if (path != null) {
+                for (String entry : path.split(File.pathSeparator)) {
+                    File program = new File(entry, name);
+                    if (program.isFile() && program.canExecute()) {
+                        return program.getPath();
+                    }
+                }
+            }
+            throw new IllegalStateException("Could not locate '"
+                    + command
+                    + "' in GRAALVM_HOME, java.home/bin, or PATH");
+        }
+
         public static Function<List<String>, OfProcess> of(List<String> program) {
             return arguments -> new OfProcess(Stream.concat(program.stream(), arguments.stream()).toList());
         }

--- a/tests/build/jenesis/test/step/NativeImageTest.java
+++ b/tests/build/jenesis/test/step/NativeImageTest.java
@@ -1,0 +1,109 @@
+package build.jenesis.test.step;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.ChecksumStatus;
+import build.jenesis.PathPlacement;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.NativeImage;
+import build.jenesis.step.ProcessHandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NativeImageTest {
+
+    @TempDir
+    private Path root;
+    private Path previous, next, supplement, bundle, shim;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        previous = root.resolve("previous");
+        next = Files.createDirectory(root.resolve("next"));
+        supplement = Files.createDirectory(root.resolve("supplement"));
+        bundle = Files.createDirectory(root.resolve("bundle"));
+        Files.writeString(Files.createDirectory(bundle.resolve(BuildStep.ARTIFACTS)).resolve("app.jar"), "jar");
+        shim = root.resolve("native-image-shim");
+        Files.writeString(shim, "#!/bin/sh\nexit 0\n");
+        assertThat(shim.toFile().setExecutable(true)).isTrue();
+    }
+
+    @Test
+    public void emits_a_modular_native_image_command() throws IOException {
+        SequencedProperties launcher = new SequencedProperties();
+        launcher.setProperty("--name", "sample-app");
+        launcher.setProperty("--module", "sample/sample.Sample");
+        store(launcher);
+
+        BuildStepResult result = run(PathPlacement.MODULE_PATH);
+        assertThat(result.next()).isTrue();
+        assertThat(command())
+                .contains("--no-fallback")
+                .contains("--module-path")
+                .contains("-o " + next.resolve(NativeImage.NATIVE).resolve("sample-app"))
+                .endsWith("--module sample/sample.Sample");
+    }
+
+    @Test
+    public void emits_a_classpath_native_image_command() throws IOException {
+        SequencedProperties launcher = new SequencedProperties();
+        launcher.setProperty("--main-jar", "app.jar");
+        launcher.setProperty("--main-class", "sample.Sample");
+        store(launcher);
+
+        BuildStepResult result = run(PathPlacement.CLASS_PATH);
+        assertThat(result.next()).isTrue();
+        assertThat(command())
+                .contains("--no-fallback")
+                .contains("-cp")
+                .doesNotContain("--module-path")
+                .endsWith("sample.Sample");
+    }
+
+    @Test
+    public void passes_a_reachability_config_directory() throws IOException {
+        SequencedProperties launcher = new SequencedProperties();
+        launcher.setProperty("--module", "sample/sample.Sample");
+        store(launcher);
+        Path config = Files.createDirectory(bundle.resolve("native-image"));
+
+        BuildStepResult result = run(PathPlacement.MODULE_PATH);
+        assertThat(result.next()).isTrue();
+        assertThat(command()).contains("-H:ConfigurationFileDirectories=" + config);
+    }
+
+    @Test
+    public void skips_when_no_launcher_is_configured() throws IOException {
+        SequencedProperties launcher = new SequencedProperties();
+        launcher.setProperty("--name", "sample-app");
+        store(launcher);
+
+        BuildStepResult result = run(PathPlacement.MODULE_PATH);
+        assertThat(result.next()).isTrue();
+        assertThat(next.resolve(NativeImage.NATIVE)).doesNotExist();
+        assertThat(supplement.resolve("command")).doesNotExist();
+    }
+
+    private void store(SequencedProperties launcher) throws IOException {
+        launcher.store(Files.createDirectory(bundle.resolve("process")).resolve("jpackage.properties"));
+    }
+
+    private BuildStepResult run(PathPlacement modulePath) throws IOException {
+        return new NativeImage(modulePath, ProcessHandler.OfProcess.of(List.of(shim.toString()))).apply(
+                Runnable::run,
+                new BuildStepContext(previous, next, supplement),
+                new LinkedHashMap<>(Map.of("artifacts", new BuildStepArgument(
+                        bundle,
+                        Map.of(Path.of("artifacts/app.jar"), ChecksumStatus.ADDED,
+                                Path.of("process/jpackage.properties"), ChecksumStatus.ADDED)))))
+                .toCompletableFuture().join();
+    }
+
+    private String command() throws IOException {
+        return Files.readString(supplement.resolve("command"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `NativeImage` (a `JdkProcessBuildStep`, modeled on `JLink`) that produces a native executable of an executable module: it builds the class/module path from `artifacts/` + `Dependencies.select(folder, "runtime")`, reads the main class / module from `module.properties` (the positional main can't ride the assembler's prepend mechanism), and forks `native-image` with `--no-fallback` and `-o native/<name>` (`--module-path … --module <mod>/<main>` modular, `-cp … <main>` classpath, main last). Skips cleanly when there's no main.
- `native-image` is a real external tool (not a Maven jar, not a JDK `ToolProvider`), so add `ProcessHandler.OfProcess.ofCommand(String)` to locate it lazily: `$GRAALVM_HOME/bin` → `java.home/bin` → `PATH`.
- Config-aware: passes `-H:ConfigurationFileDirectories` when an input carries a `native-image/` config directory, and honours arbitrary extra options via `process/native-image.properties` (auto-prepended, since the command name is `native-image`).

## Notes
- Standalone step — **not** wired into `JavaMultiProjectAssembler` (consistent with the SBOM / quality / formatting / coverage modules). A follow-up can add a `jenesis.java.native` flag next to `jpackage`.
- Stacked on `jacoco-coverage`; retarget once that merges.

## Test plan
- `NativeImageTest` (tool-free): injects a no-op shim via the factory ctor and asserts the recorded `supplement/command` for modular, classpath, config-directory, and skip-when-no-main cases. `4/4` pass; `ProcessHandlerTest` still green.
- A real native build is GraalVM-gated and manual (CI cannot assume a GraalVM toolchain).