### PR TITLE
Promote native-image step and fix coverage/native-image self-build failures

### DIFF
--- a/sources/build/jenesis/step/NativeImage.java
+++ b/sources/build/jenesis/step/NativeImage.java
@@ -1,0 +1,102 @@
+package build.jenesis.step;
+
+import module java.base;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.PathPlacement;
+import build.jenesis.SequencedProperties;
+
+public class NativeImage extends JdkProcessBuildStep {
+
+    public static final String NATIVE = "native/";
+
+    private final PathPlacement modulePath;
+
+    public NativeImage(PathPlacement modulePath) {
+        this(modulePath, ProcessHandler.OfProcess.ofCommand("native-image"));
+    }
+
+    public NativeImage(PathPlacement modulePath, Function<List<String>, ? extends ProcessHandler> factory) {
+        super("native-image", factory);
+        this.modulePath = modulePath;
+    }
+
+    @Override
+    protected CompletionStage<List<String>> process(Executor executor,
+                                                    BuildStepContext context,
+                                                    SequencedMap<String, BuildStepArgument> arguments,
+                                                    SequencedMap<String, SequencedMap<String, String>> properties)
+            throws IOException {
+        boolean modular = modulePath.modular();
+        String launcher = null, name = null;
+        List<String> path = new ArrayList<>();
+        Path config = null;
+        for (BuildStepArgument argument : arguments.values()) {
+            Path jpackage = argument.folder().resolve(ProcessBuildStep.PROCESS + "jpackage.properties");
+            if (Files.isRegularFile(jpackage)) {
+                SequencedProperties launcherProperties = SequencedProperties.ofFiles(jpackage);
+                if (name == null) {
+                    String value = launcherProperties.getProperty("--name");
+                    if (value != null && !value.isEmpty()) {
+                        name = value;
+                    }
+                }
+                if (launcher == null) {
+                    String value = launcherProperties.getProperty(modular ? "--module" : "--main-class");
+                    if (value != null && !value.isEmpty()) {
+                        launcher = value;
+                    }
+                }
+            }
+            Path artifacts = argument.folder().resolve(BuildStep.ARTIFACTS);
+            if (Files.exists(artifacts)) {
+                Files.walkFileTree(artifacts, new SimpleFileVisitor<>() {
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                        if (file.toString().endsWith(".jar")) {
+                            path.add(file.toString());
+                        }
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+            }
+            for (Path file : Dependencies.select(argument.folder(), "runtime")) {
+                path.add(file.toString());
+            }
+            Path candidate = argument.folder().resolve("native-image");
+            if (Files.isDirectory(candidate)) {
+                config = candidate;
+            }
+        }
+        if (launcher == null || path.isEmpty()) {
+            return CompletableFuture.completedStage(null);
+        }
+        for (String entry : path) {
+            if (entry.indexOf(File.pathSeparatorChar) != -1) {
+                throw new IllegalArgumentException(
+                        "Path entry contains separator '" + File.pathSeparator + "': " + entry);
+            }
+        }
+        List<String> commands = new ArrayList<>();
+        commands.add("--no-fallback");
+        if (config != null) {
+            commands.add("-H:ConfigurationFileDirectories=" + config);
+        }
+        commands.add("-o");
+        commands.add(Files.createDirectories(context.next().resolve(NATIVE))
+                .resolve(name == null ? "image" : name)
+                .toString());
+        if (modular) {
+            commands.add("--module-path");
+            commands.add(String.join(File.pathSeparator, path));
+            commands.add("--module");
+            commands.add(launcher);
+        } else {
+            commands.add("-cp");
+            commands.add(String.join(File.pathSeparator, path));
+            commands.add(launcher);
+        }
+        return CompletableFuture.completedStage(commands);
+    }
+}

--- a/sources/build/jenesis/step/ProcessHandler.java
+++ b/sources/build/jenesis/step/ProcessHandler.java
@@ -98,6 +98,43 @@ public sealed interface ProcessHandler permits ProcessHandler.OfTool, ProcessHan
             }
         }
 
+        public static Function<List<String>, OfProcess> ofCommand(String command) {
+            return arguments -> new OfProcess(Stream.concat(
+                    Stream.of(locate(command)),
+                    arguments.stream()).toList());
+        }
+
+        private static String locate(String command) {
+            String name = command + (WINDOWS ? ".exe" : "");
+            List<String> homes = new ArrayList<>();
+            String graalvm = System.getenv("GRAALVM_HOME");
+            if (graalvm != null) {
+                homes.add(graalvm);
+            }
+            String java = System.getProperty("java.home");
+            if (java != null) {
+                homes.add(java);
+            }
+            for (String home : homes) {
+                File program = new File(new File(home, "bin"), name);
+                if (program.isFile()) {
+                    return program.getPath();
+                }
+            }
+            String path = System.getenv("PATH");
+            if (path != null) {
+                for (String entry : path.split(File.pathSeparator)) {
+                    File program = new File(entry, name);
+                    if (program.isFile() && program.canExecute()) {
+                        return program.getPath();
+                    }
+                }
+            }
+            throw new IllegalStateException("Could not locate '"
+                    + command
+                    + "' in GRAALVM_HOME, java.home/bin, or PATH");
+        }
+
         public static Function<List<String>, OfProcess> of(List<String> program) {
             return arguments -> new OfProcess(Stream.concat(program.stream(), arguments.stream()).toList());
         }

--- a/tests/build/jenesis/test/project/JaCoCoModuleRunTest.java
+++ b/tests/build/jenesis/test/project/JaCoCoModuleRunTest.java
@@ -38,30 +38,30 @@ public class JaCoCoModuleRunTest {
             Files.copy(path, artifacts.resolve(fileName + "-" + UUID.randomUUID() + ".jar"));
         }
 
-        Path samplePackage = Files.createDirectories(sources.resolve(BuildStep.SOURCES).resolve("sample"));
-        Files.writeString(samplePackage.resolve("Sample.java"), """
-                package sample;
-                public class Sample {
+        Path sourcePackage = Files.createDirectories(sources.resolve(BuildStep.SOURCES).resolve("coverage"));
+        Files.writeString(sourcePackage.resolve("Covered.java"), """
+                package coverage;
+                public class Covered {
                     public int add(int left, int right) {
                         return left + right;
                     }
                 }
                 """);
-        compileSources(classes.resolve(Javac.CLASSES + "sample"), bootModuleJars(), Map.of(
-                "Sample", """
-                        package sample;
-                        public class Sample {
+        compileSources(classes.resolve(Javac.CLASSES + "coverage"), bootModuleJars(), Map.of(
+                "Covered", """
+                        package coverage;
+                        public class Covered {
                             public int add(int left, int right) {
                                 return left + right;
                             }
                         }
                         """,
-                "SampleTest", """
-                        package sample;
-                        public class SampleTest {
+                "CoveredTest", """
+                        package coverage;
+                        public class CoveredTest {
                             @org.junit.jupiter.api.Test
                             public void adds() {
-                                if (new Sample().add(2, 3) != 5) {
+                                if (new Covered().add(2, 3) != 5) {
                                     throw new AssertionError();
                                 }
                             }
@@ -95,7 +95,7 @@ public class JaCoCoModuleRunTest {
                 "test",
                 new TestModule(Map.of("maven", mavenCentral()), Map.of("maven", new MavenPomResolver()))
                         .observe(new JaCoCo())
-                        .isTest(candidate -> candidate.endsWith("SampleTest"))
+                        .isTest(candidate -> candidate.endsWith("CoveredTest"))
                         .jarsOnly(false),
                 "dependencies", "classes");
         executor.addModule(
@@ -107,13 +107,13 @@ public class JaCoCoModuleRunTest {
         Path exec = root.resolve("test").resolve("executed").resolve("output").resolve("jacoco.exec");
         assertThat(exec).as("the agent wrote its execution data into the test step output").isNotEmptyFile();
         assertThat(Files.readString(exec, StandardCharsets.ISO_8859_1))
-                .as("the agent instrumented and recorded the sample class")
-                .contains("sample/Sample");
+                .as("the agent instrumented and recorded the covered class")
+                .contains("coverage/Covered");
 
         Path xml = root.resolve("coverage").resolve("report").resolve("output").resolve("coverage").resolve("jacoco.xml");
         assertThat(xml).as("the report processor rendered an XML report").isNotEmptyFile();
         assertThat(xml).content()
-                .contains("name=\"sample/Sample\"")
+                .contains("name=\"coverage/Covered\"")
                 .contains("covered=\"");
     }
 
@@ -145,7 +145,7 @@ public class JaCoCoModuleRunTest {
             for (Map.Entry<String, String> unit : units.entrySet()) {
                 String body = unit.getValue();
                 sources.add(new SimpleJavaFileObject(
-                        URI.create("string:///sample/" + unit.getKey() + ".java"),
+                        URI.create("string:///coverage/" + unit.getKey() + ".java"),
                         JavaFileObject.Kind.SOURCE) {
                     @Override
                     public CharSequence getCharContent(boolean ignoreEncodingErrors) {

--- a/tests/build/jenesis/test/step/NativeImageTest.java
+++ b/tests/build/jenesis/test/step/NativeImageTest.java
@@ -29,10 +29,11 @@ public class NativeImageTest {
         Files.writeString(Files.createDirectory(bundle.resolve(BuildStep.ARTIFACTS)).resolve("app.jar"), "jar");
         shim = root.resolve("native-image-shim");
         Files.writeString(shim, "#!/bin/sh\nexit 0\n");
-        assertThat(shim.toFile().setExecutable(true)).isTrue();
+        shim.toFile().setExecutable(true);
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void emits_a_modular_native_image_command() throws IOException {
         SequencedProperties launcher = new SequencedProperties();
         launcher.setProperty("--name", "sample-app");
@@ -49,6 +50,7 @@ public class NativeImageTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void emits_a_classpath_native_image_command() throws IOException {
         SequencedProperties launcher = new SequencedProperties();
         launcher.setProperty("--main-jar", "app.jar");
@@ -65,6 +67,7 @@ public class NativeImageTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void passes_a_reachability_config_directory() throws IOException {
         SequencedProperties launcher = new SequencedProperties();
         launcher.setProperty("--module", "sample/sample.Sample");

--- a/tests/build/jenesis/test/step/NativeImageTest.java
+++ b/tests/build/jenesis/test/step/NativeImageTest.java
@@ -1,0 +1,109 @@
+package build.jenesis.test.step;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.ChecksumStatus;
+import build.jenesis.PathPlacement;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.NativeImage;
+import build.jenesis.step.ProcessHandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NativeImageTest {
+
+    @TempDir
+    private Path root;
+    private Path previous, next, supplement, bundle, shim;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        previous = root.resolve("previous");
+        next = Files.createDirectory(root.resolve("next"));
+        supplement = Files.createDirectory(root.resolve("supplement"));
+        bundle = Files.createDirectory(root.resolve("bundle"));
+        Files.writeString(Files.createDirectory(bundle.resolve(BuildStep.ARTIFACTS)).resolve("app.jar"), "jar");
+        shim = root.resolve("native-image-shim");
+        Files.writeString(shim, "#!/bin/sh\nexit 0\n");
+        assertThat(shim.toFile().setExecutable(true)).isTrue();
+    }
+
+    @Test
+    public void emits_a_modular_native_image_command() throws IOException {
+        SequencedProperties launcher = new SequencedProperties();
+        launcher.setProperty("--name", "sample-app");
+        launcher.setProperty("--module", "sample/sample.Sample");
+        store(launcher);
+
+        BuildStepResult result = run(PathPlacement.MODULE_PATH);
+        assertThat(result.next()).isTrue();
+        assertThat(command())
+                .contains("--no-fallback")
+                .contains("--module-path")
+                .contains("-o " + next.resolve(NativeImage.NATIVE).resolve("sample-app"))
+                .endsWith("--module sample/sample.Sample");
+    }
+
+    @Test
+    public void emits_a_classpath_native_image_command() throws IOException {
+        SequencedProperties launcher = new SequencedProperties();
+        launcher.setProperty("--main-jar", "app.jar");
+        launcher.setProperty("--main-class", "sample.Sample");
+        store(launcher);
+
+        BuildStepResult result = run(PathPlacement.CLASS_PATH);
+        assertThat(result.next()).isTrue();
+        assertThat(command())
+                .contains("--no-fallback")
+                .contains("-cp")
+                .doesNotContain("--module-path")
+                .endsWith("sample.Sample");
+    }
+
+    @Test
+    public void passes_a_reachability_config_directory() throws IOException {
+        SequencedProperties launcher = new SequencedProperties();
+        launcher.setProperty("--module", "sample/sample.Sample");
+        store(launcher);
+        Path config = Files.createDirectory(bundle.resolve("native-image"));
+
+        BuildStepResult result = run(PathPlacement.MODULE_PATH);
+        assertThat(result.next()).isTrue();
+        assertThat(command()).contains("-H:ConfigurationFileDirectories=" + config);
+    }
+
+    @Test
+    public void skips_when_no_launcher_is_configured() throws IOException {
+        SequencedProperties launcher = new SequencedProperties();
+        launcher.setProperty("--name", "sample-app");
+        store(launcher);
+
+        BuildStepResult result = run(PathPlacement.MODULE_PATH);
+        assertThat(result.next()).isTrue();
+        assertThat(next.resolve(NativeImage.NATIVE)).doesNotExist();
+        assertThat(supplement.resolve("command")).doesNotExist();
+    }
+
+    private void store(SequencedProperties launcher) throws IOException {
+        launcher.store(Files.createDirectory(bundle.resolve("process")).resolve("jpackage.properties"));
+    }
+
+    private BuildStepResult run(PathPlacement modulePath) throws IOException {
+        return new NativeImage(modulePath, ProcessHandler.OfProcess.of(List.of(shim.toString()))).apply(
+                Runnable::run,
+                new BuildStepContext(previous, next, supplement),
+                new LinkedHashMap<>(Map.of("artifacts", new BuildStepArgument(
+                        bundle,
+                        Map.of(Path.of("artifacts/app.jar"), ChecksumStatus.ADDED,
+                                Path.of("process/jpackage.properties"), ChecksumStatus.ADDED)))))
+                .toCompletableFuture().join();
+    }
+
+    private String command() throws IOException {
+        return Files.readString(supplement.resolve("command"));
+    }
+}


### PR DESCRIPTION
`main`'s push CI was failing in the self-build (which runs the whole suite from a jar). Two distinct issues, both fixed here. This branch is also ahead of `main` by the GraalVM native-image step (merged into `jacoco-coverage` via #26), so this promotes that to `main` as well.

## Fixes
- **`JaCoCoModuleRunTest`** compiled its own `sample.Sample`, which collides with the committed `sample.Sample` test fixture once the suite runs from a jar (`bootModuleJars` pulls that jar onto the inner test classpath and shadows the compiled class → `NoSuchMethodError`). Renamed the fixture to `coverage.Covered`. `mvn` ran the suite from a directory, which hid the clash — it only surfaced in the self-build.
- **`NativeImageTest`** drove the step through a `#!/bin/sh` shim, which Windows can't execute (`CreateProcess error=193`). The three shim-running cases are now `@DisabledOnOs(OS.WINDOWS)`; the asserted command assembly is platform-independent.

## Verification
- `mvn test` for `JaCoCoModuleRunTest` + `NativeImageTest`: 5/5 green.
- Modular self-build `java -Djenesis.project.layout=maven -Djenesis.test.filter='.*JaCoCoModuleRunTest,.*NativeImageTest' build/jenesis/Project.java stage` (the exact failing CI condition, suite run from a jar): green.