### PR TITLE
Surface the dependency graph: tree step and SBOM relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,9 @@ which compiles and packages every discovered module but stops short of the downs
 `Project.defaultTarget(...)` changes the default (there is no matching system property). The other
 top-level targets the shipped layouts register are `export` (on `MAVEN`, `MODULAR`, and `MODULAR_TO_MAVEN`;
 `MAVEN` publishes the staged tree into the local Maven repository, `MODULAR` into the local Jenesis module
-repository, and `MODULAR_TO_MAVEN` into both) and `pin` (rewrite every `pom.xml` / `module-info.java` so
-the full transitive closure is pinned at source level).
+repository, and `MODULAR_TO_MAVEN` into both), `pin` (rewrite every `pom.xml` / `module-info.java` so
+the full transitive closure is pinned at source level), and `tree` (print each module's resolved dependency
+graph, with licenses, from the persisted `graph.properties`; see *Printing the dependency tree*).
 
 **Module selectors.** Selectors that start with `+` are rewritten by the active layout into the per-project
 module path of that name, so a single module can be built without dragging its siblings in. The shipped
@@ -524,6 +525,21 @@ gradient tints the tree connectors. A `Resolved dependencies` list of negotiated
 resolves to `maven/org.slf4j/slf4j-api/2.0.16`). Because printing rides on the resolve rather than forcing one,
 an up-to-date (cached) `Dependencies` step prints nothing; the tree appears whenever the dependencies are
 actually resolved.
+
+To print the tree from **persisted** data instead - so it renders even when the resolve was cached - run the
+`tree` selector:
+
+    java build/jenesis/Project.java tree
+
+`tree` is a top-level selector (a sibling of `stage`/`export`/`pin`) that always runs when requested. The
+`Inventory` step surfaces each module's `graph.properties` and `licenses.properties`, and the `tree` step reads
+them back, reconstructs the graph per `<group>/<scope>`, and renders it with the same `DependencyTreeReport` -
+now with each dependency's license shown inline (`{Apache-2.0}`) next to its module name. Unlike the
+`jenesis.print.dependencies` flag, it does not depend on the resolve running in this invocation.
+
+The same `graph.properties` feeds the SBOM: the `Sbom` step reads it and emits the CycloneDX `dependencies`
+array (`ref`/`dependsOn`, each component carrying a `bom-ref`) alongside the components and licenses, so the
+emitted bill of materials records the resolved dependency relationships, not just a flat component list.
 
 ### Running inside Docker
 

--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ which compiles and packages every discovered module but stops short of the downs
 top-level targets the shipped layouts register are `export` (on `MAVEN`, `MODULAR`, and `MODULAR_TO_MAVEN`;
 `MAVEN` publishes the staged tree into the local Maven repository, `MODULAR` into the local Jenesis module
 repository, and `MODULAR_TO_MAVEN` into both), `pin` (rewrite every `pom.xml` / `module-info.java` so
-the full transitive closure is pinned at source level), and `tree` (print each module's resolved dependency
-graph, with licenses, from the persisted `graph.properties`; see *Printing the dependency tree*).
+the full transitive closure is pinned at source level), and `dependencies` (print each module's resolved
+dependency graph, with licenses, from the persisted `graph.properties`; see *Printing the dependency tree*).
 
 **Module selectors.** Selectors that start with `+` are rewritten by the active layout into the per-project
 module path of that name, so a single module can be built without dragging its siblings in. The shipped
@@ -527,14 +527,14 @@ an up-to-date (cached) `Dependencies` step prints nothing; the tree appears when
 actually resolved.
 
 To print the tree from **persisted** data instead - so it renders even when the resolve was cached - run the
-`tree` selector:
+`dependencies` selector:
 
-    java build/jenesis/Project.java tree
+    java build/jenesis/Project.java dependencies
 
-`tree` is a top-level selector (a sibling of `stage`/`export`/`pin`) that always runs when requested. The
-`Inventory` step surfaces each module's `graph.properties` and `licenses.properties`, and the `tree` step reads
-them back, reconstructs the graph per `<group>/<scope>`, and renders it with the same `DependencyTreeReport` -
-now with each dependency's license shown inline (`{Apache-2.0}`) next to its module name. Unlike the
+`dependencies` is a top-level selector (a sibling of `stage`/`export`/`pin`) that always runs when requested. The
+`Inventory` step surfaces each module's `graph.properties` and `licenses.properties`, and the `dependencies` step
+reads them back, reconstructs the graph per `<group>/<scope>`, and renders it with the same `DependencyTreeReport`
+- now with each dependency's license shown inline (`{Apache-2.0}`) next to its module name. Unlike the
 `jenesis.print.dependencies` flag, it does not depend on the resolve running in this invocation.
 
 The same `graph.properties` feeds the SBOM: the `Sbom` step reads it and emits the CycloneDX `dependencies`

--- a/sources/build/jenesis/DependencyTreeReport.java
+++ b/sources/build/jenesis/DependencyTreeReport.java
@@ -18,6 +18,10 @@ public final class DependencyTreeReport {
     }
 
     public void render(Resolver.Resolution resolution) {
+        render(resolution, "Dependency tree:");
+    }
+
+    public void render(Resolver.Resolution resolution, String title) {
         List<Resolver.Edge> edges = resolution.edges();
         if (edges.isEmpty()) {
             return;
@@ -25,7 +29,7 @@ public final class DependencyTreeReport {
         SequencedMap<String, Resolver.Vertex> nodes = resolution.vertices();
         StringBuilder builder = new StringBuilder();
         builder.append(System.lineSeparator())
-                .append(BuildExecutorCallback.YELLOW).append("Dependency tree:").append(BuildExecutorCallback.RESET)
+                .append(BuildExecutorCallback.YELLOW).append(title).append(BuildExecutorCallback.RESET)
                 .append(System.lineSeparator())
                 .append(render(edges, nodes));
         if (!nodes.isEmpty()) {
@@ -122,6 +126,13 @@ public final class DependencyTreeReport {
             }
             if (!meta.isEmpty()) {
                 line.append(' ').append(paint(109, "(" + meta + ")"));
+            }
+            String names = node.licenses().stream()
+                    .map(license -> license.name() != null ? license.name() : license.url())
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.joining(", "));
+            if (!names.isEmpty()) {
+                line.append(' ').append(paint(142, "{" + names + "}"));
             }
         }
         if (!edge.followed()) {

--- a/sources/build/jenesis/Project.java
+++ b/sources/build/jenesis/Project.java
@@ -26,6 +26,7 @@ import build.jenesis.step.Bind;
 import build.jenesis.step.ImageStaging;
 import build.jenesis.step.Inventory;
 import build.jenesis.step.TestReportStaging;
+import build.jenesis.step.Tree;
 
 public record Project(
         Path root,
@@ -49,6 +50,7 @@ public record Project(
             STAGE = "stage",
             EXPORT = "export",
             PIN = "pin",
+            TREE = "tree",
             METADATA = "metadata",
             HELP = "help",
             SKILL = "skill";
@@ -106,6 +108,8 @@ public record Project(
             executor.addModule(PIN, new PinModule(project.root(),
                     "pom.xml",
                     (path, file) -> new PinPom("maven", path, file, project.hashFunction())), BUILD);
+            executor.addModule(TREE, (tree, inherited) -> tree.addStep(
+                    "tree", new Tree(), inherited.sequencedKeySet()), BUILD);
             return name -> {
                 int slash = name.indexOf('/');
                 return slash == -1
@@ -163,6 +167,8 @@ public record Project(
             String prefix = BUILD + "/modules/" + MultiProjectModule.COMPOSE + "/" + MultiProjectModule.MODULE;
             executor.addModule(PIN, new PinModule(project.root(), "module-info.java",
                     (path, file) -> new PinModuleInfo("module", path, file, project.hashFunction())), BUILD);
+            executor.addModule(TREE, (tree, inherited) -> tree.addStep(
+                    "tree", new Tree(), inherited.sequencedKeySet()), BUILD);
             return name -> {
                 int slash = name.indexOf('/');
                 return slash == -1
@@ -230,6 +236,8 @@ public record Project(
             String prefix = BUILD + "/modules/" + MultiProjectModule.COMPOSE + "/" + MultiProjectModule.MODULE;
             executor.addModule(PIN, new PinModule(project.root(), "module-info.java",
                     (path, file) -> new PinModuleInfo("module", path, file, project.hashFunction())), BUILD);
+            executor.addModule(TREE, (tree, inherited) -> tree.addStep(
+                    "tree", new Tree(), inherited.sequencedKeySet()), BUILD);
             return name -> {
                 int slash = name.indexOf('/');
                 return slash == -1
@@ -337,6 +345,7 @@ public record Project(
                       %{name}stage%{reset}       Stage produced artifacts into a local repository
                       %{name}export%{reset}      Export the staged repository as the build deliverable
                       %{name}pin%{reset}         Rewrite version/checksum pins into pom.xml or module-info.java
+                      %{name}tree%{reset}        Print each module's resolved dependency graph (with licenses)
                       %{name}metadata%{reset}    Refresh the metadata module outputs
                       %{name}help%{reset}        Print this message
                       %{name}skill%{reset}       Print an agent-oriented onboarding briefing (plain text)

--- a/sources/build/jenesis/Project.java
+++ b/sources/build/jenesis/Project.java
@@ -50,7 +50,7 @@ public record Project(
             STAGE = "stage",
             EXPORT = "export",
             PIN = "pin",
-            TREE = "tree",
+            DEPENDENCIES = "dependencies",
             METADATA = "metadata",
             HELP = "help",
             SKILL = "skill";
@@ -108,7 +108,7 @@ public record Project(
             executor.addModule(PIN, new PinModule(project.root(),
                     "pom.xml",
                     (path, file) -> new PinPom("maven", path, file, project.hashFunction())), BUILD);
-            executor.addModule(TREE, (tree, inherited) -> tree.addStep(
+            executor.addModule(DEPENDENCIES, (tree, inherited) -> tree.addStep(
                     "tree", new Tree(), inherited.sequencedKeySet()), BUILD);
             return name -> {
                 int slash = name.indexOf('/');
@@ -167,7 +167,7 @@ public record Project(
             String prefix = BUILD + "/modules/" + MultiProjectModule.COMPOSE + "/" + MultiProjectModule.MODULE;
             executor.addModule(PIN, new PinModule(project.root(), "module-info.java",
                     (path, file) -> new PinModuleInfo("module", path, file, project.hashFunction())), BUILD);
-            executor.addModule(TREE, (tree, inherited) -> tree.addStep(
+            executor.addModule(DEPENDENCIES, (tree, inherited) -> tree.addStep(
                     "tree", new Tree(), inherited.sequencedKeySet()), BUILD);
             return name -> {
                 int slash = name.indexOf('/');
@@ -236,7 +236,7 @@ public record Project(
             String prefix = BUILD + "/modules/" + MultiProjectModule.COMPOSE + "/" + MultiProjectModule.MODULE;
             executor.addModule(PIN, new PinModule(project.root(), "module-info.java",
                     (path, file) -> new PinModuleInfo("module", path, file, project.hashFunction())), BUILD);
-            executor.addModule(TREE, (tree, inherited) -> tree.addStep(
+            executor.addModule(DEPENDENCIES, (tree, inherited) -> tree.addStep(
                     "tree", new Tree(), inherited.sequencedKeySet()), BUILD);
             return name -> {
                 int slash = name.indexOf('/');
@@ -341,14 +341,14 @@ public record Project(
                     Without selectors, the default target (%{name}build%{reset}) is executed.
 
                     %{header}Selectors (available in every layout):%{reset}
-                      %{name}build%{reset}       Resolve, compile, package, and test every module
-                      %{name}stage%{reset}       Stage produced artifacts into a local repository
-                      %{name}export%{reset}      Export the staged repository as the build deliverable
-                      %{name}pin%{reset}         Rewrite version/checksum pins into pom.xml or module-info.java
-                      %{name}tree%{reset}        Print each module's resolved dependency graph (with licenses)
-                      %{name}metadata%{reset}    Refresh the metadata module outputs
-                      %{name}help%{reset}        Print this message
-                      %{name}skill%{reset}       Print an agent-oriented onboarding briefing (plain text)
+                      %{name}build%{reset}        Resolve, compile, package, and test every module
+                      %{name}stage%{reset}        Stage produced artifacts into a local repository
+                      %{name}export%{reset}       Export the staged repository as the build deliverable
+                      %{name}pin%{reset}          Rewrite version/checksum pins into pom.xml or module-info.java
+                      %{name}dependencies%{reset} Print each module's resolved dependency graph (with licenses)
+                      %{name}metadata%{reset}     Refresh the metadata module outputs
+                      %{name}help%{reset}         Print this message
+                      %{name}skill%{reset}        Print an agent-oriented onboarding briefing (plain text)
 
                     %{header}Module-scoped selector:%{reset}
                       A selector starting with %{name}+%{reset} is shorthand for a single project module:

--- a/sources/build/jenesis/step/CycloneDxEmitter.java
+++ b/sources/build/jenesis/step/CycloneDxEmitter.java
@@ -51,18 +51,30 @@ public class CycloneDxEmitter {
             Map.entry("common development and distribution license 1.0", "CDDL-1.0"),
             Map.entry("cddl-1.0", "CDDL-1.0"));
 
-    public record Component(String group, String name, String version, String purl, String sha256, List<License> licenses) {
+    public record Component(String bomRef, String group, String name, String version, String purl, String sha256, List<License> licenses) {
     }
 
-    public String emit(Format format, Component metadata, List<Component> components) {
-        List<Component> sorted = new ArrayList<>(components);
-        sorted.sort(Comparator.comparing(component -> component.purl() == null
+    public record Dependency(String ref, List<String> dependsOn) {
+    }
+
+    public String emit(Format format, Component metadata, List<Component> components, List<Dependency> dependencies) {
+        List<Component> sortedComponents = new ArrayList<>(components);
+        sortedComponents.sort(Comparator.comparing(component -> component.purl() == null
                 ? component.group() + ":" + component.name() + ":" + component.version()
                 : component.purl()));
-        return format == Format.XML ? emitXml(metadata, sorted) : emitJson(metadata, sorted);
+        List<Dependency> sortedDependencies = new ArrayList<>();
+        for (Dependency dependency : dependencies) {
+            List<String> dependsOn = new ArrayList<>(dependency.dependsOn());
+            dependsOn.sort(Comparator.naturalOrder());
+            sortedDependencies.add(new Dependency(dependency.ref(), dependsOn));
+        }
+        sortedDependencies.sort(Comparator.comparing(Dependency::ref));
+        return format == Format.XML
+                ? emitXml(metadata, sortedComponents, sortedDependencies)
+                : emitJson(metadata, sortedComponents, sortedDependencies);
     }
 
-    private String emitJson(Component metadata, List<Component> components) {
+    private String emitJson(Component metadata, List<Component> components, List<Dependency> dependencies) {
         StringBuilder builder = new StringBuilder();
         builder.append("{\n");
         builder.append("  \"bomFormat\": \"CycloneDX\",\n");
@@ -82,6 +94,23 @@ public class CycloneDxEmitter {
             }
             builder.append("  ]");
         }
+        if (!dependencies.isEmpty()) {
+            builder.append(",\n  \"dependencies\": [\n");
+            for (int index = 0; index < dependencies.size(); index++) {
+                Dependency dependency = dependencies.get(index);
+                builder.append("    { \"ref\": \"").append(escapeJson(dependency.ref())).append("\"");
+                if (!dependency.dependsOn().isEmpty()) {
+                    builder.append(", \"dependsOn\": [");
+                    for (int on = 0; on < dependency.dependsOn().size(); on++) {
+                        builder.append(on > 0 ? ", " : "")
+                                .append("\"").append(escapeJson(dependency.dependsOn().get(on))).append("\"");
+                    }
+                    builder.append("]");
+                }
+                builder.append(" }").append(index + 1 < dependencies.size() ? ",\n" : "\n");
+            }
+            builder.append("  ]");
+        }
         builder.append("\n}\n");
         return builder.toString();
     }
@@ -90,6 +119,9 @@ public class CycloneDxEmitter {
         String pad = " ".repeat(indent);
         builder.append("{\n");
         builder.append(pad).append("  \"type\": \"library\",\n");
+        if (component.bomRef() != null) {
+            builder.append(pad).append("  \"bom-ref\": \"").append(escapeJson(component.bomRef())).append("\",\n");
+        }
         if (component.group() != null) {
             builder.append(pad).append("  \"group\": \"").append(escapeJson(component.group())).append("\",\n");
         }
@@ -125,7 +157,7 @@ public class CycloneDxEmitter {
         builder.append("\n").append(pad).append("}");
     }
 
-    private String emitXml(Component metadata, List<Component> components) {
+    private String emitXml(Component metadata, List<Component> components, List<Dependency> dependencies) {
         Document document;
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -145,6 +177,17 @@ public class CycloneDxEmitter {
             Element wrapper = (Element) bom.appendChild(document.createElementNS(NAMESPACE, "components"));
             for (Component component : components) {
                 appendXmlComponent(document, wrapper, component);
+            }
+        }
+        if (!dependencies.isEmpty()) {
+            Element wrapper = (Element) bom.appendChild(document.createElementNS(NAMESPACE, "dependencies"));
+            for (Dependency dependency : dependencies) {
+                Element node = (Element) wrapper.appendChild(document.createElementNS(NAMESPACE, "dependency"));
+                node.setAttribute("ref", dependency.ref());
+                for (String on : dependency.dependsOn()) {
+                    Element child = (Element) node.appendChild(document.createElementNS(NAMESPACE, "dependency"));
+                    child.setAttribute("ref", on);
+                }
             }
         }
         Transformer transformer;
@@ -167,6 +210,9 @@ public class CycloneDxEmitter {
     private void appendXmlComponent(Document document, Node parent, Component component) {
         Element node = (Element) parent.appendChild(document.createElementNS(NAMESPACE, "component"));
         node.setAttribute("type", "library");
+        if (component.bomRef() != null) {
+            node.setAttribute("bom-ref", component.bomRef());
+        }
         if (component.group() != null) {
             appendXmlText(document, node, "group", component.group());
         }

--- a/sources/build/jenesis/step/Dependencies.java
+++ b/sources/build/jenesis/step/Dependencies.java
@@ -315,6 +315,95 @@ public class Dependencies implements BuildStep {
         return new ArrayList<>(selected);
     }
 
+    public static SequencedMap<String, Resolver.Resolution> graph(Iterable<Path> graphFiles,
+                                                                  Iterable<Path> licenseFiles) throws IOException {
+        SequencedMap<String, SequencedMap<Integer, String[]>> licenseEntries = new LinkedHashMap<>();
+        for (Path file : licenseFiles) {
+            if (!Files.isRegularFile(file)) {
+                continue;
+            }
+            SequencedProperties properties = SequencedProperties.ofFiles(file);
+            for (String key : properties.stringPropertyNames()) {
+                int last = key.lastIndexOf('#');
+                int prior = last < 1 ? -1 : key.lastIndexOf('#', last - 1);
+                if (prior < 1) {
+                    continue;
+                }
+                int index;
+                try {
+                    index = Integer.parseInt(key.substring(prior + 1, last));
+                } catch (NumberFormatException _) {
+                    continue;
+                }
+                String[] entry = licenseEntries
+                        .computeIfAbsent(key.substring(0, prior), _ -> new TreeMap<>())
+                        .computeIfAbsent(index, _ -> new String[2]);
+                if (key.substring(last + 1).equals("name")) {
+                    entry[0] = properties.getProperty(key);
+                } else if (key.substring(last + 1).equals("url")) {
+                    entry[1] = properties.getProperty(key);
+                }
+            }
+        }
+        SequencedMap<String, List<License>> licenses = new LinkedHashMap<>();
+        licenseEntries.forEach((coordinate, byIndex) -> licenses.put(coordinate,
+                byIndex.values().stream().map(entry -> new License(entry[0], entry[1])).toList()));
+        SequencedMap<String, SequencedSet<Resolver.Edge>> edges = new LinkedHashMap<>();
+        SequencedMap<String, SequencedMap<String, Resolver.Vertex>> vertices = new LinkedHashMap<>();
+        for (Path file : graphFiles) {
+            if (!Files.isRegularFile(file)) {
+                continue;
+            }
+            SequencedProperties properties = SequencedProperties.ofFiles(file);
+            for (String key : properties.stringPropertyNames()) {
+                String value = properties.getProperty(key);
+                if (key.startsWith("edge/")) {
+                    String[] parts = value.split("\t", -1);
+                    if (parts.length != 8) {
+                        continue;
+                    }
+                    edges.computeIfAbsent(parts[0] + "/" + parts[1], _ -> new LinkedHashSet<>())
+                            .add(new Resolver.Edge(
+                                    parts[6].isEmpty() ? null : parts[6],
+                                    parts[7],
+                                    parts[5].isEmpty() ? null : parts[5],
+                                    parts[4].isEmpty() ? null : parts[4],
+                                    Boolean.parseBoolean(parts[3])));
+                } else if (key.startsWith("vertex/")) {
+                    String rest = key.substring("vertex/".length());
+                    int first = rest.indexOf('/');
+                    int second = first < 0 ? -1 : rest.indexOf('/', first + 1);
+                    if (second < 0) {
+                        continue;
+                    }
+                    String groupScope = rest.substring(0, second);
+                    String coordinate = rest.substring(second + 1);
+                    String[] parts = value.split("\t", -1);
+                    String resolvedVersion = parts[0].isEmpty() ? null : parts[0];
+                    List<License> declared = resolvedVersion == null
+                            ? List.of()
+                            : licenses.getOrDefault(coordinate + "/" + resolvedVersion, List.of());
+                    vertices.computeIfAbsent(groupScope, _ -> new LinkedHashMap<>())
+                            .putIfAbsent(coordinate, new Resolver.Vertex(
+                                    resolvedVersion,
+                                    parts.length > 1 && !parts[1].isEmpty() ? parts[1] : null,
+                                    parts.length > 2 && Boolean.parseBoolean(parts[2]),
+                                    declared));
+                }
+            }
+        }
+        SequencedMap<String, Resolver.Resolution> result = new LinkedHashMap<>();
+        SequencedSet<String> groupScopes = new LinkedHashSet<>(edges.sequencedKeySet());
+        groupScopes.addAll(vertices.sequencedKeySet());
+        for (String groupScope : groupScopes) {
+            result.put(groupScope, new Resolver.Resolution(
+                    new LinkedHashMap<>(),
+                    new ArrayList<>(edges.getOrDefault(groupScope, new LinkedHashSet<>())),
+                    vertices.getOrDefault(groupScope, new LinkedHashMap<>())));
+        }
+        return result;
+    }
+
     private static String[] split(String key) {
         int first = key.indexOf('/');
         if (first < 1) {

--- a/sources/build/jenesis/step/Inventory.java
+++ b/sources/build/jenesis/step/Inventory.java
@@ -22,6 +22,8 @@ public class Inventory implements BuildStep {
                 Path.of(SOURCES),
                 Path.of(DOCUMENTATION),
                 Path.of(DEPENDENCIES),
+                Path.of("graph.properties"),
+                Path.of("licenses.properties"),
                 Path.of(JPackage.PACKAGES),
                 Path.of(JMod.JMODS),
                 Path.of(JLink.RUNTIME),
@@ -47,6 +49,8 @@ public class Inventory implements BuildStep {
         SequencedSet<Path> documentation = new LinkedHashSet<>();
         SequencedSet<Path> jmods = new LinkedHashSet<>();
         SequencedSet<Path> testReports = new LinkedHashSet<>();
+        SequencedSet<Path> graphs = new LinkedHashSet<>();
+        SequencedSet<Path> dependencyLicenses = new LinkedHashSet<>();
         SequencedMap<String, Path> closureJars = new LinkedHashMap<>();
         SequencedMap<String, String> closureScopes = new LinkedHashMap<>();
         SequencedMap<String, String> closureChecksums = new LinkedHashMap<>();
@@ -94,6 +98,14 @@ public class Inventory implements BuildStep {
             }
             collect(folder.resolve(JMod.JMODS), jmods);
             collect(folder.resolve(TEST_REPORT), testReports);
+            Path graphFile = folder.resolve("graph.properties");
+            if (Files.isRegularFile(graphFile)) {
+                graphs.add(graphFile);
+            }
+            Path licensesFile = folder.resolve("licenses.properties");
+            if (Files.isRegularFile(licensesFile)) {
+                dependencyLicenses.add(licensesFile);
+            }
             Path runtime = folder.resolve(JLink.RUNTIME);
             if (runtimeImage == null && Files.isDirectory(runtime)) {
                 runtimeImage = runtime;
@@ -135,6 +147,8 @@ public class Inventory implements BuildStep {
         writePaths(inventory, context, prefix + "documentation", documentation);
         writePaths(inventory, context, prefix + "jmod", jmods);
         writePaths(inventory, context, prefix + "testreport", testReports);
+        writePaths(inventory, context, prefix + "graph", graphs);
+        writePaths(inventory, context, prefix + "licenses", dependencyLicenses);
         if (image != null) {
             inventory.setProperty(prefix + "package", relativize(context, image));
         }

--- a/sources/build/jenesis/step/Sbom.java
+++ b/sources/build/jenesis/step/Sbom.java
@@ -7,6 +7,7 @@ import build.jenesis.BuildStepContext;
 import build.jenesis.BuildStepResult;
 import build.jenesis.HashDigestFunction;
 import build.jenesis.License;
+import build.jenesis.Resolver;
 import build.jenesis.SequencedProperties;
 import build.jenesis.maven.MavenDependencyKey;
 
@@ -50,7 +51,12 @@ public class Sbom implements BuildStep {
         }
         HashDigestFunction hash = new HashDigestFunction("SHA-256");
         SequencedMap<String, CycloneDxEmitter.Component> components = new LinkedHashMap<>();
+        List<Path> graphFiles = new ArrayList<>();
         for (BuildStepArgument argument : arguments.values()) {
+            Path graphFile = argument.folder().resolve("graph.properties");
+            if (Files.isRegularFile(graphFile)) {
+                graphFiles.add(graphFile);
+            }
             Path index = argument.folder().resolve(DEPENDENCIES);
             if (!Files.exists(index)) {
                 continue;
@@ -77,13 +83,16 @@ public class Sbom implements BuildStep {
                         readLicenses(licenses, licenseKey)));
             }
         }
-        CycloneDxEmitter.Component project = new CycloneDxEmitter.Component(groupId,
+        String projectRef = groupId + "/" + artifactId + "/" + version;
+        CycloneDxEmitter.Component project = new CycloneDxEmitter.Component(projectRef,
+                groupId,
                 artifactId,
                 version,
                 "pkg:maven/" + groupId + "/" + artifactId + "@" + version,
                 null,
                 ownLicenses(metadata));
-        String document = new CycloneDxEmitter().emit(format, project, new ArrayList<>(components.values()));
+        List<CycloneDxEmitter.Dependency> dependencies = relationships(projectRef, components.keySet(), graphFiles);
+        String document = new CycloneDxEmitter().emit(format, project, new ArrayList<>(components.values()), dependencies);
 
         Path embedded = Files.createDirectories(context.next()
                 .resolve(RESOURCES).resolve("META-INF").resolve("sbom"));
@@ -116,18 +125,77 @@ public class Sbom implements BuildStep {
                 if (!qualifiers.isEmpty()) {
                     purl.append("?").append(String.join("&", qualifiers));
                 }
-                return new CycloneDxEmitter.Component(key.groupId(), key.artifactId(), parsed.version(),
+                return new CycloneDxEmitter.Component(coordinate, key.groupId(), key.artifactId(), parsed.version(),
                         purl.toString(), sha256, licenses);
             }
         } catch (RuntimeException _) {
         }
         int last = coordinate.lastIndexOf('/');
-        return new CycloneDxEmitter.Component(null,
+        return new CycloneDxEmitter.Component(coordinate,
+                null,
                 last < 0 ? coordinate : coordinate.substring(0, last),
                 last < 0 ? "" : coordinate.substring(last + 1),
                 null,
                 sha256,
                 licenses);
+    }
+
+    private static List<CycloneDxEmitter.Dependency> relationships(String projectRef,
+                                                                   Set<String> componentRefs,
+                                                                   List<Path> graphFiles) throws IOException {
+        if (graphFiles.isEmpty()) {
+            return List.of();
+        }
+        SequencedMap<String, SequencedSet<String>> dependsOn = new LinkedHashMap<>();
+        dependsOn.put(projectRef, new LinkedHashSet<>());
+        for (String ref : componentRefs) {
+            dependsOn.put(ref, new LinkedHashSet<>());
+        }
+        for (Resolver.Resolution resolution : Dependencies.graph(graphFiles, List.of()).values()) {
+            SequencedMap<String, Resolver.Vertex> vertices = resolution.vertices();
+            Map<String, String> vertexKeyByCoordinate = new HashMap<>();
+            for (Resolver.Edge edge : resolution.edges()) {
+                vertexKeyByCoordinate.put(edge.coordinate(), stripVersion(edge.coordinate(), edge.version()));
+            }
+            for (Resolver.Edge edge : resolution.edges()) {
+                if (!edge.followed()) {
+                    continue;
+                }
+                String childRef = ref(stripVersion(edge.coordinate(), edge.version()), vertices);
+                if (childRef == null || !componentRefs.contains(childRef)) {
+                    continue;
+                }
+                String parentRef;
+                if (edge.parent() == null) {
+                    parentRef = projectRef;
+                } else {
+                    String parentKey = vertexKeyByCoordinate.get(edge.parent());
+                    parentRef = parentKey == null ? null : ref(parentKey, vertices);
+                    if (parentRef == null || !dependsOn.containsKey(parentRef)) {
+                        continue;
+                    }
+                }
+                dependsOn.get(parentRef).add(childRef);
+            }
+        }
+        List<CycloneDxEmitter.Dependency> result = new ArrayList<>();
+        dependsOn.forEach((ref, on) -> result.add(new CycloneDxEmitter.Dependency(ref, new ArrayList<>(on))));
+        return result;
+    }
+
+    private static String ref(String vertexKey, SequencedMap<String, Resolver.Vertex> vertices) {
+        Resolver.Vertex vertex = vertices.get(vertexKey);
+        if (vertex == null || vertex.resolvedVersion() == null) {
+            return null;
+        }
+        int slash = vertexKey.indexOf('/');
+        return (slash < 0 ? vertexKey : vertexKey.substring(slash + 1)) + "/" + vertex.resolvedVersion();
+    }
+
+    private static String stripVersion(String coordinate, String version) {
+        return version != null && !version.isEmpty() && coordinate.endsWith("/" + version)
+                ? coordinate.substring(0, coordinate.length() - version.length() - 1)
+                : coordinate;
     }
 
     private static List<License> readLicenses(SequencedProperties licenses, String licenseKey) {

--- a/sources/build/jenesis/step/Tree.java
+++ b/sources/build/jenesis/step/Tree.java
@@ -1,0 +1,63 @@
+package build.jenesis.step;
+
+import module java.base;
+import build.jenesis.BuildStep;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.DependencyTreeReport;
+import build.jenesis.Resolver;
+import build.jenesis.SequencedProperties;
+
+public class Tree implements BuildStep {
+
+    private final transient PrintStream out;
+
+    public Tree() {
+        this(System.out);
+    }
+
+    public Tree(PrintStream out) {
+        this.out = out;
+    }
+
+    @Override
+    public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
+        return true;
+    }
+
+    @Override
+    public CompletionStage<BuildStepResult> apply(Executor executor,
+                                                  BuildStepContext context,
+                                                  SequencedMap<String, BuildStepArgument> arguments)
+            throws IOException {
+        DependencyTreeReport report = new DependencyTreeReport(out);
+        for (BuildStepArgument argument : arguments.values()) {
+            Path inventoryFile = argument.folder().resolve(Inventory.INVENTORY);
+            if (!Files.isRegularFile(inventoryFile)) {
+                continue;
+            }
+            SequencedProperties inventory = SequencedProperties.ofFiles(inventoryFile);
+            String prefix = inventoryPrefix(inventory);
+            if (prefix == null) {
+                continue;
+            }
+            List<Path> graphs = Inventory.paths(inventory, argument.folder(), prefix + ".graph");
+            List<Path> licenses = Inventory.paths(inventory, argument.folder(), prefix + ".licenses");
+            SequencedMap<String, Resolver.Resolution> resolutions = Dependencies.graph(graphs, licenses);
+            resolutions.forEach((groupScope, resolution) ->
+                    report.render(resolution, groupScope + " (" + prefix + ")"));
+        }
+        return CompletableFuture.completedStage(new BuildStepResult(true));
+    }
+
+    private static String inventoryPrefix(SequencedProperties inventory) {
+        for (String key : inventory.stringPropertyNames()) {
+            int dot = key.indexOf('.');
+            if (dot > 0) {
+                return key.substring(0, dot);
+            }
+        }
+        return null;
+    }
+}

--- a/tests/build/jenesis/test/step/CycloneDxEmitterTest.java
+++ b/tests/build/jenesis/test/step/CycloneDxEmitterTest.java
@@ -12,18 +12,23 @@ public class CycloneDxEmitterTest {
     private final CycloneDxEmitter emitter = new CycloneDxEmitter();
 
     private static final CycloneDxEmitter.Component PROJECT = new CycloneDxEmitter.Component(
-            "build.jenesis", "demo", "1.0.0", "pkg:maven/build.jenesis/demo@1.0.0", null,
+            "build.jenesis/demo/1.0.0", "build.jenesis", "demo", "1.0.0", "pkg:maven/build.jenesis/demo@1.0.0", null,
             List.of(new License("Apache-2.0", "https://www.apache.org/licenses/LICENSE-2.0.txt")));
 
     private static final List<CycloneDxEmitter.Component> COMPONENTS = List.of(
-            new CycloneDxEmitter.Component("org.foo", "bar", "1.2.3", "pkg:maven/org.foo/bar@1.2.3", "abc123",
+            new CycloneDxEmitter.Component("org.foo/bar/1.2.3", "org.foo", "bar", "1.2.3", "pkg:maven/org.foo/bar@1.2.3", "abc123",
                     List.of(new License("The Apache Software License, Version 2.0", "https://apache.org/"))),
-            new CycloneDxEmitter.Component("org.baz", "qux", "4.5", "pkg:maven/org.baz/qux@4.5", "def456",
+            new CycloneDxEmitter.Component("org.baz/qux/4.5", "org.baz", "qux", "4.5", "pkg:maven/org.baz/qux@4.5", "def456",
                     List.of(new License("Some Custom License", "https://example.com/license"))));
+
+    private static final List<CycloneDxEmitter.Dependency> DEPENDENCIES = List.of(
+            new CycloneDxEmitter.Dependency("build.jenesis/demo/1.0.0", List.of("org.foo/bar/1.2.3")),
+            new CycloneDxEmitter.Dependency("org.foo/bar/1.2.3", List.of("org.baz/qux/4.5")),
+            new CycloneDxEmitter.Dependency("org.baz/qux/4.5", List.of()));
 
     @Test
     public void emits_cyclonedx_json() {
-        String json = emitter.emit(CycloneDxEmitter.Format.JSON, PROJECT, COMPONENTS);
+        String json = emitter.emit(CycloneDxEmitter.Format.JSON, PROJECT, COMPONENTS, DEPENDENCIES);
         assertThat(json)
                 .contains("\"bomFormat\": \"CycloneDX\"")
                 .contains("\"specVersion\": \"1.6\"")
@@ -34,27 +39,35 @@ public class CycloneDxEmitterTest {
                 .as("an unrecognized license falls back to name and url")
                 .contains("\"name\": \"Some Custom License\"")
                 .contains("\"url\": \"https://example.com/license\"");
+        assertThat(json)
+                .as("components carry a bom-ref and the dependency graph references them")
+                .contains("\"bom-ref\": \"org.foo/bar/1.2.3\"")
+                .contains("{ \"ref\": \"build.jenesis/demo/1.0.0\", \"dependsOn\": [\"org.foo/bar/1.2.3\"] }")
+                .contains("{ \"ref\": \"org.foo/bar/1.2.3\", \"dependsOn\": [\"org.baz/qux/4.5\"] }");
         assertThat(json).doesNotContain("serialNumber").doesNotContain("timestamp");
     }
 
     @Test
     public void emits_cyclonedx_xml() {
-        String xml = emitter.emit(CycloneDxEmitter.Format.XML, PROJECT, COMPONENTS);
+        String xml = emitter.emit(CycloneDxEmitter.Format.XML, PROJECT, COMPONENTS, DEPENDENCIES);
         assertThat(xml)
                 .contains("<bom")
                 .contains("cyclonedx.org/schema/bom/1.6")
                 .contains("<purl>pkg:maven/org.foo/bar@1.2.3</purl>")
                 .contains("<id>Apache-2.0</id>")
-                .contains("<name>Some Custom License</name>");
+                .contains("<name>Some Custom License</name>")
+                .contains("bom-ref=\"org.foo/bar/1.2.3\"")
+                .contains("<dependency ref=\"org.foo/bar/1.2.3\">");
     }
 
     @Test
     public void is_deterministic_and_order_independent() {
-        String first = emitter.emit(CycloneDxEmitter.Format.JSON, PROJECT, COMPONENTS);
+        String first = emitter.emit(CycloneDxEmitter.Format.JSON, PROJECT, COMPONENTS, DEPENDENCIES);
         String reversed = emitter.emit(CycloneDxEmitter.Format.JSON, PROJECT,
-                List.of(COMPONENTS.get(1), COMPONENTS.get(0)));
+                List.of(COMPONENTS.get(1), COMPONENTS.get(0)),
+                List.of(DEPENDENCIES.get(2), DEPENDENCIES.get(1), DEPENDENCIES.get(0)));
         assertThat(reversed)
-                .as("components are sorted by purl, so input order does not change the output")
+                .as("components and dependencies are sorted, so input order does not change the output")
                 .isEqualTo(first);
     }
 }

--- a/tests/build/jenesis/test/step/SbomTest.java
+++ b/tests/build/jenesis/test/step/SbomTest.java
@@ -40,6 +40,10 @@ public class SbomTest {
         licenses.setProperty("maven/org.example/lib/1.2.3#0#name", "Apache-2.0");
         licenses.setProperty("maven/org.example/lib/1.2.3#0#url", "https://www.apache.org/licenses/LICENSE-2.0.txt");
         licenses.store(argument.resolve("licenses.properties"));
+        SequencedProperties graph = new SequencedProperties();
+        graph.setProperty("edge/0", "main\tcompile\tmaven\ttrue\tcompile\t1.2.3\t\tmaven/org.example/lib/1.2.3");
+        graph.setProperty("vertex/main/compile/maven/org.example/lib", "1.2.3\t\tfalse");
+        graph.store(argument.resolve("graph.properties"));
         SequencedProperties metadata = new SequencedProperties();
         metadata.setProperty("project", "build.jenesis");
         metadata.setProperty("artifact", "demo");
@@ -69,6 +73,10 @@ public class SbomTest {
                 .contains("\"purl\": \"pkg:maven/org.example/lib@1.2.3\"")
                 .contains("\"content\": \"" + sha256 + "\"")
                 .contains("\"id\": \"Apache-2.0\"");
+        assertThat(sbom)
+                .as("the resolved dependency graph is emitted as CycloneDX relationships")
+                .contains("\"bom-ref\": \"org.example/lib/1.2.3\"")
+                .contains("{ \"ref\": \"build.jenesis/demo/1.0.0\", \"dependsOn\": [\"org.example/lib/1.2.3\"] }");
 
         SequencedProperties manifest = SequencedProperties.ofFiles(next.resolve("manifest.mf"));
         assertThat(manifest.getProperty("Sbom-Format")).isEqualTo("CycloneDX");

--- a/tests/build/jenesis/test/step/TreeTest.java
+++ b/tests/build/jenesis/test/step/TreeTest.java
@@ -1,0 +1,60 @@
+package build.jenesis.test.step;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildStepArgument;
+import build.jenesis.BuildStepContext;
+import build.jenesis.BuildStepResult;
+import build.jenesis.ChecksumStatus;
+import build.jenesis.SequencedProperties;
+import build.jenesis.step.Inventory;
+import build.jenesis.step.Tree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TreeTest {
+
+    @TempDir
+    private Path root;
+    private Path previous, next, supplement, argument;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        previous = root.resolve("previous");
+        next = Files.createDirectory(root.resolve("next"));
+        supplement = Files.createDirectory(root.resolve("supplement"));
+        argument = Files.createDirectory(root.resolve("argument"));
+    }
+
+    @Test
+    public void renders_the_resolution_graph_from_the_inventory() throws IOException {
+        SequencedProperties graph = new SequencedProperties();
+        graph.setProperty("edge/0", "main\tcompile\tmaven\ttrue\tcompile\t1.0\t\tmaven/org.foo/bar/1.0");
+        graph.setProperty("edge/1", "main\tcompile\tmaven\ttrue\tcompile\t2.0\tmaven/org.foo/bar/1.0\tmaven/org.foo/baz/2.0");
+        graph.setProperty("vertex/main/compile/maven/org.foo/bar", "1.0\torg.foo.bar\tfalse");
+        graph.setProperty("vertex/main/compile/maven/org.foo/baz", "2.0\t\tfalse");
+        graph.store(argument.resolve("graph.properties"));
+        SequencedProperties licenses = new SequencedProperties();
+        licenses.setProperty("maven/org.foo/bar/1.0#0#name", "Apache-2.0");
+        licenses.store(argument.resolve("licenses.properties"));
+        SequencedProperties inventory = new SequencedProperties();
+        inventory.setProperty("module.graph.0", "graph.properties");
+        inventory.setProperty("module.licenses.0", "licenses.properties");
+        inventory.store(argument.resolve(Inventory.INVENTORY));
+
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        BuildStepResult result = new Tree(new PrintStream(bytes, true, StandardCharsets.UTF_8)).apply(
+                Runnable::run,
+                new BuildStepContext(previous, next, supplement),
+                new LinkedHashMap<>(Map.of("argument", new BuildStepArgument(
+                        argument,
+                        Map.of(Path.of(Inventory.INVENTORY), ChecksumStatus.ADDED)))))
+                .toCompletableFuture().join();
+        assertThat(result.next()).isTrue();
+        String text = bytes.toString(StandardCharsets.UTF_8).replaceAll("\033\\[[0-9;]*m", "");
+        assertThat(text).contains("main/compile (module)");
+        assertThat(text).contains("maven/org.foo/bar 1.0 [compile] (module org.foo.bar) {Apache-2.0}");
+        assertThat(text).contains("└─ maven/org.foo/baz 2.0 [compile]");
+        assertThat(text).contains("maven/org.foo/bar -> 1.0");
+    }
+}


### PR DESCRIPTION
## Stage 2 of 2: inventory graph + `tree` step + SBOM relationships

Stacked on #28 (base branch `resolver-graph`; will retarget to `main` once #28 merges). Stage 2 consumes the `graph.properties` / `licenses.properties` sidecars that Stage 1 made the `Dependencies` step write on every resolve.

### What changed

- **`Inventory`** surfaces each module's `graph.properties` and `licenses.properties` as inventory paths (`module-<path>.graph` / `.licenses`), mirroring its existing artifact/report path collection.
- **New top-level `tree` step** (`step/Tree.java`), a sibling of `stage`/`export`/`pin` registered in every layout. It always runs when selected, reads the sidecars back from the inventory, reconstructs the resolved graph per `<group>/<scope>` via a shared `Dependencies.graph(...)` parser, and renders it with `DependencyTreeReport` — now with each dependency's **module name and license shown inline**. Unlike `jenesis.print.dependencies`, it renders from persisted data, so it works even when the resolve was cached.
- **`DependencyTreeReport`** gains a labeled `render(resolution, title)` overload and renders vertex licenses inline (`{Eclipse Public License v2.0}`).
- **`Sbom` + `CycloneDxEmitter`** read `graph.properties` and emit the CycloneDX `dependencies` array (`ref`/`dependsOn`, each component carrying a `bom-ref` keyed by its resolved coordinate) alongside the existing components and licenses.

### Verification

- `mvn -o test`: green (new `TreeTest`; updated `CycloneDxEmitterTest`/`SbomTest` assert `bom-ref` + the `dependencies` array).
- Clean **modular** self-build of `stage tree`: green; the `tree` step renders the resolved forest from the inventory.
- **modular_to_maven** `tree`: green; the tree renders with module names **and inline licenses** (EPL / Apache) across the closure.

### Notes

The `Sbom` step is standalone (not wired into a default layout yet, as in Stage 1), so the relationship emission is exercised by `SbomTest`. `tree` is opt-in and not part of the CI `stage` matrix. Pure-MODULAR license capture remains deferred (module repos expose no POM licenses), so MODULAR trees show module names without `{...}` license tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)