### PR TITLE
Packaged resources, META-INF rule, native-image capture demo, and assembler configurators

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -476,12 +476,6 @@ Java module name in the default `main` group.
 Together these show that build logic itself is just another module - it can be
 authored inline, loaded from source, or consumed as a versioned artifact.
 
-> Status: both `internal-module` and `external-module` currently fail at the
-> build-module load step, because the plugin's `build.jenesis` dependency
-> resolves to a published version that lags the local sources the host runs
-> against. They will work once a matching `build.jenesis` is released; see their
-> `README.md`s.
-
 ## 18. Driving the build without `Project` - [`custom-maven`](demo-26-custom-maven/README.md), [`custom-modular`](demo-27-custom-modular/README.md)
 
 The previous customizations still went through `Project`. These two go a step

--- a/demo/README.md
+++ b/demo/README.md
@@ -600,13 +600,17 @@ the running JDK's `bin/`, then `PATH`, so the build runs on a GraalVM JDK or wit
 
 The new idea is **closed-world ahead-of-time compilation**, and its catch:
 `native-image` only sees code reached statically, so anything dynamic (reflection,
-JNI, resources, proxies) needs reachability metadata - a `native-image/` config
-directory the step passes through, usually captured by running once under the
-tracing agent. This demo's module is dependency- and reflection-free, so it needs
-none. native-image is an *alternative* to jpackage, not a successor: jpackage for a
-faithful bundle of the JVM you tested against, native-image when startup latency and
-footprint dominate. Like `docker-isolation`, it needs tooling the CI runners lack
-(GraalVM), so it is a local exercise.
+JNI, resources, proxies) needs reachability metadata. The demo walks the whole loop:
+`Sample` loads its greeter by a name assembled at run time, so the binary needs
+metadata; `-Djenesis.observe.native=true` runs the tracing agent during the test
+(the second observation engine from section 13) and stages what it records; you
+commit that into `sources/META-INF/native-image/`, where native-image auto-discovers
+it from the jar. Build with the metadata and the reflective greeting works; delete it
+and the binary fails with `ClassNotFoundException`. native-image is an *alternative*
+to jpackage, not a successor: jpackage for a faithful bundle of the JVM you tested
+against, native-image when startup latency and footprint dominate. Like
+`docker-isolation`, it needs tooling the CI runners lack (GraalVM), so it is a local
+exercise.
 
 Cross-cutting concepts
 ----------------------

--- a/demo/demo-04-java-modular-multi/README.md
+++ b/demo/demo-04-java-modular-multi/README.md
@@ -25,6 +25,7 @@ The project is three module directories, each with its own `module-info.java`:
     |-- build/jenesis        symlink to ../../../sources/build/jenesis
     |-- greeter/             the library module
     |   |-- module-info.java     module demo.greeter { exports sample.greeter; }
+    |   |-- messages.properties  a root resource, packaged into the jar and read at run time
     |   `-- sample/greeter/Greeter.java
     |-- greeter-test/        the test variant of demo.greeter
     |   |-- module-info.java     open module demo.greeter.test (@jenesis.test demo.greeter)
@@ -52,6 +53,18 @@ repository (`target/stage/maven/output`, keyed by the generated coordinate), and
 `export` publishes each. The sibling resolves as the Maven coordinate read from
 `greeter`'s generated POM, so the published `app` POM declares a dependency on
 the published `greeter` artifact.
+
+Packaging a resource
+--------------------
+
+`greeter` ships a `messages.properties` at its source root, outside any package. A
+non-`.java` file is not compiled - Jenesis copies it verbatim into the module jar
+(here at the jar root), so `Greeter.prefix()` reads its greeting back at run time
+with `Greeter.class.getResourceAsStream("/messages.properties")`. Because the file
+sits in no package it is not module-encapsulated, so the class loads it from its
+own module without the descriptor having to `opens` anything. `greeter-test`
+asserts the greeting comes from that resource, so the build itself proves the
+resource was packaged and is loadable.
 
 Tests
 -----

--- a/demo/demo-04-java-modular-multi/greeter-test/greetertest/GreeterTest.java
+++ b/demo/demo-04-java-modular-multi/greeter-test/greetertest/GreeterTest.java
@@ -17,4 +17,9 @@ class GreeterTest {
     void prefix_is_not_blank() {
         assertFalse(new Greeter().prefix().isBlank());
     }
+
+    @Test
+    void prefix_is_loaded_from_the_packaged_resource() {
+        assertTrue(new Greeter().prefix().contains("packaged resource"));
+    }
 }

--- a/demo/demo-04-java-modular-multi/greeter/messages.properties
+++ b/demo/demo-04-java-modular-multi/greeter/messages.properties
@@ -1,0 +1,1 @@
+greeting=hello from a multi-module modular project, loaded from a packaged resource

--- a/demo/demo-04-java-modular-multi/greeter/sample/greeter/Greeter.java
+++ b/demo/demo-04-java-modular-multi/greeter/sample/greeter/Greeter.java
@@ -1,5 +1,9 @@
 package sample.greeter;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,6 +13,15 @@ public class Greeter {
 
     public String prefix() {
         LOGGER.info("building greeting");
-        return "hello from a multi-module modular project, compiled by Jenesis!";
+        Properties messages = new Properties();
+        try (InputStream input = Greeter.class.getResourceAsStream("/messages.properties")) {
+            if (input == null) {
+                throw new IllegalStateException("messages.properties was not packaged onto the module path");
+            }
+            messages.load(input);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return messages.getProperty("greeting");
     }
 }

--- a/demo/demo-12-kotlin/README.md
+++ b/demo/demo-12-kotlin/README.md
@@ -25,13 +25,17 @@ sources out under one package:
 
     demo/demo-12-kotlin
     |-- build/jenesis              symlink to ../../../sources/build/jenesis
-    `-- sources
-        |-- module-info.java       requires kotlin.stdlib; exports sample; exports sample.pure
-        `-- sample
-            |-- Greeter.java       a Java type in the exported 'sample' package
-            |-- Sample.kt          Kotlin that calls Greeter
-            `-- pure
-                `-- Pure.kt        a pure-Kotlin package, exported with no Java type
+    |-- sources
+    |   |-- module-info.java       requires kotlin.stdlib; exports sample; exports sample.pure
+    |   |-- messages.properties    a root resource, read by Greeter at run time
+    |   `-- sample
+    |       |-- Greeter.java       a Java type in the exported 'sample' package; loads the resource
+    |       |-- Sample.kt          Kotlin that calls Greeter
+    |       `-- pure
+    |           `-- Pure.kt        a pure-Kotlin package, exported with no Java type
+    `-- test
+        |-- module-info.java       open module sample.kotlin.test (@jenesis.test sample.kotlin)
+        `-- sampletest/SampleTest.java   asserts the greeting comes from the resource
 
 How Jenesis builds it
 ---------------------
@@ -57,6 +61,21 @@ type, yet `module-info.java` exports it. The order is what makes this work -
 so the Kotlin classes must exist first. `kotlinc` and `scalac` can read `.java`
 as source, so they run ahead of `javac`; `groovyc` cannot, which is why the
 `groovy` demo's exported package still needs a Java type.
+
+Packaging a resource in a mixed-language module
+-----------------------------------------------
+
+`messages.properties` sits at the source root, outside any package. In a
+single-language module the one compiler copies non-source files into the jar
+alongside the classes; here two compilers run, so neither owns that step and a
+dedicated resource step copies every non-source file instead - `messages.properties`
+lands at the jar root either way. `Greeter.java` reads it back with
+`Greeter.class.getResourceAsStream("/messages.properties")` and `Sample.kt` returns
+it with a Kotlin suffix, so one greeting crosses Java -> resource -> Kotlin. The
+`sample.kotlin.test` module asserts the result, so the build proves the resource was
+packaged into the mixed jar and is loadable. (Files under `META-INF/` are always
+copied this way too, except the `META-INF/versions/` multi-release overlay, which is
+compiled - see `../demo-07-java-multi-release`.)
 
 Pinning
 -------

--- a/demo/demo-12-kotlin/sources/messages.properties
+++ b/demo/demo-12-kotlin/sources/messages.properties
@@ -1,0 +1,1 @@
+greeting=Hello from a packaged resource

--- a/demo/demo-12-kotlin/sources/sample/Greeter.java
+++ b/demo/demo-12-kotlin/sources/sample/Greeter.java
@@ -1,8 +1,22 @@
 package sample;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Properties;
+
 public class Greeter {
 
     public String prefix() {
-        return "Hello from Java";
+        Properties messages = new Properties();
+        try (InputStream input = Greeter.class.getResourceAsStream("/messages.properties")) {
+            if (input == null) {
+                throw new IllegalStateException("messages.properties was not packaged onto the module path");
+            }
+            messages.load(input);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return messages.getProperty("greeting");
     }
 }

--- a/demo/demo-12-kotlin/test/module-info.java
+++ b/demo/demo-12-kotlin/test/module-info.java
@@ -1,0 +1,31 @@
+/**
+ * The test module for sample.kotlin. It exercises the Kotlin Sample, which reads
+ * its greeting from a packaged resource (messages.properties) through the Java
+ * Greeter, proving that a root resource is copied into the jar of a mixed
+ * Java + Kotlin module. Its JUnit closure plus the kotlin.stdlib runtime it
+ * inherits from sample.kotlin are pinned on the plain module trail.
+ *
+ * @jenesis.release 25
+ * @jenesis.test sample.kotlin
+ * @jenesis.pin kotlin.stdlib 1.9.10
+ * @jenesis.pin org.jetbrains.kotlin/kotlin-stdlib 1.9.10 SHA-256/55e989c512b80907799f854309f3bc7782c5b3d13932442d0379d5c472711504
+ * @jenesis.pin org.jetbrains.kotlin/kotlin-stdlib-common 1.9.10 SHA-256/cde3341ba18a2ba262b0b7cf6c55b20c90e8d434e42c9a13e6a3f770db965a88
+ * @jenesis.pin org.jetbrains/annotations 13.0 SHA-256/ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478
+ * @jenesis.pin org.apiguardian/apiguardian-api 1.1.2 SHA-256/b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38
+ * @jenesis.pin org.junit.jupiter 5.11.3
+ * @jenesis.pin org.junit.jupiter/junit-jupiter 5.11.3 SHA-256/ac7578efed162367c3ddc006338e07d4571510fd9866642ea93d5b9e4ed2f665
+ * @jenesis.pin org.junit.jupiter/junit-jupiter-api 5.11.3 SHA-256/5d8147a60f49453973e250ed68701b7ff055964fe2462fc2cb1ec1d6d44889ba
+ * @jenesis.pin org.junit.jupiter/junit-jupiter-engine 5.11.3 SHA-256/e62420c99f7c0d59a2159a2ef63e61877e9c80bd722c03ca8bf3bdcea050a589
+ * @jenesis.pin org.junit.jupiter/junit-jupiter-params 5.11.3 SHA-256/0f798ebec744c4e6605fd4f2072f41a8e989e2d469e21db5aa67cf799c0b51ec
+ * @jenesis.pin org.junit.platform.console 1.11.3
+ * @jenesis.pin org.junit.platform/junit-platform-commons 1.11.3 SHA-256/be262964b0b6b48de977c61d4f931df8cf61e80e750cc3f3a0a39cdd21c1008c
+ * @jenesis.pin org.junit.platform/junit-platform-console 1.11.3 SHA-256/a21b34807eb7d8aa56295d152ff7e0988bd22bbd5f17086c10f42b5c5ac46033
+ * @jenesis.pin org.junit.platform/junit-platform-engine 1.11.3 SHA-256/0043f72f611664735da8dc9a308bf12ecd2236b05339351c4741edb4d8fab0da
+ * @jenesis.pin org.junit.platform/junit-platform-launcher 1.11.3 SHA-256/b4727459201b0011beb0742bd807421a1fc8426b116193031ed87825bc2d4f04
+ * @jenesis.pin org.junit.platform/junit-platform-reporting 1.11.3 SHA-256/b8e19dbebcae7d1ff30b9d767047fbf3694027c33dfa423b371693b7f6679ed1
+ * @jenesis.pin org.opentest4j/opentest4j 1.3.0 SHA-256/48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b
+ */
+open module sample.kotlin.test {
+    requires sample.kotlin;
+    requires org.junit.jupiter;
+}

--- a/demo/demo-12-kotlin/test/sampletest/SampleTest.java
+++ b/demo/demo-12-kotlin/test/sampletest/SampleTest.java
@@ -1,0 +1,16 @@
+package sampletest;
+
+import org.junit.jupiter.api.Test;
+import sample.Sample;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SampleTest {
+
+    @Test
+    void greeting_is_loaded_from_the_packaged_resource() {
+        String greeting = new Sample().greet();
+        assertTrue(greeting.contains("packaged resource"), greeting);
+        assertTrue(greeting.contains("Kotlin"), greeting);
+    }
+}

--- a/demo/demo-32-native-image/README.md
+++ b/demo/demo-32-native-image/README.md
@@ -7,16 +7,21 @@ carries no Java runtime, because the runtime it needs is linked into the binary
 itself. It is the ahead-of-time counterpart of `../demo-06-java-modular-executable`:
 where that demo packages a `jpackage` app-image (your jar plus a trimmed JVM that
 runs it), this one produces a self-contained machine-code program with no JVM at
-all. The project is the same minimal shape - a `module-info.java` plus a single
-Java source with a `main` - only here Jenesis hands the resolved module path to
-`native-image` instead of `jpackage`.
+all.
 
-This demo is local-only: it needs the GraalVM `native-image` tool on the build's
-toolchain (see below), which the CI runners do not carry, so unlike most demos it
-is not part of the CI matrix.
+The demo deliberately reaches for **reflection**, the thing native-image's
+closed-world analysis cannot see, so it shows the whole loop: a test captures the
+reachability metadata, you commit it next to the sources, and the native build picks
+it up. `Sample` loads its greeter by a name assembled at run time -
+`Class.forName("sample." + name)` - and invokes it reflectively, so neither the class
+nor its methods are statically reachable.
 
-Run it
-------
+This demo is local-only: it needs the GraalVM `native-image` tool (and, for the
+capture, the GraalVM tracing agent) on the build's toolchain, which the CI runners
+do not carry, so unlike most demos it is not part of the CI matrix.
+
+Build the native image
+----------------------
 
 `native-image` is located the same way every external tool is - `GRAALVM_HOME`
 first, then the running JDK's own `bin/` (`java.home`), then `PATH`. So either run
@@ -29,19 +34,61 @@ managed by [SDKMAN](https://sdkman.io/), `sdk install java 25.0.3-graal`):
 
     GRAALVM_HOME=~/.sdkman/candidates/java/25.0.3-graal java -Djenesis.java.native=true build/jenesis/Project.java
 
-Either way the build compiles the module, jars it, then runs `native-image` over
-the produced module path. The image build is the slow step (around a minute - it
+The build compiles the modules, runs the test, then runs `native-image` over the
+produced module path. The image build is the slow step (a minute or two - it
 analyses the whole reachable program), after which the standalone binary lands at:
 
     target/build/modules/compose/module/module-sources/produce/assemble/native-image/output/native/demo.graal.image
 
 Run it directly - there is no `java` in the command, because there is no JVM:
 
-    .../native/demo.graal.image            # prints: Hello, world, from a native binary built by Jenesis!
-    .../native/demo.graal.image Ada Lovelace   # Hello, Ada Lovelace, from a native binary built by Jenesis!
+    .../native/demo.graal.image            # Hello, world, from a native binary built by Jenesis (reflectively)!
+    .../native/demo.graal.image Ada        # Hello, Ada, from a native binary built by Jenesis (reflectively)!
 
 The result is a ~6 MB ELF executable (`.exe` on Windows, a Mach-O binary on macOS)
-that links `java.base` statically and starts without a runtime.
+that links `java.base` statically and starts without a runtime. The greeting comes
+back through reflection - which only works because the committed metadata told
+native-image to keep `sample.Greeter`. Delete
+`sources/META-INF/native-image/demo.graal.image/reachability-metadata.json`, rebuild,
+and the binary fails at run time with `ClassNotFoundException: sample.Greeter`: the
+closed-world analysis dropped the class it never saw referenced.
+
+Capturing the metadata with the tracing agent
+----------------------------------------------
+
+Where does that metadata come from? Jenesis runs GraalVM's tracing agent the same
+way it runs JaCoCo coverage (`../demo-19-code-coverage`): as a **test-observation
+engine**. The `demo.graal.image.test` module exercises exactly the reflective call
+`Sample` makes, so building on a GraalVM JDK with
+
+    java -Djenesis.observe.native=true build/jenesis/Project.java stage
+
+attaches `-agentlib:native-image-agent` to the test JVM, and the agent records every
+reflective, JNI, resource and proxy access the test triggers. The capture is staged
+as a report:
+
+    target/stage/reports/native-image/<module>/reachability-metadata.json
+
+which for this demo holds exactly the `sample.Greeter` constructor and `greet`
+method. You review that, then commit the app-relevant entries into the module's
+`sources/META-INF/native-image/` (here under `demo.graal.image/`).
+
+How the committed metadata reaches the build
+--------------------------------------------
+
+`META-INF/native-image/` is the GraalVM-standard location: native-image scans it
+inside every jar on the module path and applies whatever configuration it finds, so
+nothing has to point the build at the file. Jenesis packages it there for free -
+files under `META-INF/` are copied into the jar verbatim (they are resources, not
+sources to compile), so `sources/META-INF/native-image/demo.graal.image/reachability-metadata.json`
+lands at `META-INF/native-image/demo.graal.image/` in the produced jar, and the
+native build on that jar discovers it automatically.
+
+That keeps capture and build deliberately **separate**: the agent only ships in the
+GraalVM runtime (so the observation engine needs no coordinate to resolve), and the
+metadata it records is staged for you to vet and commit before the image is built
+from it, rather than fed blindly into the same build. The same committed file also
+serves a plain JVM run and any other tool that honours `META-INF/native-image/`.
 
 How the native-image step fits the build
 -----------------------------------------
@@ -50,77 +97,31 @@ Native compilation is opt-in through a single boolean property,
 `-Djenesis.java.native=true`. When it is set, `InferredMultiProjectAssembler` wires a
 per-module `native-image` step that runs for every module declaring a main class -
 exactly the `@jenesis.main` field that `../demo-06-java-modular-executable` uses for
-`jpackage`, read from the same `module.properties`. Modules without a main class are
-skipped, so a library in a multi-module build is left alone.
-
-The step reuses the launcher coordinates the build already derived: the module path
-is the produced jar plus its resolved runtime dependency jars, and the launcher is
-`--module <module>/<main-class>` (the same `--module` jpackage would receive). It
+`jpackage`, read from the same `module.properties`. Modules without a main class
+(the test module) are skipped. The step reuses the launcher coordinates the build
+already derived - the produced module path and `--module <module>/<main-class>` - and
 invokes:
 
     native-image --no-fallback -o <name> --module-path <jars> --module <module>/<main-class>
 
-`--no-fallback` forces a real native image (never a JVM-backed fallback), and the
-binary is named after the module's coordinate (`demo.graal.image`), the same name
-jpackage's `--name` derives.
-
-Unlike the `jpackage` app-image, the native binary is **not** collected by the
-`STAGE` module (there is no `stage/native` analogue of `stage/packages`); it stays
-under its step's output directory shown above. The point of the demo is producing
-the binary, not staging it.
-
-A self-contained module by design
----------------------------------
-
-This module has no external dependencies on purpose. `native-image` performs a
-closed-world static analysis: code reached only through reflection, JNI, resource
-lookups, or dynamic proxies is invisible to it unless described by *reachability
-metadata*. A dependency-free, reflection-free program needs none, so it compiles
-cleanly with nothing but `--no-fallback`. That keeps the demo about the build
-wiring rather than about feeding GraalVM a configuration.
-
-When a real application does need metadata, the step picks it up automatically: a
-`native-image/` directory among the module's inputs (for instance a
-`sources/native-image/` resource folder) is passed through as
-`-H:ConfigurationFileDirectories=<dir>`. The usual way to produce that directory is
-to run the application once under the tracing agent
-(`-agentlib:native-image-agent=config-output-dir=...`), which records the reflective
-accesses the static analysis cannot see. This demo has nothing to record, so it
-ships no such directory.
-
-Capturing that metadata with an observation engine
---------------------------------------------------
-
-Jenesis automates running the tracing agent the same way it automates JaCoCo
-coverage (`../demo-19-code-coverage`): as a **test-observation engine**. On a
-project with tests, build it on a GraalVM JDK with
-
-    java -Djenesis.observe.native=true build/jenesis/Project.java stage
-
-and the `observed` step attaches `-agentlib:native-image-agent` to the test JVM, so
-every reflective, JNI, resource and proxy access the tests exercise is recorded.
-The capture is staged as a report:
-
-    target/stage/reports/native-image/<module>/reachability-metadata.json
-
-Review it, then commit it into the module's `sources/META-INF/native-image/`, where
-both `native-image` and the plain JVM auto-discover it from the jar. The split is
-deliberate - capture happens during the test run (so the agent only ever ships in
-the GraalVM runtime, no coordinate to resolve), while building the image stays a
-separate, reviewable step - which is why Jenesis stages the metadata for you to vet
-rather than feeding it straight into the same build. This demo carries no tests and
-no reflection, so there is nothing to capture; the flow matters once an app reaches
-for dynamic features. Like the image build, it needs a GraalVM JDK, so it is a local
-exercise.
+The native binary is **not** collected by the `STAGE` module (there is no
+`stage/native` analogue of `stage/packages`); it stays under its step's output
+directory shown above.
 
 Layout
 ------
 
     demo/demo-32-native-image
     |-- build/jenesis        symlink to ../../../sources/build/jenesis
-    `-- sources/
-        |-- module-info.java     module demo.graal.image (@jenesis.main, no dependencies)
-        `-- sample/Sample.java   main(String[] args); prints a greeting
+    |-- sources/
+    |   |-- module-info.java     module demo.graal.image (@jenesis.main sample.Sample)
+    |   |-- META-INF/native-image/demo.graal.image/reachability-metadata.json
+    |   `-- sample/
+    |       |-- Sample.java       main; loads the greeter reflectively by a run-time name
+    |       `-- Greeter.java      the reflective target (reached only via Class.forName)
+    `-- test/
+        |-- module-info.java     open module demo.graal.image.test (@jenesis.test demo.graal.image)
+        `-- imagetest/SampleTest.java   exercises the reflection so the agent records it
 
 With a `module-info.java` and no `pom.xml`, Jenesis auto-detects the
 MODULAR_TO_MAVEN layout, exactly as `../demo-02-java-modular` does. The module is
@@ -139,8 +140,7 @@ app into something a user runs without installing a JDK, but they differ in kind
 - **native-image** compiles the program *and* the runtime it touches into one
   machine-code binary ahead of time. Startup is near-instant and the binary is
   small, but it needs GraalVM at build time, a slow closed-world compile, and
-  reachability metadata for anything dynamic. It is the better fit for short-lived
-  CLIs and fast-scaling services where JVM warm-up cost dominates.
+  reachability metadata for anything dynamic - the loop this demo walks through.
 
 So the two are alternatives, not a progression: pick jpackage for a faithful,
 no-extra-tooling bundle of the very JVM you tested against, and native-image when

--- a/demo/demo-32-native-image/sources/META-INF/native-image/demo.graal.image/reachability-metadata.json
+++ b/demo/demo-32-native-image/sources/META-INF/native-image/demo.graal.image/reachability-metadata.json
@@ -1,0 +1,19 @@
+{
+  "reflection": [
+    {
+      "type": "sample.Greeter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "greet",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/demo/demo-32-native-image/sources/sample/Greeter.java
+++ b/demo/demo-32-native-image/sources/sample/Greeter.java
@@ -1,0 +1,8 @@
+package sample;
+
+public class Greeter {
+
+    public String greet(String who) {
+        return "Hello, " + who + ", from a native binary built by Jenesis (reflectively)!";
+    }
+}

--- a/demo/demo-32-native-image/sources/sample/Sample.java
+++ b/demo/demo-32-native-image/sources/sample/Sample.java
@@ -2,8 +2,15 @@ package sample;
 
 public class Sample {
 
-    public static void main(String[] args) {
-        String who = args.length == 0 ? "world" : String.join(" ", args);
-        System.out.println("Hello, " + who + ", from a native binary built by Jenesis!");
+    public static void main(String[] args) throws Exception {
+        String who = args.length == 0 ? "world" : args[0];
+        // The greeter is named at run time, so native-image's closed-world
+        // analysis cannot see it: the binary needs reachability metadata, which
+        // the tracing agent records from the test run.
+        String name = args.length > 1 ? args[1] : "Greeter";
+        Class<?> greeter = Class.forName("sample." + name);
+        Object greeting = greeter.getMethod("greet", String.class)
+                .invoke(greeter.getConstructor().newInstance(), who);
+        System.out.println(greeting);
     }
 }

--- a/demo/demo-32-native-image/test/imagetest/SampleTest.java
+++ b/demo/demo-32-native-image/test/imagetest/SampleTest.java
@@ -1,0 +1,16 @@
+package imagetest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SampleTest {
+
+    @Test
+    void greets_through_reflection() throws Exception {
+        Class<?> greeter = Class.forName("sample.Greeter");
+        Object greeting = greeter.getMethod("greet", String.class)
+                .invoke(greeter.getConstructor().newInstance(), "test");
+        assertTrue(((String) greeting).contains("test"));
+    }
+}

--- a/demo/demo-32-native-image/test/module-info.java
+++ b/demo/demo-32-native-image/test/module-info.java
@@ -1,0 +1,27 @@
+/**
+ * The test module for demo.graal.image. It exercises the same reflective greeter
+ * that sample.Sample uses, so when the build runs the test under the GraalVM
+ * tracing agent (-Djenesis.observe.native=true) the agent records exactly the
+ * reachability metadata the native image needs. Its JUnit closure is pinned on
+ * the plain module trail.
+ *
+ * @jenesis.release 25
+ * @jenesis.test demo.graal.image
+ * @jenesis.pin org.apiguardian/apiguardian-api 1.1.2 SHA-256/b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38
+ * @jenesis.pin org.junit.jupiter 5.11.3
+ * @jenesis.pin org.junit.jupiter/junit-jupiter 5.11.3 SHA-256/ac7578efed162367c3ddc006338e07d4571510fd9866642ea93d5b9e4ed2f665
+ * @jenesis.pin org.junit.jupiter/junit-jupiter-api 5.11.3 SHA-256/5d8147a60f49453973e250ed68701b7ff055964fe2462fc2cb1ec1d6d44889ba
+ * @jenesis.pin org.junit.jupiter/junit-jupiter-engine 5.11.3 SHA-256/e62420c99f7c0d59a2159a2ef63e61877e9c80bd722c03ca8bf3bdcea050a589
+ * @jenesis.pin org.junit.jupiter/junit-jupiter-params 5.11.3 SHA-256/0f798ebec744c4e6605fd4f2072f41a8e989e2d469e21db5aa67cf799c0b51ec
+ * @jenesis.pin org.junit.platform.console 1.11.3
+ * @jenesis.pin org.junit.platform/junit-platform-commons 1.11.3 SHA-256/be262964b0b6b48de977c61d4f931df8cf61e80e750cc3f3a0a39cdd21c1008c
+ * @jenesis.pin org.junit.platform/junit-platform-console 1.11.3 SHA-256/a21b34807eb7d8aa56295d152ff7e0988bd22bbd5f17086c10f42b5c5ac46033
+ * @jenesis.pin org.junit.platform/junit-platform-engine 1.11.3 SHA-256/0043f72f611664735da8dc9a308bf12ecd2236b05339351c4741edb4d8fab0da
+ * @jenesis.pin org.junit.platform/junit-platform-launcher 1.11.3 SHA-256/b4727459201b0011beb0742bd807421a1fc8426b116193031ed87825bc2d4f04
+ * @jenesis.pin org.junit.platform/junit-platform-reporting 1.11.3 SHA-256/b8e19dbebcae7d1ff30b9d767047fbf3694027c33dfa423b371693b7f6679ed1
+ * @jenesis.pin org.opentest4j/opentest4j 1.3.0 SHA-256/48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b
+ */
+open module demo.graal.image.test {
+    requires demo.graal.image;
+    requires org.junit.jupiter;
+}

--- a/sources/build/jenesis/BuildStep.java
+++ b/sources/build/jenesis/BuildStep.java
@@ -49,4 +49,10 @@ public interface BuildStep extends Serializable {
             Files.copy(existing, link);
         }
     }
+
+    static boolean underMetaInfVersions(Path path) {
+        return path.getNameCount() >= 2
+                && path.getName(0).toString().equals("META-INF")
+                && path.getName(1).toString().equals("versions");
+    }
 }

--- a/sources/build/jenesis/project/GroovyCompilerModule.java
+++ b/sources/build/jenesis/project/GroovyCompilerModule.java
@@ -193,7 +193,9 @@ public class GroovyCompilerModule implements BuildExecutorModule {
                             String name = file.toString();
                             if (name.endsWith(".groovy")) {
                                 files.add(name);
-                            } else if (includeResources && !name.endsWith(".java")) {
+                            } else if (includeResources
+                                    && !name.endsWith(".java")
+                                    && !BuildStep.underMetaInfVersions(sources.relativize(file))) {
                                 BuildStep.linkOrCopy(target.resolve(sources.relativize(file)), file);
                             }
                             return FileVisitResult.CONTINUE;

--- a/sources/build/jenesis/project/InferredCompilerChainModule.java
+++ b/sources/build/jenesis/project/InferredCompilerChainModule.java
@@ -201,11 +201,13 @@ public class InferredCompilerChainModule implements BuildExecutorModule {
                     @Override
                     public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                         String name = file.getFileName().toString();
+                        Path relative = sources.relativize(file);
                         if (!name.endsWith(".java")
                                 && !name.endsWith(".kt")
                                 && !name.endsWith(".scala")
-                                && !name.endsWith(".groovy")) {
-                            BuildStep.linkOrCopy(target.resolve(sources.relativize(file)), file);
+                                && !name.endsWith(".groovy")
+                                && !BuildStep.underMetaInfVersions(relative)) {
+                            BuildStep.linkOrCopy(target.resolve(relative), file);
                         }
                         return FileVisitResult.CONTINUE;
                     }

--- a/sources/build/jenesis/project/InferredMultiProjectAssembler.java
+++ b/sources/build/jenesis/project/InferredMultiProjectAssembler.java
@@ -27,7 +27,11 @@ public record InferredMultiProjectAssembler(String packaging,
                                             boolean bundle,
                                             boolean nativeImage,
                                             CycloneDxEmitter.Format sbom,
-                                            TestEngine testEngine) implements MultiProjectAssembler<ProjectModuleDescriptor> {
+                                            UnaryOperator<InferredSourceCodeQualityModule> check,
+                                            UnaryOperator<InferredSourceFormattingModule> format,
+                                            UnaryOperator<InferredByteCodeQualityModule> validate,
+                                            UnaryOperator<InferredTestObservationModule> observe,
+                                            UnaryOperator<TestModule> test) implements MultiProjectAssembler<ProjectModuleDescriptor> {
 
     public InferredMultiProjectAssembler() {
         String packagingOverride = System.getProperty("jenesis.java.jpackage");
@@ -43,35 +47,55 @@ public record InferredMultiProjectAssembler(String packaging,
                     default -> throw new IllegalArgumentException(
                             "Unknown SBOM format: " + sbomFormat + " (expected json or xml)");
                 },
-                null);
+                UnaryOperator.identity(),
+                UnaryOperator.identity(),
+                UnaryOperator.identity(),
+                UnaryOperator.identity(),
+                UnaryOperator.identity());
     }
 
     public InferredMultiProjectAssembler packaging(String packaging) {
-        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, testEngine);
+        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, check, format, validate, observe, test);
     }
 
     public InferredMultiProjectAssembler jmod(boolean jmod) {
-        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, testEngine);
+        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, check, format, validate, observe, test);
     }
 
     public InferredMultiProjectAssembler jlink(boolean jlink) {
-        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, testEngine);
+        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, check, format, validate, observe, test);
     }
 
     public InferredMultiProjectAssembler bundle(boolean bundle) {
-        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, testEngine);
+        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, check, format, validate, observe, test);
     }
 
     public InferredMultiProjectAssembler nativeImage(boolean nativeImage) {
-        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, testEngine);
+        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, check, format, validate, observe, test);
     }
 
     public InferredMultiProjectAssembler sbom(CycloneDxEmitter.Format sbom) {
-        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, testEngine);
+        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, check, format, validate, observe, test);
     }
 
-    public InferredMultiProjectAssembler testEngine(TestEngine testEngine) {
-        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, testEngine);
+    public InferredMultiProjectAssembler check(UnaryOperator<InferredSourceCodeQualityModule> check) {
+        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, check, format, validate, observe, test);
+    }
+
+    public InferredMultiProjectAssembler format(UnaryOperator<InferredSourceFormattingModule> format) {
+        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, check, format, validate, observe, test);
+    }
+
+    public InferredMultiProjectAssembler validate(UnaryOperator<InferredByteCodeQualityModule> validate) {
+        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, check, format, validate, observe, test);
+    }
+
+    public InferredMultiProjectAssembler observe(UnaryOperator<InferredTestObservationModule> observe) {
+        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, check, format, validate, observe, test);
+    }
+
+    public InferredMultiProjectAssembler test(UnaryOperator<TestModule> test) {
+        return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, nativeImage, sbom, check, format, validate, observe, test);
     }
 
     @Override
@@ -84,12 +108,12 @@ public record InferredMultiProjectAssembler(String packaging,
                     new Prepare(descriptor.modulePath()),
                     outerInherited.sequencedKeySet().stream());
             sub.addModule("check",
-                    new InferredSourceCodeQualityModule(descriptor.configuration(), repositories, resolvers)
-                            .pinning(descriptor.pinning()),
+                    check.apply(new InferredSourceCodeQualityModule(descriptor.configuration(), repositories, resolvers)
+                            .pinning(descriptor.pinning())),
                     descriptor.sources());
             sub.addModule("format",
-                    new InferredSourceFormattingModule(descriptor.configuration(), repositories, resolvers)
-                            .pinning(descriptor.pinning()),
+                    format.apply(new InferredSourceFormattingModule(descriptor.configuration(), repositories, resolvers)
+                            .pinning(descriptor.pinning())),
                     descriptor.sources());
             if (sbom != null) {
                 sub.addStep("sbom", new Sbom().format(sbom),
@@ -99,8 +123,8 @@ public record InferredMultiProjectAssembler(String packaging,
                             .compiler(new InferredCompilerChainModule(repositories, resolvers)
                                     .pinning(descriptor.pinning())
                                     .modulePath(descriptor.modulePath()))
-                            .validator(new InferredByteCodeQualityModule(descriptor.configuration(), repositories, resolvers)
-                                    .pinning(descriptor.pinning()))
+                            .validator(validate.apply(new InferredByteCodeQualityModule(descriptor.configuration(), repositories, resolvers)
+                                    .pinning(descriptor.pinning())))
                             .archiver(new Jar(factory, Jar.Sort.CLASSES).asModule("jar")),
                     Stream.of(
                             Stream.of("prepare"),
@@ -120,17 +144,16 @@ public record InferredMultiProjectAssembler(String packaging,
                 if (module != null) {
                     SequencedProperties properties = SequencedProperties.ofFiles(module);
                     if (properties.getProperty("test") != null) {
-                        sub.addModule("observed", new InferredTestObservationModule(
+                        sub.addModule("observed", observe.apply(new InferredTestObservationModule(
                                 repositories,
                                 resolvers,
                                 descriptor.pinning(),
-                                engines -> new TestModule(repositories, resolvers)
-                                        .engine(testEngine)
+                                engines -> test.apply(new TestModule(repositories, resolvers)
                                         .observe(engines)
                                         .pinning(descriptor.pinning())
                                         .modulePath(descriptor.modulePath())
-                                        .moduleName(properties.getProperty("module"))
-                                ), Stream.concat(Stream.of("prepare", "binary"), inputs(descriptor)));
+                                        .moduleName(properties.getProperty("module")))
+                                )), Stream.concat(Stream.of("prepare", "binary"), inputs(descriptor)));
                     }
                 }
             }

--- a/sources/build/jenesis/project/KotlinCompilerModule.java
+++ b/sources/build/jenesis/project/KotlinCompilerModule.java
@@ -209,7 +209,9 @@ public class KotlinCompilerModule implements BuildExecutorModule {
                                     || (name.endsWith(".java")
                                     && !file.getFileName().toString().equals("module-info.java"))) {
                                 files.add(name);
-                            } else if (includeResources && !name.endsWith(".java")) {
+                            } else if (includeResources
+                                    && !name.endsWith(".java")
+                                    && !BuildStep.underMetaInfVersions(sources.relativize(file))) {
                                 BuildStep.linkOrCopy(target.resolve(sources.relativize(file)), file);
                             }
                             return FileVisitResult.CONTINUE;

--- a/sources/build/jenesis/project/ScalaCompilerModule.java
+++ b/sources/build/jenesis/project/ScalaCompilerModule.java
@@ -209,7 +209,9 @@ public class ScalaCompilerModule implements BuildExecutorModule {
                                     || (name.endsWith(".java")
                                     && !file.getFileName().toString().equals("module-info.java"))) {
                                 files.add(name);
-                            } else if (includeResources && !name.endsWith(".java")) {
+                            } else if (includeResources
+                                    && !name.endsWith(".java")
+                                    && !BuildStep.underMetaInfVersions(sources.relativize(file))) {
                                 BuildStep.linkOrCopy(target.resolve(sources.relativize(file)), file);
                             }
                             return FileVisitResult.CONTINUE;

--- a/sources/build/jenesis/step/Javac.java
+++ b/sources/build/jenesis/step/Javac.java
@@ -159,7 +159,7 @@ public class Javac extends JdkProcessBuildStep {
                             if (versionOf(relative) == null) {
                                 files.add(name);
                             }
-                        } else if (includeResources) {
+                        } else if (includeResources && !BuildStep.underMetaInfVersions(relative)) {
                             BuildStep.linkOrCopy(target.resolve(relative), file);
                         }
                         return FileVisitResult.CONTINUE;

--- a/tests/build/jenesis/test/BuildStepTest.java
+++ b/tests/build/jenesis/test/BuildStepTest.java
@@ -1,0 +1,26 @@
+package build.jenesis.test;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.BuildStep;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BuildStepTest {
+
+    @Test
+    public void recognises_the_meta_inf_versions_overlay() {
+        assertThat(BuildStep.underMetaInfVersions(Path.of("META-INF/versions/25/sample/Platform.class"))).isTrue();
+        assertThat(BuildStep.underMetaInfVersions(Path.of("META-INF/versions/25/overlay.json"))).isTrue();
+        assertThat(BuildStep.underMetaInfVersions(Path.of("META-INF/versions"))).isTrue();
+    }
+
+    @Test
+    public void other_meta_inf_content_is_not_the_versions_overlay() {
+        assertThat(BuildStep.underMetaInfVersions(Path.of("META-INF/native-image/app/reachability-metadata.json"))).isFalse();
+        assertThat(BuildStep.underMetaInfVersions(Path.of("META-INF/services/java.sql.Driver"))).isFalse();
+        assertThat(BuildStep.underMetaInfVersions(Path.of("META-INF/MANIFEST.MF"))).isFalse();
+        assertThat(BuildStep.underMetaInfVersions(Path.of("sample/Sample.class"))).isFalse();
+        assertThat(BuildStep.underMetaInfVersions(Path.of("versions/META-INF/overlay.json"))).isFalse();
+    }
+}

--- a/tests/build/jenesis/test/project/InferredMultiProjectAssemblerTest.java
+++ b/tests/build/jenesis/test/project/InferredMultiProjectAssemblerTest.java
@@ -13,6 +13,7 @@ import build.jenesis.SequencedProperties;
 import build.jenesis.project.InferredMultiProjectAssembler;
 import build.jenesis.project.ProjectModule;
 import build.jenesis.project.ProjectModuleDescriptor;
+import build.jenesis.project.TestModule;
 import build.jenesis.step.JPackage;
 import build.jenesis.step.ProcessBuildStep;
 
@@ -283,7 +284,8 @@ public class InferredMultiProjectAssemblerTest {
             }
         };
         ProjectModuleDescriptor descriptor = new ProjectModuleDescriptor(base, sources, tests, source, documentation, null, PathPlacement.INFERRED);
-        BuildExecutorModule assembled = new InferredMultiProjectAssembler(packageType, jmod, jlink, false, false, null, null).apply(descriptor, Map.of(), Map.of());
+        BuildExecutorModule assembled = new InferredMultiProjectAssembler()
+                .packaging(packageType).jmod(jmod).jlink(jlink).apply(descriptor, Map.of(), Map.of());
         BuildExecutor executor = BuildExecutor.of(build,
                 Duration.ZERO,
                 new HashDigestFunction("MD5"),
@@ -302,6 +304,19 @@ public class InferredMultiProjectAssemblerTest {
         SequencedMap<String, Path> execute(String selector) {
             return executor.execute(Runnable::run, selector).toCompletableFuture().join();
         }
+    }
+
+    @Test
+    public void sub_module_configurators_default_to_identity_and_round_trip() {
+        InferredMultiProjectAssembler assembler = new InferredMultiProjectAssembler();
+        assertThat(assembler.check().apply(null)).as("check configurator defaults to identity").isNull();
+        assertThat(assembler.format().apply(null)).as("format configurator defaults to identity").isNull();
+        assertThat(assembler.validate().apply(null)).as("validate configurator defaults to identity").isNull();
+        assertThat(assembler.observe().apply(null)).as("observe configurator defaults to identity").isNull();
+        assertThat(assembler.test().apply(null)).as("test configurator defaults to identity").isNull();
+
+        UnaryOperator<TestModule> custom = test -> test.requireEngine(false);
+        assertThat(assembler.test(custom).test()).as("the test wither stores the configurator").isSameAs(custom);
     }
 
     private static SequencedProperties readProperties(Path path) throws IOException {

--- a/tests/build/jenesis/test/step/JavacTest.java
+++ b/tests/build/jenesis/test/step/JavacTest.java
@@ -593,4 +593,30 @@ public class JavacTest {
                 .as("foreign-language sources are excluded from output when includeResources(false)")
                 .doesNotExist();
     }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void copies_meta_inf_resources_but_not_the_versions_overlay(boolean process) throws IOException {
+        Path sample = Files.createDirectories(sources.resolve(BuildStep.SOURCES + "sample"));
+        Files.writeString(sample.resolve("Sample.java"), "package sample; public class Sample { }\n");
+        Path config = Files.createDirectories(sources.resolve(BuildStep.SOURCES + "META-INF/native-image/app"));
+        Files.writeString(config.resolve("reachability-metadata.json"), "[]");
+        Path versioned = Files.createDirectories(sources.resolve(BuildStep.SOURCES + "META-INF/versions/25"));
+        Files.writeString(versioned.resolve("overlay.json"), "{}");
+        BuildStepResult result = new Javac(process ? ProcessHandler.Factory.FORK : ProcessHandler.Factory.TOOL)
+                .apply(Runnable::run,
+                        new BuildStepContext(previous, next, supplement),
+                        new LinkedHashMap<>(Map.of("sources", new BuildStepArgument(
+                                sources,
+                                Map.of(Path.of("sources/sample/Sample.java"), ChecksumStatus.ADDED,
+                                        Path.of("sources/META-INF/native-image/app/reachability-metadata.json"), ChecksumStatus.ADDED,
+                                        Path.of("sources/META-INF/versions/25/overlay.json"), ChecksumStatus.ADDED))))).toCompletableFuture().join();
+        assertThat(result.next()).isTrue();
+        assertThat(next.resolve(Javac.CLASSES + "META-INF/native-image/app/reachability-metadata.json"))
+                .as("META-INF resources are copied into the classes output verbatim")
+                .content().isEqualTo("[]");
+        assertThat(next.resolve(Javac.CLASSES + "META-INF/versions/25/overlay.json"))
+                .as("the META-INF/versions multi-release overlay is not copied as a plain resource")
+                .doesNotExist();
+    }
 }


### PR DESCRIPTION
A batch of follow-ups from the native-image work. Five focused commits.

## 1. META-INF always copied, except the versions overlay
Non-source files are copied into the jar by whichever step owns resources (the single-language compiler, or the shared `Resources` step for multi-language modules). Now `META-INF/versions/` is excluded from that copy - it is the multi-release overlay, compiled, not packaged as a plain resource. A shared `BuildStep.underMetaInfVersions(Path)` encodes the rule at all five copy sites. Guarded by `BuildStepTest` (the helper) and a `JavacTest` case.

## 2. Resource demos (Java + multi-language)
`java-modular-multi`'s greeter and the `kotlin` demo each ship a `messages.properties` at the source root; the `Greeter` loads it with `getResourceAsStream` and a test asserts the greeting comes from the resource, so the build proves a root resource is packaged into the jar. The kotlin case exercises the multi-language path (the shared resource step).

## 3. native-image demo reworked to show capture → consumption
demo-32 now walks the whole reachability-metadata loop instead of being reflection-free:
- `Sample` loads its greeter by a name assembled at run time, so the native image needs metadata.
- A `demo.graal.image.test` module exercises the same reflective call, so `-Djenesis.observe.native=true` captures it during the test and stages it as a report.
- The capture is committed to `sources/META-INF/native-image/.../reachability-metadata.json`, packaged verbatim into the jar (item 1), where native-image auto-discovers it - the GraalVM-standard consumption path.

Verified on GraalVM 25.0.3: with the metadata the reflective greeting works; remove it and the binary fails with `ClassNotFoundException: sample.Greeter`. Corrects the earlier README claim that `sources/native-image/` feeds `-H:ConfigurationFileDirectories`.

## 4. Assembler sub-module configurators
`InferredMultiProjectAssembler` held a `TestEngine` field that it forwarded to the `TestModule` - and that `.engine(null)` forwarding silently overrode `TestModule`'s own `jenesis.test.engine` default. Replaced with one `UnaryOperator` configurator per configurable sub-module (`check`, `format`, `validate`, `observe`, `test`), each defaulting to identity and applied to the stock, framework-configured sub-module. A caller customises a sub-module through its own withers (`.test(t -> t.engine(...).parallel(true))`) instead of the assembler repeating properties; with identity defaults each sub-module again reads its own properties.

> Note: the request said `BinaryOperator`, but the described semantics (an identity that returns the value it receives, configure via withers) are `UnaryOperator<T>` - a `BinaryOperator` takes two arguments and has no identity-returns-input. Implemented as `UnaryOperator<T>`; happy to rename if a two-arg form was intended.

## 5. Removed an obsolete build warning
internal/external-module build and pass in CI, so the "fails at the build-module load step" note is gone.

## Verification
- Full suite: **977 tests, 0 failures**.
- Strict-pinning builds of demo-04 / demo-12 / demo-32 and the main project self-build all pass (every download pinned with version + checksum).
- Multi-release demo (demo-07) still selects the Java 25 overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)