### PR TITLE
Hash file trees in parallel on the build executor

### DIFF
--- a/sources/build/jenesis/BuildExecutorDefault.java
+++ b/sources/build/jenesis/BuildExecutorDefault.java
@@ -67,7 +67,7 @@ class BuildExecutorDefault implements BuildExecutor {
                 try {
                     future.complete(Map.of(identity, Map.of(
                             identity,
-                            new StepSummary(path, HashFunction.read(path, hash)))));
+                            new StepSummary(path, HashFunction.read(path, hash, executor)))));
                 } catch (Throwable t) {
                     future.completeExceptionally(t);
                 }
@@ -118,7 +118,7 @@ class BuildExecutorDefault implements BuildExecutor {
                     String serialization = stepProperties.getProperty("serialization");
                     consistent = serialization != null
                             && Arrays.equals(currentStepHash, HexFormat.of().parseHex(serialization))
-                            && HashFunction.areConsistent(output, current, hash);
+                            && HashFunction.areConsistent(output, current, hash, executor);
                 } else {
                     consistent = false;
                 }
@@ -166,7 +166,7 @@ class BuildExecutorDefault implements BuildExecutor {
                                         checksum.resolve("argument." + BuildExecutorModule.encode(entry.getKey()) + ".properties"),
                                         entry.getValue().checksums());
                             }
-                            Map<Path, byte[]> checksums = HashFunction.read(output, hash);
+                            Map<Path, byte[]> checksums = HashFunction.read(output, hash, executor);
                             HashFunction.write(checksum.resolve("output.properties"), checksums);
                             SequencedProperties stepProperties = new SequencedProperties();
                             stepProperties.setProperty("serialization", HexFormat.of().formatHex(currentStepHash));
@@ -533,7 +533,7 @@ class BuildExecutorDefault implements BuildExecutor {
                     for (Path path : paths) {
                         extended.put(
                                 ":" + BuildExecutorModule.encode(path.toString()),
-                                new StepSummary(path, HashFunction.read(path, hash)));
+                                new StepSummary(path, HashFunction.read(path, hash, executor)));
                     }
                     return delegate.apply(identity, executor, extended, selectors);
                 }

--- a/sources/build/jenesis/HashFunction.java
+++ b/sources/build/jenesis/HashFunction.java
@@ -16,11 +16,21 @@ public interface HashFunction {
         return checksums;
     }
 
-    static Map<Path, byte[]> read(Path folder, HashFunction hash) throws IOException {
+    static Map<Path, byte[]> read(Path folder, HashFunction hash, Executor executor) throws IOException {
         Map<Path, byte[]> checksums = new LinkedHashMap<>();
         if (!Files.exists(folder)) {
             return checksums;
         }
+        List<Path> files = files(folder);
+        Map<Path, byte[]> hashes = hashAll(files, hash, executor);
+        for (Path file : files) {
+            checksums.put(folder.relativize(file), hashes.get(file));
+        }
+        return checksums;
+    }
+
+    private static List<Path> files(Path folder) throws IOException {
+        List<Path> files = new ArrayList<>();
         Queue<Path> queue = new ArrayDeque<>(List.of(folder));
         do {
             Path current = queue.remove();
@@ -29,10 +39,43 @@ public interface HashFunction {
                     stream.forEach(queue::add);
                 }
             } else {
-                checksums.put(folder.relativize(current), hash.hash(current));
+                files.add(current);
             }
         } while (!queue.isEmpty());
-        return checksums;
+        return files;
+    }
+
+    private static Map<Path, byte[]> hashAll(List<Path> files, HashFunction hash, Executor executor) throws IOException {
+        if (files.size() < 2) {
+            Map<Path, byte[]> hashes = new HashMap<>();
+            for (Path file : files) {
+                hashes.put(file, hash.hash(file));
+            }
+            return hashes;
+        }
+        Map<Path, byte[]> hashes = new ConcurrentHashMap<>();
+        List<CompletableFuture<?>> futures = new ArrayList<>(files.size());
+        for (Path file : files) {
+            CompletableFuture<?> future = new CompletableFuture<>();
+            executor.execute(() -> {
+                try {
+                    hashes.put(file, hash.hash(file));
+                    future.complete(null);
+                } catch (Throwable t) {
+                    future.completeExceptionally(t);
+                }
+            });
+            futures.add(future);
+        }
+        try {
+            CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof IOException exception) {
+                throw exception;
+            }
+            throw e;
+        }
+        return hashes;
     }
 
     static void write(Path file, Map<Path, byte[]> checksums) throws IOException {
@@ -46,22 +89,21 @@ public interface HashFunction {
         properties.store(file);
     }
 
-    static boolean areConsistent(Path folder, Map<Path, byte[]> checksums, HashFunction hash) throws IOException {
+    static boolean areConsistent(Path folder, Map<Path, byte[]> checksums, HashFunction hash, Executor executor)
+            throws IOException {
         Map<Path, byte[]> remaining = new HashMap<>(checksums);
-        Queue<Path> queue = new ArrayDeque<>(List.of(folder));
-        do {
-            Path current = queue.remove();
-            if (Files.isDirectory(current)) {
-                try (DirectoryStream<Path> stream = Files.newDirectoryStream(current)) {
-                    stream.forEach(queue::add);
-                }
-            } else {
-                byte[] checksum = remaining.remove(folder.relativize(current));
-                if (checksum == null || !Arrays.equals(checksum, hash.hash(current))) {
-                    return false;
-                }
+        List<Path> files = files(folder);
+        for (Path file : files) {
+            if (!remaining.containsKey(folder.relativize(file))) {
+                return false;
             }
-        } while (!queue.isEmpty());
+        }
+        Map<Path, byte[]> hashes = hashAll(files, hash, executor);
+        for (Path file : files) {
+            if (!Arrays.equals(remaining.remove(folder.relativize(file)), hashes.get(file))) {
+                return false;
+            }
+        }
         return remaining.isEmpty();
     }
 }

--- a/sources/build/jenesis/step/FormatBuildStep.java
+++ b/sources/build/jenesis/step/FormatBuildStep.java
@@ -59,7 +59,7 @@ public abstract class FormatBuildStep extends JdkProcessBuildStep {
             if (candidate != null) {
                 config = candidate;
             }
-            current.putAll(formattable(argument.folder(), hash));
+            current.putAll(formattable(argument.folder(), hash, executor));
         }
         if (current.isEmpty()) {
             return CompletableFuture.completedStage(null);
@@ -97,7 +97,7 @@ public abstract class FormatBuildStep extends JdkProcessBuildStep {
                 HashFunction hash = new HashDigestFunction("SHA-256");
                 Map<Path, byte[]> after = new LinkedHashMap<>();
                 for (BuildStepArgument argument : arguments.values()) {
-                    after.putAll(formattable(argument.folder(), hash));
+                    after.putAll(formattable(argument.folder(), hash, executor));
                 }
                 HashFunction.write(context.next().resolve(FORMATTED), after);
                 return CompletableFuture.completedStage(result);
@@ -107,13 +107,13 @@ public abstract class FormatBuildStep extends JdkProcessBuildStep {
         });
     }
 
-    private Map<Path, byte[]> formattable(Path folder, HashFunction hash) throws IOException {
+    private Map<Path, byte[]> formattable(Path folder, HashFunction hash, Executor executor) throws IOException {
         Path sources = folder.resolve(Bind.SOURCES);
         if (!Files.isDirectory(sources)) {
             return Map.of();
         }
         Map<Path, byte[]> formattable = new LinkedHashMap<>();
-        for (Map.Entry<Path, byte[]> entry : HashFunction.read(sources, hash).entrySet()) {
+        for (Map.Entry<Path, byte[]> entry : HashFunction.read(sources, hash, executor).entrySet()) {
             Path file = sources.resolve(entry.getKey());
             if (isFormattable(file)) {
                 formattable.put(file, entry.getValue());

--- a/tests/build/jenesis/test/BuildExecutorTest.java
+++ b/tests/build/jenesis/test/BuildExecutorTest.java
@@ -142,9 +142,9 @@ public class BuildExecutorTest implements Serializable {
                 checksum = Files.createDirectory(step.resolve("checksum")),
                 output = Files.createDirectory(step.resolve("output"));
         Files.writeString(source.resolve("file"), "foo");
-        HashFunction.write(checksum.resolve("argument.source.properties"), HashFunction.read(source, hash));
+        HashFunction.write(checksum.resolve("argument.source.properties"), HashFunction.read(source, hash, Runnable::run));
         Files.writeString(output.resolve("file"), "foo");
-        HashFunction.write(checksum.resolve("output.properties"), HashFunction.read(output, hash));
+        HashFunction.write(checksum.resolve("output.properties"), HashFunction.read(output, hash, Runnable::run));
         BuildStep buildStep = (_, _, _) -> {
             throw new AssertionError("Did not expect that step is executed");
         };
@@ -165,9 +165,9 @@ public class BuildExecutorTest implements Serializable {
                 checksum = Files.createDirectory(step.resolve("checksum")),
                 output = Files.createDirectory(step.resolve("output"));
         Files.writeString(source.resolve("file"), "foo");
-        HashFunction.write(checksum.resolve("argument.source.properties"), HashFunction.read(source, _ -> new byte[0]));
+        HashFunction.write(checksum.resolve("argument.source.properties"), HashFunction.read(source, _ -> new byte[0], Runnable::run));
         Files.writeString(output.resolve("file"), "bar");
-        HashFunction.write(checksum.resolve("output.properties"), HashFunction.read(output, hash));
+        HashFunction.write(checksum.resolve("output.properties"), HashFunction.read(output, hash, Runnable::run));
         BuildStep buildStep = (_, context, arguments) -> {
             assertThat(context.previous()).exists().isEqualTo(output);
             assertThat(context.next()).isNotEqualTo(output).isDirectory();
@@ -196,9 +196,9 @@ public class BuildExecutorTest implements Serializable {
                 checksum = Files.createDirectory(step.resolve("checksum")),
                 output = Files.createDirectory(step.resolve("output"));
         Files.writeString(source.resolve("file"), "foo");
-        HashFunction.write(checksum.resolve("argument.source.properties"), HashFunction.read(source, hash));
+        HashFunction.write(checksum.resolve("argument.source.properties"), HashFunction.read(source, hash, Runnable::run));
         Files.writeString(output.resolve("file"), "foo");
-        HashFunction.write(checksum.resolve("output.properties"), HashFunction.read(output, hash));
+        HashFunction.write(checksum.resolve("output.properties"), HashFunction.read(output, hash, Runnable::run));
         BuildStep buildStep = new BuildStep() {
             @Override
             public boolean shouldRun(SequencedMap<String, BuildStepArgument> arguments) {
@@ -238,9 +238,9 @@ public class BuildExecutorTest implements Serializable {
                 checksum = Files.createDirectory(step.resolve("checksum")),
                 output = Files.createDirectory(step.resolve("output"));
         Files.writeString(source.resolve("file"), "foo");
-        HashFunction.write(checksum.resolve("argument.source.properties"), HashFunction.read(source, _ -> new byte[0]));
+        HashFunction.write(checksum.resolve("argument.source.properties"), HashFunction.read(source, _ -> new byte[0], Runnable::run));
         Files.writeString(output.resolve("file"), "qux");
-        HashFunction.write(checksum.resolve("output.properties"), HashFunction.read(output, hash));
+        HashFunction.write(checksum.resolve("output.properties"), HashFunction.read(output, hash, Runnable::run));
         BuildStep buildStep = (_, context, arguments) -> {
             assertThat(context.previous()).exists().isEqualTo(output);
             assertThat(context.next()).isNotEqualTo(output).isDirectory();
@@ -269,9 +269,9 @@ public class BuildExecutorTest implements Serializable {
                 checksum = Files.createDirectory(step.resolve("checksum")),
                 output = Files.createDirectory(step.resolve("output"));
         Files.writeString(source.resolve("file"), "foo");
-        HashFunction.write(checksum.resolve("argument.source.properties"), HashFunction.read(source, hash));
+        HashFunction.write(checksum.resolve("argument.source.properties"), HashFunction.read(source, hash, Runnable::run));
         Files.writeString(output.resolve("file"), "qux");
-        HashFunction.write(checksum.resolve("output.properties"), HashFunction.read(output, _ -> new byte[0]));
+        HashFunction.write(checksum.resolve("output.properties"), HashFunction.read(output, _ -> new byte[0], Runnable::run));
         buildExecutor.addSource("source", source);
         buildExecutor.addStep("step", (_, context, arguments) -> {
             assertThat(context.previous()).isNull();

--- a/tests/build/jenesis/test/HashFunctionTest.java
+++ b/tests/build/jenesis/test/HashFunctionTest.java
@@ -23,7 +23,7 @@ public class HashFunctionTest {
     @Test
     public void can_extract_folder() throws IOException {
         Files.writeString(folder.resolve("foo"), "bar");
-        Map<Path, byte[]> checksums = HashFunction.read(folder, _ -> new byte[]{1, 2, 3});
+        Map<Path, byte[]> checksums = HashFunction.read(folder, _ -> new byte[]{1, 2, 3}, Runnable::run);
         assertThat(checksums).containsOnlyKeys(Path.of("foo"));
         assertThat(checksums.get(Path.of("foo"))).isEqualTo(new byte[]{1, 2, 3});
     }
@@ -31,7 +31,7 @@ public class HashFunctionTest {
     @Test
     public void can_extract_nested_folder() throws IOException {
         Files.writeString(Files.createDirectory(folder.resolve("bar")).resolve("foo"), "bar");
-        Map<Path, byte[]> checksums = HashFunction.read(folder, _ -> new byte[]{1, 2, 3});
+        Map<Path, byte[]> checksums = HashFunction.read(folder, _ -> new byte[]{1, 2, 3}, Runnable::run);
         assertThat(checksums).containsOnlyKeys(Path.of("bar/foo"));
         assertThat(checksums.get(Path.of("bar/foo"))).isEqualTo(new byte[]{1, 2, 3});
     }
@@ -40,7 +40,7 @@ public class HashFunctionTest {
     public void can_extract_empty_folder() throws IOException {
         Map<Path, byte[]> checksums = HashFunction.read(folder, _ -> {
             throw new UnsupportedOperationException();
-        });
+        }, Runnable::run);
         assertThat(checksums).isEmpty();
     }
 }


### PR DESCRIPTION
Follow-up from comparing Maven and Jenesis build performance on this repository.

## Measurements (8 cores, JDK 25, warm dependency caches)

| Scenario | Maven (`mvn package`) | Jenesis (`java build/jenesis/Project.java`) |
| --- | --- | --- |
| Cold build (compile + test + jar) | 5m31s | 5m14s |
| No-op rebuild | 5m41s | 6-11s |
| Bytecode-identical edit (trailing newline) | 5m41s | 10s |
| Bytecode-changing edit | ~5m40s | 5m39s |

Both tools are test-execution-bound when tests must run (the suite itself is ~4m50s of either total); the structural difference is everything else. Jenesis skips the test rerun entirely when a recompile reproduces byte-identical output, which Maven cannot observe. The per-invocation fixed cost (~2.5-4s) is the JDK source launcher recompiling the build tool plus JVM warmup, not executor work, and disappears when running a published launcher jar.

## The win

Profiling the executor paths found them already lean: shared upstream hash summaries, lazy checksum encoding, short-circuited consistency checks, 64k digest buffers, buffered properties I/O. The one scalable gap: `HashFunction.read` and `HashFunction.areConsistent` hash every file of a tree sequentially on the calling thread, while every caller has the build executor at hand.

Both now collect the file list in the same deterministic walk order and fan only the digest computation out on the executor (the `Resolver.materializeAll` idiom); returned map order and the strict-consistency guarantee are unchanged - every file is still hashed on every check. On a synthetic 1 GB tree of 256 files: 0.78s sequential to 0.17s parallel (4.6x). On this repository's 24 MB output tree the effect is small; it grows with project size, where source and output hashing is the dominant warm-path cost.

Verified with the full suite (1038 tests), a complete self-build including the network-gated tests, and demo runs on the real virtual-thread executor.