### PR TITLE
Support short-form pins in the POM jenesis.pin comment block

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,9 @@ Two callbacks govern how the build is assembled, and they are pluggable independ
   coordinate) is written in full. The repository is otherwise spelled out (`module`, `maven`); a `module-info.java`
   can therefore pin a Maven coordinate it pulls in transitively (e.g. a non-modular transitive of a named module
   dependency) as `org.foo/bar` (or `main/maven/org.foo/bar` in full) even though its declared dependencies resolve
-  through the `module` repository. A `module`-repository pin's version value may additionally select an artifact
+  through the `module` repository. The grammar - including both abbreviations - is identical for the
+  `module-info.java` `@jenesis.pin` tag and the `pom.xml` `<!--jenesis.pin ... -->` comment block, and a malformed
+  token fails the build in either place rather than being silently ignored. A `module`-repository pin's version value may additionally select an artifact
   classifier with a leading-colon qualifier, `:<classifier>[:<version>]` (e.g.
   `@jenesis.pin org.example.native :windows-x86_64:1.2.3 <algo>/<hash>`, or `:windows-x86_64` alone to leave the
   version floating). The pin stays keyed by the bare module name - the classifier is part of the value, never the

--- a/sources/build/jenesis/maven/MavenPomResolver.java
+++ b/sources/build/jenesis/maven/MavenPomResolver.java
@@ -921,12 +921,30 @@ public class MavenPomResolver implements MavenResolver {
                         if (value.isEmpty()) {
                             continue;
                         }
+                        String key;
                         int firstSlash = token.indexOf('/');
-                        int secondSlash = firstSlash < 1 ? -1 : token.indexOf('/', firstSlash + 1);
-                        if (secondSlash < firstSlash + 2 || secondSlash == token.length() - 1) {
-                            continue;
+                        int secondSlash = firstSlash < 0 ? -1 : token.indexOf('/', firstSlash + 1);
+                        if (firstSlash < 0) {
+                            key = "main/module/" + token;
+                        } else if (secondSlash < 0) {
+                            if (firstSlash < 1 || firstSlash == token.length() - 1) {
+                                throw new IllegalArgumentException("Malformed jenesis.pin token '"
+                                        + token
+                                        + "': expected <module>, <groupId>/<artifactId>,"
+                                        + " or <group>/<repository>/<coordinate>");
+                            }
+                            key = "main/maven/" + token;
+                        } else {
+                            if (firstSlash < 1 || secondSlash == firstSlash + 1
+                                    || secondSlash == token.length() - 1) {
+                                throw new IllegalArgumentException("Malformed jenesis.pin token '"
+                                        + token
+                                        + "': expected <module>, <groupId>/<artifactId>,"
+                                        + " or <group>/<repository>/<coordinate>");
+                            }
+                            key = token;
                         }
-                        entries.put(guard == null ? token : token + "[" + guard + "]", value);
+                        entries.put(guard == null ? key : key + "[" + guard + "]", value);
                     }
                 });
         return entries;

--- a/sources/build/jenesis/maven/PinPom.java
+++ b/sources/build/jenesis/maven/PinPom.java
@@ -180,29 +180,26 @@ public class PinPom implements BuildStep {
             }
             pins.add(new Pin(token, value, guard));
             if (guard != null) {
-                guarded.add(token);
+                guarded.add(expand(token));
             }
         }
         if (guarded.isEmpty()) {
             return List.of();
         }
-        // A key with platform guards keeps every line in place; only the line whose guard
-        // matched the local platform (or the unguarded fallback) is refreshed from the
-        // resolved closure, since this resolution only reflects the local variant.
+        // A coordinate with platform guards keeps every line in place; only the line whose
+        // guard matched the local platform (or the unguarded fallback) is refreshed from the
+        // resolved closure, since this resolution only reflects the local variant. Lines are
+        // matched by their expanded coordinate, so short and full forms refer to the same key.
         for (String key : guarded) {
-            String resolved = qualified.remove(key);
-            if (key.startsWith("main/maven/")) {
-                String fromManaged = managed.remove(key.substring("main/maven/".length()));
-                if (resolved == null) {
-                    resolved = fromManaged;
-                }
-            }
+            String resolved = key.startsWith("main/maven/")
+                    ? managed.remove(key.substring("main/maven/".length()))
+                    : qualified.remove(key);
             Integer fallback = null, matched = null;
             int specificity = 0;
             boolean ambiguous = false;
             for (int index = 0; index < pins.size(); index++) {
                 Pin pin = pins.get(index);
-                if (!pin.token().equals(key)) {
+                if (!expand(pin.token()).equals(key)) {
                     continue;
                 }
                 if (pin.guard() == null) {
@@ -229,11 +226,19 @@ public class PinPom implements BuildStep {
         }
         List<String> preserved = new ArrayList<>();
         for (Pin pin : pins) {
-            if (guarded.contains(pin.token())) {
+            if (guarded.contains(expand(pin.token()))) {
                 preserved.add(pin.token() + " " + pin.value() + (pin.guard() == null ? "" : " [" + pin.guard() + "]"));
             }
         }
         return preserved;
+    }
+
+    private static String expand(String token) {
+        int first = token.indexOf('/');
+        if (first < 0) {
+            return "main/module/" + token;
+        }
+        return token.indexOf('/', first + 1) < 0 ? "main/maven/" + token : token;
     }
 
     private static String renderRequires(SequencedMap<String, String> qualified, List<String> preserved, String indent) {

--- a/tests/build/jenesis/test/maven/MavenProjectTest.java
+++ b/tests/build/jenesis/test/maven/MavenProjectTest.java
@@ -17,6 +17,7 @@ import build.jenesis.maven.MavenRepository;
 import build.jenesis.project.JavaToolchainModule;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 public class MavenProjectTest {
@@ -664,6 +665,67 @@ public class MavenProjectTest {
                 .as("a group-qualified block pin keeps its own group rather than being prefixed with main/")
                 .containsEntry("launcher/maven/build.jenesis/build.jenesis.launcher", "0.2.0 SHA-256/abc");
         assertThat(versions.stringPropertyNames()).noneMatch(name -> name.startsWith("main/maven/launcher"));
+    }
+
+    @Test
+    public void expands_short_form_block_pins_into_the_main_group() throws IOException {
+        Files.writeString(project.resolve("pom.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>group</groupId>
+                    <artifactId>artifact</artifactId>
+                    <version>1</version>
+                    <!--jenesis.pin
+                    org.slf4j/slf4j-api 2.0.16 SHA-256/abc
+                    some.module 1.2.3 SHA-256/def
+                    -->
+                </project>
+                """);
+        Files.writeString(Files.createDirectories(project.resolve("src/main/java")).resolve("source"), "foo");
+        BuildExecutor executor = BuildExecutor.of(build,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+        executor.addModule("maven", new MavenProject(project, "maven", mavenRepository, mavenPomResolver));
+        SequencedMap<String, Path> results = executor.execute(Runnable::run).toCompletableFuture().join();
+        SequencedProperties versions = SequencedProperties.ofFiles(
+                results.get("maven/module-/manifests").resolve(BuildStep.VERSIONS));
+        assertThat(versions)
+                .as("a one-slash short form expands to the main/maven group")
+                .containsEntry("main/maven/org.slf4j/slf4j-api", "2.0.16 SHA-256/abc");
+        assertThat(versions)
+                .as("a bare module short form expands to the main/module group")
+                .containsEntry("main/module/some.module", "1.2.3 SHA-256/def");
+    }
+
+    @Test
+    public void rejects_malformed_block_pin_token() throws IOException {
+        Files.writeString(project.resolve("pom.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>group</groupId>
+                    <artifactId>artifact</artifactId>
+                    <version>1</version>
+                    <!--jenesis.pin
+                    org.slf4j/ 2.0.16
+                    -->
+                </project>
+                """);
+        Files.writeString(Files.createDirectories(project.resolve("src/main/java")).resolve("source"), "foo");
+        BuildExecutor executor = BuildExecutor.of(build,
+                Duration.ZERO,
+                new HashDigestFunction("MD5"),
+                BuildStepHashFunction.ofSerializationDigest("MD5"),
+                BuildExecutorCallback.nop(), false);
+        executor.addModule("maven", new MavenProject(project, "maven", mavenRepository, mavenPomResolver));
+        assertThatThrownBy(() -> executor.execute(Runnable::run).toCompletableFuture().join())
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .rootCause()
+                .hasMessageContaining("Malformed jenesis.pin token")
+                .hasMessageContaining("org.slf4j/");
     }
 
     @Test

--- a/tests/build/jenesis/test/maven/PinPomTest.java
+++ b/tests/build/jenesis/test/maven/PinPomTest.java
@@ -118,6 +118,61 @@ public class PinPomTest {
     }
 
     @Test
+    public void refreshes_short_form_guarded_main_pin_without_duplicating() throws IOException {
+        Path pom = root.resolve("pom.xml");
+        Files.writeString(pom, """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>group</groupId>
+                    <artifactId>artifact</artifactId>
+                    <version>1</version>
+                    <!--jenesis.pin
+                    org.foo/bar 1.0.0 SHA-256/aaa [legacy]
+                    org.foo/bar 2.0.0 SHA-256/bbb
+                    -->
+                </project>
+                """);
+        writeResolved(Map.of("maven/org.foo/bar", "3.0.0 SHA-256/fresh"));
+        String result = run(pom, Platform.of("linux,x86_64,legacy"));
+        assertThat(result).contains("org.foo/bar 3.0.0 SHA-256/fresh [legacy]");
+        assertThat(result).contains("org.foo/bar 2.0.0 SHA-256/bbb");
+        assertThat(result).doesNotContain("SHA-256/aaa");
+        assertThat(result).as("the guarded short-form main pin is not migrated into dependencyManagement")
+                .doesNotContain("<dependencyManagement>");
+        assertThat(result).as("the short form is not duplicated as a full main/maven line")
+                .doesNotContain("main/maven/org.foo/bar");
+    }
+
+    @Test
+    public void updates_only_the_matched_guard_among_several_and_retains_the_rest() throws IOException {
+        Path pom = root.resolve("pom.xml");
+        Files.writeString(pom, """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>group</groupId>
+                    <artifactId>artifact</artifactId>
+                    <version>1</version>
+                    <!--jenesis.pin
+                    kotlin/maven/org.x/y 1.0 SHA-256/win [windows]
+                    kotlin/maven/org.x/y 2.0 SHA-256/leg [legacy]
+                    kotlin/maven/org.x/y 3.0 SHA-256/fb
+                    -->
+                </project>
+                """);
+        writeResolved("kotlin", Map.of("maven/org.x/y", "9.9 SHA-256/fresh"));
+        String result = run(pom, Platform.of("linux,x86_64,legacy"));
+        assertThat(result).as("the matched [legacy] line is refreshed")
+                .contains("kotlin/maven/org.x/y 9.9 SHA-256/fresh [legacy]");
+        assertThat(result).as("the non-matched [windows] line is retained verbatim")
+                .contains("kotlin/maven/org.x/y 1.0 SHA-256/win [windows]");
+        assertThat(result).as("the fallback line is retained verbatim")
+                .contains("kotlin/maven/org.x/y 3.0 SHA-256/fb");
+        assertThat(result).as("the stale [legacy] value is gone").doesNotContain("SHA-256/leg");
+    }
+
+    @Test
     public void updates_matched_fallback_comment_line_and_preserves_guard() throws IOException {
         Path pom = root.resolve("pom.xml");
         Files.writeString(pom, """

--- a/tests/build/jenesis/test/module/PinModuleInfoTest.java
+++ b/tests/build/jenesis/test/module/PinModuleInfoTest.java
@@ -365,6 +365,27 @@ public class PinModuleInfoTest {
     }
 
     @Test
+    public void updates_only_the_matched_guard_among_several_and_retains_the_rest() throws IOException {
+        Path file = root.resolve("module-info.java");
+        Files.writeString(file, """
+                /**
+                 * @jenesis.pin bar :win:1.0 SHA-256/win [windows]
+                 * @jenesis.pin bar :leg:2.0 SHA-256/leg [legacy]
+                 * @jenesis.pin bar 3.0 SHA-256/fb
+                 */
+                module foo {
+                  requires bar;
+                }
+                """);
+        writeResolved(Map.of("module/bar-leg", "9.9 SHA-256/fresh"));
+        String result = run(file, Platform.of("linux,x86_64,legacy"));
+        assertThat(result).contains("@jenesis.pin bar :leg:9.9 SHA-256/fresh [legacy]");
+        assertThat(result).contains("@jenesis.pin bar :win:1.0 SHA-256/win [windows]");
+        assertThat(result).contains("@jenesis.pin bar 3.0 SHA-256/fb");
+        assertThat(result).doesNotContain("SHA-256/leg ");
+    }
+
+    @Test
     public void updates_matched_guard_without_hash() throws IOException {
         Path file = root.resolve("module-info.java");
         Files.writeString(file, """


### PR DESCRIPTION
Brings the `pom.xml` `<!--jenesis.pin ... -->` comment block to parity with `module-info.java` pins, and hardens the platform-guard repin for the POM.

## Short forms (parser)

`MavenPomResolver.toQualifiedDependencies` required the full `<group>/<repository>/<coordinate>` form and **silently dropped** anything with fewer than two slashes, whereas `ModuleInfoParser` expands the abbreviations. It now mirrors module-info exactly:

- bare `<module>` → `main/module/<module>`
- `<groupId>/<artifactId>` → `main/maven/<groupId>/<artifactId>`
- two+ slashes → used as-is
- a malformed token (e.g. `org.slf4j/`) now **throws** instead of being silently ignored

This runs only on the project's own root POM (`extended=true`), so the loud error is safe.

## Guard repin (writer)

`PinPom.preserveGuarded` keyed guarded comment lines by their **raw token**, so a hand-written short-form guarded pin (`org.foo/bar 1.0 [legacy]`) never matched the resolved closure (keyed `main/maven/org.foo/bar`): the line was left unrefreshed *and* the coordinate was duplicated as a separate full-form line. It now keys by the **expanded** coordinate, exactly like `PinModuleInfo`, so:

- the line matching the local platform — and only that line — is refreshed from the resolved closure
- every non-matched guard and the unguarded fallback are retained **verbatim**, in whatever form the user wrote (short or full)
- no duplication, and a guarded `main/maven` pin still stays in the comment rather than migrating into `<dependencyManagement>`

## Tests

- `MavenProjectTest`: `expands_short_form_block_pins_into_the_main_group`, `rejects_malformed_block_pin_token`
- `PinPomTest`: `refreshes_short_form_guarded_main_pin_without_duplicating`, `updates_only_the_matched_guard_among_several_and_retains_the_rest`
- `PinModuleInfoTest`: `updates_only_the_matched_guard_among_several_and_retains_the_rest` (parity check — the module-info side was already correct)

Full suite passes (1049 tests). README grammar updated to state that both abbreviations and the loud error apply equally to the POM comment block.