### PR TITLE
Build performance: README section, benchmark suite, Maven 4 compiler-plugin pin, versions-only pinning mode

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,85 @@
+name: Build performance benchmarks
+
+# On-demand only: build-performance numbers are environment-sensitive, so this is
+# never run automatically. Trigger it from the Actions tab; results are written to
+# a per-OS text file and uploaded as an artifact.
+on:
+  workflow_dispatch:
+    inputs:
+      tables:
+        description: 'Benchmark tables to run (space-separated subset of: launch compile full maven pinning aot all)'
+        default: 'launch compile pinning aot'
+      runs_cold:
+        description: 'Repetitions per cold scenario'
+        default: '5'
+      runs_warm:
+        description: 'Repetitions per warm scenario'
+        default: '3'
+
+# Route Maven Central through the repository variable MAVEN_REPOSITORY_URI when set
+# (the Google Cloud mirror of Central, to avoid Central rate-limiting the runners),
+# falling back to Central itself so an unset variable never becomes an empty URI.
+env:
+  MAVEN_REPOSITORY_URI: ${{ vars.MAVEN_REPOSITORY_URI || 'https://repo1.maven.org/maven2/' }}
+
+jobs:
+  benchmark:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # GraalVM gives both a HotSpot `java` (for the source, precompiled and AOT
+      # scenarios) and `native-image` (for the native launcher column); it also
+      # exports GRAALVM_HOME, which benchmark.sh reads to build the native image.
+      - name: Set up GraalVM JDK 25
+        uses: graalvm/setup-graalvm@329c42c5f4c343bceb505f0b28cc8499bc2bf174 # v1.5.4
+        with:
+          distribution: graalvm
+          java-version: '25'
+
+      # Populate the caches the offline benchmarks rely on: a full Jenesis build
+      # primes its resolution cache, and a full Maven build primes ~/.m2 so the
+      # `-o` (offline) Maven scenarios resolve. Maven is only primed when a table
+      # that runs it is requested.
+      - name: Warm caches
+        shell: bash
+        env:
+          TABLES: ${{ inputs.tables }}
+        run: |
+          java build/jenesis/Project.java build
+          case " $TABLES " in
+            *" compile "*|*" full "*|*" maven "*|*" all "*) mvn -B -ntp package ;;
+          esac
+
+      - name: Run benchmarks
+        shell: bash
+        env:
+          TABLES: ${{ inputs.tables }}
+          RUNS_COLD: ${{ inputs.runs_cold }}
+          RUNS_WARM: ${{ inputs.runs_warm }}
+        run: |
+          out="benchmark-${{ matrix.os }}.txt"
+          {
+            echo "Jenesis build-performance benchmarks"
+            echo "os:     ${{ matrix.os }} (${{ runner.arch }})"
+            echo "tables: $TABLES"
+            echo "runs:   cold=$RUNS_COLD warm=$RUNS_WARM"
+            echo "date:   $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            java -version 2>&1 | sed 's/^/java:   /'
+            echo
+          } | tee "$out"
+          for t in $TABLES; do
+            bash benchmark/benchmark.sh "$t" 2>&1 | tee -a "$out"
+          done
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-${{ matrix.os }}
+          path: benchmark-${{ matrix.os }}.txt
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -240,6 +240,173 @@ which bridge classes across class loaders) needs a full JVM and is not supported
 the precompiled or native launcher whenever the build sources change; this only accelerates launching the
 build, while the project being built is still recompiled by the build graph when its own sources change.
 
+### Building the launcher with Jenesis itself
+
+The native build above invokes `native-image` by hand. Jenesis can also drive it as a build step, the same way it
+drives `javac`, `jlink` or `jpackage`, so the launcher is produced by the build rather than a separate script.
+Because the root `pom.xml` declares `<mainClass>build.jenesis.Project</mainClass>`, the default assembler treats
+`build.jenesis` as a launchable module and, when asked, wires a `native-image` step for it. The reflection that
+`native-image`'s closed-world analysis cannot see is discovered by running the build's own tests under GraalVM's
+tracing agent. Both phases need a GraalVM JDK (or `GRAALVM_HOME` pointed at one):
+
+    # 1. capture: run the tests under the tracing agent, which records the reflection the engine reaches
+    java -Djenesis.observe.native=true build/jenesis/Project.java
+
+    # 2. commit the captured metadata where native-image looks for it (it is packaged into the jar)
+    mkdir -p sources/META-INF/native-image/build.jenesis
+    cp target/build/maven/compose/module/test-module-/produce/assemble/observed/native-image/report/output/reports/native-image/reachability-metadata.json \
+       sources/META-INF/native-image/build.jenesis/
+
+    # 3. build the native launcher through Jenesis (native-image runs over the produced module)
+    java -Djenesis.java.native=true build/jenesis/Project.java
+
+`jenesis.observe.native` attaches `-agentlib:native-image-agent` to the test JVM, so the agent records every
+reflective, JNI, resource and serialization access the 1049 tests exercise (including the `BuildStep` serialization
+the incremental cache depends on) and stages it as a `reports/native-image/` report. Reviewed and copied under
+`sources/META-INF/native-image/`, that file is packaged verbatim into the jar (files under `META-INF/` are copied
+as resources), where `native-image` discovers it without further configuration. `jenesis.java.native` then runs
+`native-image` over the produced launcher, locating the tool through `GRAALVM_HOME`, then `java.home`, then `PATH`,
+and writes the executable under the step's output:
+
+    target/build/maven/compose/module/module-/produce/assemble/native-image/output/native/build.jenesis
+
+Running that binary launches the build with the near-instant startup measured below. This was verified end to end
+on a GraalVM 25 JDK: the agent run produced a 212 KB `reachability-metadata.json`, and the resulting native
+executable launched the build correctly.
+
+The two phases cannot collapse into one build, and the reason is structural rather than a missing convenience. The
+metadata is captured by the *test* module, which `requires build.jenesis` (it tests the main module); the
+`native-image` step lives on the *main* module. For the main module's image to consume the test module's captured
+metadata in the same build, the main module would have to depend on the test module that already depends on it - a
+cycle. So capture and consumption are necessarily separated by the `META-INF/native-image/` hand-off (which also
+serves as the human review point for what reflection gets baked into the closed-world image), exactly as the
+[`demo-35-native-image`](demo/demo-35-native-image) example shows for an application rather than the build tool. The
+only fully automatic alternative would move `native-image` out of the per-module pipeline into a terminal step that
+depends on both the main artifact and the test capture, which the shipped layouts deliberately do not do.
+
+### Build performance
+
+Because every build step is content-hashed and the build itself ships as plain Java source, Jenesis's
+performance profile differs from a plugin-based build, and it shifts again with how the build is launched. The
+figures below build Jenesis itself (130 main sources, 112 test sources, 1049 tests) and compare it against Maven
+on the same machine.
+
+*Conditions.* All wall-clock times are measured externally with `/usr/bin/time` (its `%e` elapsed field), never a
+build tool's own self-report. The machine is an 8-core x86-64 laptop on JDK 25, kept on AC power with the CPU power
+profile pinned to `performance`; the laptop's default `power-saver` profile pins the cores near 1.4 GHz and
+inflates every figure by roughly 2.6x, which is the single largest measurement error to rule out before trusting
+any number. Both tools run with warm dependency caches (`~/.m2` for Maven, `.jenesis/cache` for Jenesis). To keep
+network latency out of the results, the whole matrix was re-run under a hard block - Maven `-o` plus a dead
+HTTP/HTTPS proxy (`127.0.0.1:1`) injected into every JVM via `JAVA_TOOL_OPTIONS`, so any real fetch fails instantly
+rather than adding latency - and each run's network byte delta was recorded: every compile-only, incremental and
+launch build completed with **0 KB transferred** (a passing build under the dead proxy is itself proof it needs no
+network). The one exception is the full build with tests, which moves about 25 KB **symmetrically on both tools**
+(a `maven-metadata.xml` lookup for the `RELEASE`-versioned external tools the test fixtures resolve - PMD,
+Checkstyle, the Scala and Kotlin compilers); that is sub-second against ~270 s of test execution and identical on
+both sides, so it does not bias the comparison. A first build on a fresh machine pays a one-time dependency
+download not shown here. The cold compile figure is the median of five runs and the other compile-only figures the
+median of three; the full builds are run once or twice, being test-bound and barely variable. Maven is 3.9.16
+(Maven 4 is discussed at the end).
+
+The Jenesis build is launched three ways, differing only in how the build engine is loaded:
+
+- *source* - `java build/jenesis/Project.java`, the canonical form, which recompiles the engine every invocation;
+- *precompiled* - `javac` the engine once into `.jenesis/launcher`, then `java -cp .jenesis/launcher build.jenesis.Project`;
+- *native* - `native-image` the launcher once into `./jenesis`.
+
+**Launch overhead** (running `help`, no project work; median of five):
+
+| Launcher    | Overhead     |
+|-------------|--------------|
+| source      | 2.81 s       |
+| precompiled | 0.07 s       |
+| native      | under 0.01 s |
+
+The source launcher recompiles the roughly 313-file engine on every run; removing that is the entire point of
+precompiling or going native. The one-time cost to obtain them is a couple of seconds for the `javac` launcher and
+about 160 s (yielding a 61 MB binary) for the native image, and both must be rebuilt whenever the build sources
+change.
+
+**Compile and package, tests compiled but not run** (`-DskipTests` for Maven, `-Djenesis.test.skip` for Jenesis).
+Both compile the 130 main and 112 test sources and skip only execution, which is the fairest tool-to-tool
+comparison: CPU-bound and network-free. Cold is the median of five runs (tight, within +/- 0.4 s); the rest are the
+median of three:
+
+| Scenario                          | Maven 3 | Jenesis source | Jenesis precompiled | Jenesis native |
+|-----------------------------------|---------|----------------|---------------------|----------------|
+| cold (empty `target/`)            | 11.5 s  | 14.9 s         | 10.6 s              | 12.5 s         |
+| warm no-op (nothing changed)      | 1.6 s   | 6.3 s          | 0.41 s              | 0.06 s         |
+| one-line edit to a main source    | 12.4 s  | 11.8 s         | 3.3 s               | 3.4 s          |
+| spurious `touch` (content same)   | 12.1 s  | 6.3 s          | 0.55 s              | 0.06 s         |
+
+Read cold-to-warm, not only left-to-right. Cold, the precompiled launcher (10.6 s) edges out Maven (11.5 s) and the
+two are otherwise close: Jenesis's extra per-build work (resolving the dependency graph, emitting a POM, metadata
+and an inventory, content-hashing every input and output) is repaid by compiling each module in a single in-process
+`javac` invocation. The source launcher adds the per-run engine recompile on top (14.9 s). Warm and incremental are where content-hashing
+separates them. A no-op rebuild is 0.06 to 0.41 s on a precompiled or native launcher, because every step's input
+hash matches its recorded output and nothing re-runs, while Maven still walks its lifecycle in ~1.6 s. On any change
+to a main source - a real one-line edit, or even a content-preserving `touch` - Maven's mtime-based staleness
+recompiles the main sources *and* all 112 test sources (~12 s), because test compilation depends on the main output.
+Jenesis keys on content instead: a `touch` that does not change the bytes is a near no-op (0.06 s native), and a
+real edit recompiles only the module that changed (3.3 s precompiled), leaving the unaffected module's compiled
+tests cached.
+
+Flight-recorder profiles (`-XX:StartFlightRecording=settings=profile`) confirm where the differences come from.
+In the source-launcher cold build the hottest methods are all in `com.sun.tools.javac` (`Type.hasTag`,
+`Resolve.instantiate`, `Check.checkType`): it is compiler-bound, and it compiles the 313-file engine on top of the
+project's own sources. The precompiled-launcher cold build is also compiler-bound but only for the project sources -
+the engine is already compiled - which is the ~4 s difference between them. In the warm no-op build the compiler
+disappears from the profile entirely; the hottest methods are `sun.security.provider.DigestBase` and file
+I/O, because the only work left is content-hashing step inputs and outputs to confirm nothing changed. That digest
+is the incremental cache's `jenesis.executor.digest`, MD5 by default (`DigestBase` is the shared base class; the
+samples are MD5's compression), and is deliberately distinct from the SHA-256 used for dependency-pinning
+checksums, which a warm build does not touch. That is the incremental engine made visible: a warm rebuild hashes,
+it does not compile.
+
+Two things about the native launcher are worth explaining. It is the fastest to *launch* and the most
+*reproducible* (ahead-of-time compiled, so no JIT warm-up, where the JVM launchers vary run to run with JIT and the
+CPU's sustained clock - it floated between 3.3 and 3.7 GHz across sessions here), yet it is the *slowest of the
+Jenesis launchers on a cold build* (12.5 s, behind the precompiled 10.6 s). That is not a contradiction: a native
+image has no in-process JDK tools, so the build detects the native runtime and forks an external `javac` (and
+`jar`) process instead of calling the compiler in-process through `ToolProvider`. A cold build, which actually
+compiles, pays that process-fork plus a cold `javac` JVM that shares no JIT state with the build, which is the ~2 s
+it trails the precompiled launcher by. A warm no-op compiles nothing, so the fork never happens and the native
+binary's instant startup (no JVM to boot) makes it the quickest of all - the 0.06 s in the warm row. In short:
+forking `javac` costs the native launcher on compile-heavy runs and its zero startup wins on cache-hit runs.
+
+**Full build, all 1049 tests** (warm caches; the ~25 KB symmetric metadata fetch noted under *Conditions* applies
+here and only here):
+
+| Scenario                         | Maven 3 | Jenesis |
+|----------------------------------|---------|---------|
+| cold                             | 268 s   | 270 s   |
+| warm no-op (nothing changed)     | 279 s   | 6.6 s   |
+
+Cold, the two land within one percent: the build is dominated by running 1049 integration tests that drive external
+tools (PMD, Checkstyle, the Scala and Kotlin compilers, and so on), which is process- and IO-bound and essentially
+independent of the build tool - it barely moved when the CPU was unthrottled from 1.4 to 3.6 GHz. The warm no-op
+row is where they diverge by more than an order of magnitude. Maven's surefire re-runs the entire suite on every
+invocation, so a rebuild with nothing changed still costs the full 279 s; Jenesis content-hashes each test step's
+inputs - the compiled classes under test and their dependency closure - and skips the step when that hash is
+unchanged, so a no-op rebuild is about 6.6 s. This is the property that compounds in multi-module builds: a test
+step re-runs only when the artifacts it depends on actually change, so editing one module re-tests that module and
+its dependents while every unaffected module keeps its cached test result. The single-project measurement here is
+the floor of that effect; the more modules a build carries, the larger the share of the suite a typical change
+leaves untouched. (The ~1 % cold gap was checked, not assumed: byte counters put both tools at the same ~25 KB of
+metadata I/O, and an earlier Jenesis cold run that had measured 442 s - making Maven look intrinsically faster -
+did not reproduce once instrumented (re-measured: 270 s). That spike was the first test-running build of its
+session warming the external-tool cache, after which the next tool inherited it; with the tool cache warm on both
+sides the cold builds are equal.)
+
+**Maven 3 versus Maven 4.** The project's `pom.xml` pins `maven-compiler-plugin` to 3.15.0 in `<pluginManagement>`,
+which both Maven versions honour; Maven 3.9.16 already selects that version by default, while Maven 4.0.0-rc-5 would
+otherwise bind the older 3.13.0, whose bundled ASM rejects Java 25 bytecode (`Unsupported class file major version
+69`), so the pin is what lets Maven 4 compile Java 25 at all. With it in place, the two are equivalent on real
+builds: measured back to back, a cold compile lands within run-to-run noise of Maven 3, and Maven 4-rc5 only adds
+about 0.9 s of fixed CLI startup overhead, visible just on near-empty rebuilds. The tables above were measured with
+Maven 3.9.16. Jenesis sidesteps the plugin question entirely: it compiles through the JDK's own
+`javac` by way of `ToolProvider`, with no intermediate bytecode-analysis layer that can lag the JDK.
+
 ### Selectors
 
 `Project.main(args)` and `Project.build(args)` accept selector strings as positional arguments. The canonical
@@ -1623,7 +1790,7 @@ The following system properties and environment variables tune the build at laun
 | `jenesis.format.java`, `jenesis.format.rewrite`, `jenesis.format.<tool>` | system property | Read by `InferredSourceFormattingModule` (wired as the per-module `format` step). `jenesis.format.java=google\|palantir` selects a Java formatter - a Java formatter has no config file to infer from, so unset runs none; `.javaFormatter(GOOGLE\|PALANTIR)` is the in-code equivalent. `jenesis.format.ktlint` / `jenesis.format.scalafmt` (each default `true`) switch off the ktlint / scalafmt formatters, which otherwise activate from `.editorconfig` / `.scalafmt.conf`. `jenesis.format.rewrite` (default `false`) flips the whole chain from verify mode (a CI gate that fails on an unformatted source without writing it) to rewriting sources in place (it sets `.verify(false)` on each formatter). Default: no Java formatter, ktlint/scalafmt on, verify mode. |
 | `jenesis.observe.jacoco` | system property | Read by `InferredTestObservationModule` (wired as the per-module `observed` step that wraps the test run). When `true`, it adds JaCoCo as a coverage agent that `-javaagent`-attaches to the test JVM and writes `jacoco.exec`, which the `JaCoCoModule` then renders into an HTML/XML report under `reports/jacoco/`. The `.jacoco(boolean)` wither sets it directly in code. Default `false` (no observation agent, the test run is unwrapped). |
 | `jenesis.observe.native` | system property | Read by `InferredTestObservationModule`, the GraalVM counterpart of `jenesis.observe.jacoco`. When `true`, it adds the `NativeImageAgent` engine, which `-agentlib:native-image-agent=config-output-dir=...`-attaches the GraalVM tracing agent to the test JVM so it records the reflection, JNI, resource, proxy and serialization the tests exercise. The agent ships in the GraalVM runtime (no coordinate to resolve), so the build must run on a GraalVM JDK (or with `GRAALVM_HOME` set, as the test JVM inherits the build's `java.home`); on a stock JDK the test run fails to load the agent. `NativeImageAgentModule` then stages the captured config (`reachability-metadata.json` and friends) as a report under `reports/native-image/`, ready to commit into `META-INF/native-image/` where `native-image` (`jenesis.java.native`) auto-discovers it. The `.nativeImage(boolean)` wither sets it directly in code. Default `false`. |
-| `jenesis.dependency.pin` | system property | A pinning mode - `strict` or `ignore` (unset is the lenient default). `strict` makes every `Dependencies` step the project wires (through the layouts' `MavenProject.make`/`ModularProject.make`, and through `InferredMultiProjectAssembler`'s `TestModule`) fail the build with an `IllegalStateException` for any resolved coordinate that has no checksum pinned in `requires.properties` - locking the build down so every artifact has to come with a SHA pin from a `pom.xml` `<!--Checksum/...-->` comment or a `@jenesis.pin <group>/<repository>/<coordinate> <version> <algorithm>/<hex>` Javadoc tag. `ignore` is the opposite: every Jenesis pin (managed version and checksum) is dropped, so versions float to the latest the repository serves and checksums are not verified; run the `pin` step under it on a trusted machine to refresh the pinned closure to the latest versions and freshly computed checksums. Unset applies existing pins but tolerates missing ones. The mode is a `Pinning` enum whose **default value is resolved from this property**: `Project`'s default constructor reads it once via `Pinning.fromProperty()` (a bare `Project()` is pinned according to `jenesis.dependency.pin`), and that value is threaded down through `MavenProject.make` / `ModularProject.make` / `ProjectModuleDescriptor` / `InferredMultiProjectAssembler` / `TestModule` into every `Dependencies`, so a user never has to remember to propagate it. The `pinning(...)` withers override that default - `Project.pinning(Pinning.STRICT)` to lock down or `Project.pinning(Pinning.IGNORE)` to opt out - and the override (including an explicit `null`, which stays lenient regardless of the property) wins all the way down; `Dependencies` also takes it directly (`new Dependencies(repositories, resolvers).pinning(Pinning.STRICT)`). |
+| `jenesis.dependency.pin` | system property | A pinning mode - `strict`, `versions`, or `ignore` (unset is the lenient default). `strict` makes every `Dependencies` step the project wires (through the layouts' `MavenProject.make`/`ModularProject.make`, and through `InferredMultiProjectAssembler`'s `TestModule`) fail the build with an `IllegalStateException` for any resolved coordinate that has no checksum pinned in `requires.properties` - locking the build down so every artifact has to come with a SHA pin from a `pom.xml` `<!--Checksum/...-->` comment or a `@jenesis.pin <group>/<repository>/<coordinate> <version> <algorithm>/<hex>` Javadoc tag. `ignore` is the opposite: every Jenesis pin (managed version and checksum) is dropped, so versions float to the latest the repository serves and checksums are not verified; run the `pin` step under it on a trusted machine to refresh the pinned closure to the latest versions and freshly computed checksums. `versions` is in between: it keeps the managed versions but strips their checksums before the `Resolver` runs, so the build selects exactly the pinned version without validating any artifact digest - useful to pin versions for reproducibility without committing or maintaining checksums (and it disables the per-artifact SHA validation that the resolver otherwise performs when a checksum is pinned). Unset applies existing pins but tolerates missing ones. The mode is a `Pinning` enum whose **default value is resolved from this property**: `Project`'s default constructor reads it once via `Pinning.fromProperty()` (a bare `Project()` is pinned according to `jenesis.dependency.pin`), and that value is threaded down through `MavenProject.make` / `ModularProject.make` / `ProjectModuleDescriptor` / `InferredMultiProjectAssembler` / `TestModule` into every `Dependencies`, so a user never has to remember to propagate it. The `pinning(...)` withers override that default - `Project.pinning(Pinning.STRICT)` to lock down or `Project.pinning(Pinning.IGNORE)` to opt out - and the override (including an explicit `null`, which stays lenient regardless of the property) wins all the way down; `Dependencies` also takes it directly (`new Dependencies(repositories, resolvers).pinning(Pinning.STRICT)`). |
 | `jenesis.platform.<token>` | system property | Adds (`=true`) or removes (`=false`) a single platform token, where the active platform starts from the detected operating system (`windows`/`linux`/`macos`) and chipset (`x86_64`/`aarch64`). The token set is read once by `Platform`'s no-arg constructor (a value record) when `MavenProject` / `ModularProject` / `PinModuleInfo` / `PinPom` are constructed, and threaded into the manifests step where it selects which platform-guarded pin lines apply (a `@jenesis.pin ... [<token>,...]` Javadoc tag, or a guarded line in a `pom.xml`'s `<!--jenesis.pin ... -->` block): a guard applies when all its tokens are in the active set, the most specific match wins, the unguarded line for the same coordinate is the fallback. `=true` activates a custom flavor (`-Djenesis.platform.fips=true` selects a `[fips]` guard on top of the real machine), `=false` disables a detected default (`-Djenesis.platform.linux=false -Djenesis.platform.windows=true` cross-resolves a Windows closure from a Linux host). The platform is part of the manifests step's serialized cache identity, so changing it re-runs exactly the affected selection; an in-code build overrides it wholesale through the `platform(Platform)` builder method. |
 | `jenesis.project.digest` | system property | Content digest algorithm threaded through the build as the project's `HashDigestFunction` (default `SHA-256`). Used by `PinPom` / `PinModuleInfo` to recompute checksums over the resolved jar artifacts during the `pin` step - pin always rehashes whatever is sitting in the upstream `artifacts/` folders, so the pinned `<!--Checksum/...-->` / `@jenesis.pin` lines always reflect the bytes the build actually used. (The intra-project sibling-artifact fingerprint that `MultiProjectDependencies` writes into `requires.properties` is instead the build executor's own per-file checksum, so it follows `jenesis.executor.digest`, not this property.) Any `MessageDigest` algorithm name is accepted (`SHA-512`, `SHA-1`, etc.). |
 | `jenesis.project.version` | system property   | When set, stamps the version onto every artifact this build produces. It is appended last into every per-module `metadata.properties` (after the framework defaults and the project-root override file), so it overrides the `version` from either layer. `Javac` passes `--module-version <V>` when compiling a `module-info.java`, so the produced `module-info.class` carries it as `Module.version` (and downstream consumers automatically pick it up as `compiledVersion` on their `requires` directives). `Pom` writes it into `<version>`; dependency versions are unaffected. `MavenRepositoryStaging` reads coordinates from the produced `pom.xml`, so the staged folder path, artifact filenames and `MavenRepositoryExport`'s `maven-metadata-local.xml` follow along. |

--- a/README.md
+++ b/README.md
@@ -212,28 +212,42 @@ that recompile. Precompile once with `javac` and run from the classes:
 Or ahead-of-time compile that launcher with GraalVM `native-image` for near-instant startup. Two things
 matter for the native build:
 
-- A native image has no in-process JDK tools, so `ProcessHandler.Factory.of()` detects the native-image
-  runtime (via the `org.graalvm.nativeimage.imagecode` system property) and defaults to the `FORK` factory,
-  forking the JDK `javac`/`jar` instead. Keep a JDK on `JAVA_HOME`/`PATH` at runtime.
+- **How the image runs the JDK tools.** A bare native image has no in-process JDK tools, so
+  `ProcessHandler.Factory.of()` detects the native-image runtime (via the `org.graalvm.nativeimage.imagecode`
+  system property) and forks `javac`/`jar` from a JDK on `JAVA_HOME`/`PATH`. Adding `--add-modules
+  jdk.compiler,jdk.jartool` to the `native-image` command keeps `javac` and `jar` *inside* the image;
+  `Factory.of()` then sees that `javac` is present and runs the tools in-process, with no per-compile process
+  fork. In-process is markedly faster - the ahead-of-time-compiled `javac` has no JVM startup and no JIT warm-up -
+  so it is the form to prefer; the [Build performance](#build-performance) section measures a cold build at ~6 s
+  in-process against ~13 s forking. (`-Djenesis.process.factory=tool|fork` overrides the choice.) A JDK on
+  `JAVA_HOME` is still required either way - the build resolves its tool home from it, and `javac --release` reads
+  that JDK's symbol files - so this trades the fork's process-spawn cost for speed, not the JDK dependency itself.
 - The incremental cache serializes every `BuildStep` to key it, so that a changed step configuration (for
   example the `jenesis.test.filter` filter) invalidates that step. That serialization needs native-image
   reachability metadata, which is captured from a real build with the native-image agent.
 
-Putting it together (after the `javac` precompile above):
+Putting it together (after the `javac` precompile above), on a GraalVM JDK:
 
-    # capture metadata from a representative build (process mode, so the forked-tool steps are recorded)
-    java -Djenesis.process.factory=fork \
+    # capture metadata from a representative build, running the tools in-process so javac/jar are recorded
+    java -Djenesis.process.factory=tool \
         -agentlib:native-image-agent=config-output-dir=.jenesis/native-config \
         -cp .jenesis/launcher build.jenesis.Project build
 
-    # build the native launcher with that metadata
-    native-image --no-fallback \
+    # build the launcher with javac/jar kept in the image, so the build compiles in-process
+    native-image --no-fallback --add-modules jdk.compiler,jdk.jartool \
+        -H:IncludeResourceBundles=com.sun.tools.javac.resources.compiler,com.sun.tools.javac.resources.javac,com.sun.tools.javac.resources.ct,sun.tools.jar.resources.jar \
         -H:ConfigurationFileDirectories=.jenesis/native-config \
         -cp .jenesis/launcher build.jenesis.Project jenesis
 
-    # run it; process mode is auto-detected, no flags needed
-    ./jenesis [selectors...]
+    # run it; in-process tools are auto-detected, no factory flag needed (a JDK on JAVA_HOME is still required)
+    JAVA_HOME=/path/to/jdk ./jenesis [selectors...]
 
+The `-H:IncludeResourceBundles` flag is essential, not optional: the agent only records the message bundles a
+captured compile happened to load, so without forcing javac's bundles into the image the in-process compiler dies
+with a `MissingResourceException` (`JavacMessages.getBundles`) the first time it formats a diagnostic it had not
+recorded. For the smaller fork-based image instead, drop `--add-modules` and `-H:IncludeResourceBundles` and
+capture with
+`-Djenesis.process.factory=fork`; it then forks `javac`/`jar` from a JDK on `PATH` at run time.
 Capture the metadata from builds that exercise every layout and step you use, custom steps included, since it
 only covers what the agent run reached. Loading foreign build modules (`InternalModule` / `ExternalModule`,
 which bridge classes across class loaders) needs a full JVM and is not supported in a native image. Rebuild
@@ -334,10 +348,14 @@ median of three:
 
 | Scenario                          | Maven 3 | Jenesis source | Jenesis precompiled | Jenesis native |
 |-----------------------------------|---------|----------------|---------------------|----------------|
-| cold (empty `target/`)            | 11.5 s  | 14.9 s         | 10.6 s              | 12.5 s         |
+| cold (empty `target/`)            | 11.5 s  | 14.9 s         | 10.6 s              | 6.8 s          |
 | warm no-op (nothing changed)      | 1.6 s   | 6.3 s          | 0.41 s              | 0.06 s         |
-| one-line edit to a main source    | 12.4 s  | 11.8 s         | 3.3 s               | 3.4 s          |
+| one-line edit to a main source    | 12.4 s  | 11.8 s         | 3.3 s               | 0.90 s         |
 | spurious `touch` (content same)   | 12.1 s  | 6.3 s          | 0.55 s              | 0.06 s         |
+
+The `native` column is the in-process build (`--add-modules jdk.compiler,jdk.jartool`, see below); a bare native
+image that forks `javac` instead is slower cold (~12.5 s) and is the variant to reach for only when a smaller
+image matters more than build speed.
 
 Read cold-to-warm, not only left-to-right. Cold, the precompiled launcher (10.6 s) edges out Maven (11.5 s) and the
 two are otherwise close: Jenesis's extra per-build work (resolving the dependency graph, emitting a POM, metadata
@@ -363,16 +381,23 @@ samples are MD5's compression), and is deliberately distinct from the SHA-256 us
 checksums, which a warm build does not touch. That is the incremental engine made visible: a warm rebuild hashes,
 it does not compile.
 
-Two things about the native launcher are worth explaining. It is the fastest to *launch* and the most
-*reproducible* (ahead-of-time compiled, so no JIT warm-up, where the JVM launchers vary run to run with JIT and the
-CPU's sustained clock - it floated between 3.3 and 3.7 GHz across sessions here), yet it is the *slowest of the
-Jenesis launchers on a cold build* (12.5 s, behind the precompiled 10.6 s). That is not a contradiction: a native
-image has no in-process JDK tools, so the build detects the native runtime and forks an external `javac` (and
-`jar`) process instead of calling the compiler in-process through `ToolProvider`. A cold build, which actually
-compiles, pays that process-fork plus a cold `javac` JVM that shares no JIT state with the build, which is the ~2 s
-it trails the precompiled launcher by. A warm no-op compiles nothing, so the fork never happens and the native
-binary's instant startup (no JVM to boot) makes it the quickest of all - the 0.06 s in the warm row. In short:
-forking `javac` costs the native launcher on compile-heavy runs and its zero startup wins on cache-hit runs.
+The native launcher leads the table, and why is worth unpacking. It is built with `--add-modules
+jdk.compiler,jdk.jartool` (see [Faster launch](#faster-launch-precompiling-and-native-images)), which keeps `javac`
+and `jar` *inside* the image so `Factory.of()` runs them in-process. The ahead-of-time-compiled `javac` reaches
+full speed instantly - no JVM to boot, no JIT warm-up - so it wins every row: a cold build in ~6.8 s (under the
+precompiled launcher's 10.6 s and Maven's 11.5 s), a one-line edit in ~0.9 s (the changed module recompiled by an
+already-hot AOT compiler, against the precompiled launcher's 3.3 s), and the warm and `touch` no-ops at ~0.06 s
+(just the MD5 hash check, with no JVM to start). Its times are also the most *reproducible*: being AOT they barely
+move run to run, where the JVM launchers drift with JIT and the CPU's 3.3-3.7 GHz clock.
+
+Two caveats come with it. A native image is closed-world, so its reachability metadata must be complete - and the
+agent only records the message bundles a training compile happened to load, so without `-H:IncludeResourceBundles`
+for javac's and jar's bundles the in-process compiler dies at run time with a `MissingResourceException`
+(`JavacMessages.getBundles`); the flag forces them in and makes it deterministic. And a *bare* native image,
+without `--add-modules`, has no in-process JDK tools and forks an external `javac` instead - that variant is the
+slowest cold (~12.5 s, paying a process fork plus a cold `javac` JVM with no shared JIT state) and earns its keep
+only when a smaller image and reusing the machine's JDK matter more than build speed. A JDK on `JAVA_HOME` is
+required either way (`javac --release` reads its symbol files).
 
 **Full build, all 1049 tests** (warm caches; the ~25 KB symmetric metadata fetch noted under *Conditions* applies
 here and only here):
@@ -381,6 +406,11 @@ here and only here):
 |----------------------------------|---------|---------|
 | cold                             | 268 s   | 270 s   |
 | warm no-op (nothing changed)     | 279 s   | 6.6 s   |
+
+The launcher variant is omitted here on purpose. This table is test-bound, and which launcher starts the build
+(source, precompiled, or native) only moves the few seconds of launch-and-compile against ~270 s of tool-driven
+test execution; the native launcher's win does not apply, and running the 1049-test integration suite *inside* a
+native image (JUnit plus the forked external tools, all closed-world) is impractical, so the JVM launcher is used.
 
 Cold, the two land within one percent: the build is dominated by running 1049 integration tests that drive external
 tools (PMD, Checkstyle, the Scala and Kotlin compilers, and so on), which is process- and IO-bound and essentially

--- a/README.md
+++ b/README.md
@@ -399,6 +399,23 @@ slowest cold (~12.5 s, paying a process fork plus a cold `javac` JVM with no sha
 only when a smaller image and reusing the machine's JDK matter more than build speed. A JDK on `JAVA_HOME` is
 required either way (`javac --release` reads its symbol files).
 
+**A JVM AOT cache, without GraalVM (JDK 25).** The precompiled launcher can also be sped up on a plain JVM with
+JDK 25's AOT cache (JEP 514/515): a *recording run* captures the classes the build loads and links, plus JIT
+method profiles, into a cache that later runs memory-map in. It is a smaller, lower-effort win than a native image
+- measured here a cold compile goes 10.8 s to 9.5 s and a warm no-op 0.42 s to 0.34 s - because the cache
+front-loads class loading and warm-up but the JVM still interprets-then-JITs `javac`, where the native image's
+`javac` is machine code from the first instruction. Two practicalities decide whether it works: the engine must be
+a *jar*, not an exploded class directory (CDS/AOT refuses a non-empty directory on the classpath), and the cache
+comes from a training run:
+
+    jar --create --file launcher.jar -C .jenesis/launcher .
+    java -XX:AOTCacheOutput=build.aot -cp launcher.jar build.jenesis.Project build   # recording run
+    java -XX:AOTCache=build.aot       -cp launcher.jar build.jenesis.Project build   # subsequent runs
+
+The same mechanism would trim the startup and early warm-up off the test JVM, but the full build's test phase is
+dominated by long-running and forked external tools rather than JVM warm-up, so the effect there is small.
+`benchmark/benchmark.sh aot` reproduces the launcher figures above.
+
 **Full build, all 1049 tests** (warm caches; the ~25 KB symmetric metadata fetch noted under *Conditions* applies
 here and only here):
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -54,10 +54,12 @@ These controls are what make the comparison fair; they are the conclusions of a 
 Notes on the figures
 ---------------------
 
-- The `native` launcher is the fastest to launch and the most reproducible (ahead-of-time, no JIT warm-up) but
-  the slowest Jenesis launcher on a *cold* build, because a native image has no in-process JDK tools and forks an
-  external `javac` instead of compiling through `ToolProvider`; a warm no-op compiles nothing, so its zero
-  startup wins instead.
+- The `native` launcher this script builds carries `jdk.compiler`/`jdk.jartool` (`--add-modules`) and forces
+  javac's and jar's message bundles in (`-H:IncludeResourceBundles`, without which the in-process compiler fails
+  non-deterministically on an un-recorded bundle), so it runs `javac` in-process; with the ahead-of-time-compiled
+  compiler - no JVM startup, no JIT warm-up - it is the fastest configuration measured here, cold and warm. A bare
+  native image without those modules has no in-process JDK tools and forks an external `javac`, making it the
+  slowest on a cold build instead (the `jenesis.process.factory=tool|fork` property forces either path).
 - `pin=versions` (checksums stripped, versions kept) shows no measurable speedup: the warm hot path is the
   incremental cache's MD5 hashing, and the SHA-256 artifact validation it removes runs only on a cold
   `Dependencies` step and is negligible.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,66 @@
+Build-performance benchmarks
+============================
+
+`benchmark.sh` reproduces the numbers in the README's [Build performance](../README.md#build-performance)
+section. It compares Maven against the three ways the Jenesis build is launched (source, `javac`-precompiled,
+and `native-image`) across launch overhead, compile-and-package, full builds, Maven 3 vs Maven 4, and the
+dependency-pinning modes.
+
+Running
+-------
+
+    benchmark/benchmark.sh compile     # one table
+    benchmark/benchmark.sh all         # every table
+
+Subcommands: `launch`, `compile`, `full`, `maven`, `pinning`, `all`.
+
+Configuration (environment variables, all optional):
+
+| Variable       | Default        | Purpose                                                              |
+|----------------|----------------|----------------------------------------------------------------------|
+| `JAVA_HOME`    | java on `PATH` | JDK 25+ for the Jenesis and Maven builds                             |
+| `MVN`          | `mvn`          | Maven 3 launcher                                                     |
+| `MVN4`         | unset          | Maven 4 launcher; the `maven` table is skipped without it           |
+| `GRAALVM_HOME` | unset          | GraalVM 25+; the native launcher is skipped without it              |
+| `RUNS_COLD`    | `5`            | repetitions for cold builds                                          |
+| `RUNS_WARM`    | `3`            | repetitions for warm and incremental builds                         |
+
+The script prepares what it needs: it precompiles the engine into `.jenesis/launcher` for the precompiled
+launcher, and (when `GRAALVM_HOME` is set) captures reachability metadata and builds a native launcher once.
+
+Methodology
+-----------
+
+These controls are what make the comparison fair; they are the conclusions of a long measurement exercise.
+
+- **External timing.** Wall-clock comes from `/usr/bin/time` (its `%e` field), never a build tool's own
+  "BUILD SUCCESS in N s" line. The cold figure is the median of `RUNS_COLD`, the rest of `RUNS_WARM`.
+- **CPU power profile.** Run on a `performance` profile. A laptop's default `power-saver` pins the cores low
+  (here ~1.4 GHz vs ~3.6 GHz) and inflates every figure ~2.6x; the script warns if the profile is not
+  `performance`. Keep the machine on AC and otherwise idle.
+- **Warm caches, and network proven absent.** Both tools run with warm dependency caches (`~/.m2`,
+  `.jenesis/cache`). Each run records the host network byte delta and prints `net<=NKB`; with warm caches the
+  compile, incremental and launch builds transfer **0 KB**. The only exception is the full build with tests,
+  which makes a ~25 KB `maven-metadata.xml` lookup for the `RELEASE`-versioned external test tools - the same on
+  both tools - so the `full` table needs the network and does not assert zero bytes.
+- **Like-for-like work.** Maven runs with `-DskipTests`, which compiles the test sources but skips executing
+  them; Jenesis's `-Djenesis.test.skip` likewise compiles the test module and skips only the runner. Both
+  therefore compile the same 130 main + 112 test sources. (Maven's `-Dmaven.test.skip=true` would skip compiling
+  the tests entirely and is *not* comparable.) The full table runs the real ~1049-test suite on both.
+- **First-run caveat.** A from-scratch machine pays one-time dependency and external-tool downloads the warm
+  numbers exclude. In particular, the first test-running build of a session populates the external-tool cache,
+  so when comparing cold full builds make sure that cache is warm on both sides first.
+
+Notes on the figures
+---------------------
+
+- The `native` launcher is the fastest to launch and the most reproducible (ahead-of-time, no JIT warm-up) but
+  the slowest Jenesis launcher on a *cold* build, because a native image has no in-process JDK tools and forks an
+  external `javac` instead of compiling through `ToolProvider`; a warm no-op compiles nothing, so its zero
+  startup wins instead.
+- `pin=versions` (checksums stripped, versions kept) shows no measurable speedup: the warm hot path is the
+  incremental cache's MD5 hashing, and the SHA-256 artifact validation it removes runs only on a cold
+  `Dependencies` step and is negligible.
+- Maven 4.0.0-rc-5 needs the `maven-compiler-plugin` pin the project's `pom.xml` already carries (its default
+  3.13.0 cannot read Java 25 bytecode); with it, Maven 3 and 4 are equivalent bar ~0.9 s of Maven 4 startup
+  overhead.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -29,6 +29,19 @@ Configuration (environment variables, all optional):
 The script prepares what it needs: it precompiles the engine into `.jenesis/launcher` for the precompiled
 launcher, and (when `GRAALVM_HOME` is set) captures reachability metadata and builds a native launcher once.
 
+It is `bash` (not POSIX `sh`) and runs on Linux, macOS and Windows (Git Bash). Where GNU `time` is absent
+(macOS, Windows) it falls back to the shell's `time` keyword for wall-clock, and where `/proc/net/dev` is
+absent it omits the `net<=NKB` column rather than asserting zero bytes.
+
+Continuous integration
+----------------------
+
+The `Build performance benchmarks` GitHub Action (`.github/workflows/benchmark.yml`) runs these tables on
+Linux, macOS and Windows on demand: trigger it from the Actions tab, optionally choosing which tables and how
+many repetitions, and it uploads a `benchmark-<os>.txt` per runner. Runner figures are noisier than a
+controlled local machine (shared, virtualized cores), so treat them as cross-platform smoke and relative
+comparisons rather than the headline numbers.
+
 Methodology
 -----------
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -12,7 +12,8 @@ Running
     benchmark/benchmark.sh compile     # one table
     benchmark/benchmark.sh all         # every table
 
-Subcommands: `launch`, `compile`, `full`, `maven`, `pinning`, `all`.
+Subcommands: `launch`, `compile`, `full`, `maven`, `pinning`, `aot`, `all`. (`aot` measures a JDK 25 AOT cache
+for the precompiled launcher - JEP 514/515 - via a recording run; it needs JDK 25+.)
 
 Configuration (environment variables, all optional):
 

--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -53,7 +53,6 @@ check_env() {
 
 rxtx() { awk -F'[: ]+' '/eth|wl|en|wlp|enp|eno/{rx+=$3;tx+=$11} END{print rx+0" "tx+0}' /proc/net/dev; }
 
-# timeit "<command>" -> echoes "wall_seconds rx_kb tx_kb rc"
 timeit() {
   local b0 b1; b0=$(rxtx)
   /usr/bin/time -f "$TFMT" -o "$TF" bash -c "$1" >"$LOG" 2>&1; local rc=$?
@@ -66,7 +65,6 @@ median() { # reads numbers on stdin, prints median
   sort -n | awk '{a[NR]=$1} END{print (NR%2)?a[(NR+1)/2]:(a[NR/2]+a[NR/2+1])/2}'
 }
 
-# bench <label> <runs> <per-run-setup> <timed-cmd>
 bench() {
   local label="$1" runs="$2" setup="$3" cmd="$4" i walls="" worst=0
   printf '%-26s ' "$label"
@@ -81,7 +79,6 @@ bench() {
   printf 'median %6.2fs  (n=%s, net<=%sKB)\n' "$(printf '%s' "$walls" | median)" "$runs" "$worst"
 }
 
-# warm variant: establish state once (untimed), then time N runs with no further setup
 bench_warm() {
   local label="$1" runs="$2" warmup="$3" cmd="$4" i walls="" worst=0
   bash -c "$warmup" >/dev/null 2>&1
@@ -107,16 +104,11 @@ build_native() {
   [ -n "$GRAALVM_HOME" ] || { warn "GRAALVM_HOME not set - skipping the native launcher"; return 1; }
   build_launcher
   note "Capturing reachability metadata and building the native launcher (one-off)"
-  # Capture with the tools in-process so javac/jar are recorded, and keep jdk.compiler/jdk.jartool in the image:
-  # Factory.of() then runs the compiler in-process (no fork), which is markedly faster on a cold build.
   local cfg; cfg="$(mktemp -d)"
   "$GRAALVM_HOME/bin/java" -Djenesis.process.factory=tool -Djenesis.test.skip=true \
       -agentlib:native-image-agent=config-output-dir="$cfg" \
       -cp "$LAUNCHER" build.jenesis.Project build >/dev/null 2>&1
   rm -rf target
-  # -H:IncludeResourceBundles forces javac's message bundles into the image: the agent only records bundles a
-  # captured compile happened to load, so without this the in-process compiler fails the moment it formats a
-  # diagnostic it did not record (a MissingResourceException in JavacMessages.getBundles).
   "$GRAALVM_HOME/bin/native-image" --no-fallback --add-modules jdk.compiler,jdk.jartool \
       -H:IncludeResourceBundles=com.sun.tools.javac.resources.compiler,com.sun.tools.javac.resources.javac,com.sun.tools.javac.resources.ct,sun.tools.jar.resources.jar \
       -H:ConfigurationFileDirectories="$cfg" \
@@ -124,7 +116,6 @@ build_native() {
     && echo "native launcher (in-process javac): $NATIVE" || { warn "native-image build failed"; return 1; }
 }
 
-# command strings (Maven compiles tests; Jenesis test-skip compiles the test module, both skip the run)
 M_NT() { echo "$1 package -o -q -ntp -DskipTests"; }
 M_F()  { echo "$1 package -o -q -ntp"; }
 SRC_NT="java -Djenesis.test.skip=true build/jenesis/Project.java build"
@@ -156,8 +147,6 @@ table_compile() {
   [ -x "$NATIVE" ] && bench_warm "jenesis-native" "$RUNS_WARM" "rm -rf target; $NATIVE_NT" "$NATIVE_NT"
   echo "-- one-line edit to a main source --"
   if git diff --quiet -- "$EDIT" 2>/dev/null; then
-    # the edit scenario appends to $EDIT and restores it with 'git checkout'; only run it when $EDIT is
-    # committed-clean, so a contributor's uncommitted changes are never discarded.
     bench_warm "maven3"      "$RUNS_WARM" "git checkout -- $EDIT; rm -rf target; $m" "printf '\n//e%s\n' \"\$(date +%s%N)\">>$EDIT; $m"
     bench_warm "jenesis-source"  "$RUNS_WARM" "git checkout -- $EDIT; rm -rf target; $SRC_NT" "printf '\n//e%s\n' \"\$(date +%s%N)\">>$EDIT; $SRC_NT"
     bench_warm "jenesis-precompiled" "$RUNS_WARM" "git checkout -- $EDIT; rm -rf target; $JAVAC_NT" "printf '\n//e%s\n' \"\$(date +%s%N)\">>$EDIT; $JAVAC_NT"
@@ -171,7 +160,6 @@ table_compile() {
   bench "jenesis-source"  "$RUNS_WARM" "rm -rf target>/dev/null 2>&1; $SRC_NT>/dev/null 2>&1; touch $EDIT" "$SRC_NT"
   bench "jenesis-precompiled" "$RUNS_WARM" "rm -rf target>/dev/null 2>&1; $JAVAC_NT>/dev/null 2>&1; touch $EDIT" "$JAVAC_NT"
   [ -x "$NATIVE" ] && bench "jenesis-native" "$RUNS_WARM" "rm -rf target>/dev/null 2>&1; $NATIVE_NT>/dev/null 2>&1; touch $EDIT" "$NATIVE_NT"
-  # 'touch' only changes mtime, not content, so $EDIT needs no restore here.
 }
 
 table_full() {
@@ -199,7 +187,6 @@ table_aot() {
   note "Table: JDK 25 AOT cache (JEP 514/515) for the precompiled launcher"
   build_launcher
   local jar="$ROOT/.jenesis/launcher.jar" aot="$ROOT/.jenesis/build.aot"
-  # CDS/AOT rejects an exploded class directory on the classpath, so the engine must be a jar.
   rm -f "$jar"; jar --create --file "$jar" -C "$LAUNCHER" .
   local B="-Djenesis.test.skip=true -cp $jar build.jenesis.Project build"
   note "recording run (-XX:AOTCacheOutput captures classes + method profiles)"

--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -4,7 +4,7 @@
 # Reproduces the tables in the README "Build performance" section.
 #
 # Usage:
-#   benchmark/benchmark.sh {launch|compile|full|maven|pinning|all}
+#   benchmark/benchmark.sh {launch|compile|full|maven|pinning|aot|all}
 #
 # Methodology (see benchmark/README.md for the rationale):
 #   - Wall-clock is measured externally with /usr/bin/time (its %e field), never a build tool's self-report.
@@ -195,6 +195,25 @@ table_maven() {
   bench_warm "maven4" "$RUNS_WARM" "rm -rf target; $m4" "$m4"
 }
 
+table_aot() {
+  note "Table: JDK 25 AOT cache (JEP 514/515) for the precompiled launcher"
+  build_launcher
+  local jar="$ROOT/.jenesis/launcher.jar" aot="$ROOT/.jenesis/build.aot"
+  # CDS/AOT rejects an exploded class directory on the classpath, so the engine must be a jar.
+  rm -f "$jar"; jar --create --file "$jar" -C "$LAUNCHER" .
+  local B="-Djenesis.test.skip=true -cp $jar build.jenesis.Project build"
+  note "recording run (-XX:AOTCacheOutput captures classes + method profiles)"
+  rm -rf target "$aot"
+  java -XX:AOTCacheOutput="$aot" $B >/dev/null 2>&1 || { warn "AOT cache training failed (needs JDK 25+)"; rm -f "$jar"; return 1; }
+  echo "-- cold --"
+  bench "precompiled (jar)"       "$RUNS_COLD" "rm -rf target" "java $B"
+  bench "precompiled (jar) + AOT" "$RUNS_COLD" "rm -rf target" "java -XX:AOTCache=$aot $B"
+  echo "-- warm no-op --"
+  bench_warm "precompiled (jar)"       "$RUNS_WARM" "rm -rf target; java $B"                  "java $B"
+  bench_warm "precompiled (jar) + AOT" "$RUNS_WARM" "rm -rf target; java -XX:AOTCache=$aot $B" "java -XX:AOTCache=$aot $B"
+  rm -f "$jar" "$aot"
+}
+
 table_pinning() {
   note "Table: dependency pinning - default (checksums verified) vs versions (checksums stripped)"
   build_launcher
@@ -215,7 +234,8 @@ case "${1:-}" in
   full)    table_full ;;
   maven)   table_maven ;;
   pinning) table_pinning ;;
-  all)     table_launch; table_compile; table_full; table_maven; table_pinning ;;
-  *) echo "usage: $0 {launch|compile|full|maven|pinning|all}"; exit 1 ;;
+  aot)     table_aot ;;
+  all)     table_launch; table_compile; table_full; table_maven; table_pinning; table_aot ;;
+  *) echo "usage: $0 {launch|compile|full|maven|pinning|aot|all}"; exit 1 ;;
 esac
 note "done: ${1:-}"

--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# Reproducible build-performance benchmarks for the Jenesis project.
+# Reproduces the tables in the README "Build performance" section.
+#
+# Usage:
+#   benchmark/benchmark.sh {launch|compile|full|maven|pinning|all}
+#
+# Methodology (see benchmark/README.md for the rationale):
+#   - Wall-clock is measured externally with /usr/bin/time (its %e field), never a build tool's self-report.
+#   - Every run records the network byte delta on the host interfaces, printed as net=+RX/TXKB; with warm caches
+#     the compile/incremental/launch builds transfer 0 KB (the full build does a ~25 KB symmetric metadata fetch).
+#   - The CPU should be on a "performance" power profile; the script warns if it is not (a "power-saver" profile
+#     pins the cores low and inflates every figure several-fold).
+#   - Maven compiles the tests but skips running them (-DskipTests); Jenesis's -Djenesis.test.skip likewise
+#     compiles the test module and skips only the runner, so both compile the same sources.
+#
+# Configuration (override via environment):
+#   JAVA_HOME      JDK 25+ used for the Jenesis and Maven builds (default: the java on PATH).
+#   MVN            Maven 3 launcher                 (default: mvn)
+#   MVN4           Maven 4 launcher, optional       (default: unset; the 'maven' table needs it)
+#   GRAALVM_HOME   GraalVM 25+ for the native image (default: unset; the native launcher is skipped without it)
+#   RUNS_COLD      repetitions for cold builds      (default: 5)
+#   RUNS_WARM      repetitions for warm/incremental (default: 3)
+#
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+cd "$ROOT"
+
+MVN="${MVN:-mvn}"
+MVN4="${MVN4:-}"
+GRAALVM_HOME="${GRAALVM_HOME:-}"
+RUNS_COLD="${RUNS_COLD:-5}"
+RUNS_WARM="${RUNS_WARM:-3}"
+LAUNCHER="$ROOT/.jenesis/launcher"
+NATIVE="$ROOT/.jenesis/benchmark-image"
+EDIT="sources/build/jenesis/Project.java"
+TFMT="%e %U %S %M"
+TF="$(mktemp)"; LOG="$(mktemp)"; trap 'rm -f "$TF" "$LOG"' EXIT
+
+note() { printf '\n== %s ==\n' "$*"; }
+warn() { printf '!! %s\n' "$*" >&2; }
+
+check_env() {
+  command -v /usr/bin/time >/dev/null || { warn "/usr/bin/time (GNU time) is required"; exit 1; }
+  if command -v powerprofilesctl >/dev/null; then
+    [ "$(powerprofilesctl get 2>/dev/null)" = performance ] \
+      || warn "CPU power profile is not 'performance' - figures will be slow and noisy (try: powerprofilesctl set performance)"
+  fi
+  java -version >/dev/null 2>&1 || { warn "no java on PATH / JAVA_HOME"; exit 1; }
+}
+
+rxtx() { awk -F'[: ]+' '/eth|wl|en|wlp|enp|eno/{rx+=$3;tx+=$11} END{print rx+0" "tx+0}' /proc/net/dev; }
+
+# timeit "<command>" -> echoes "wall_seconds rx_kb tx_kb rc"
+timeit() {
+  local b0 b1; b0=$(rxtx)
+  /usr/bin/time -f "$TFMT" -o "$TF" bash -c "$1" >"$LOG" 2>&1; local rc=$?
+  b1=$(rxtx); set -- $b0; local r0=$1 t0=$2; set -- $b1
+  local wall; wall=$(cut -d' ' -f1 "$TF")
+  echo "$wall $(( ($1-r0)/1024 )) $(( ($2-t0)/1024 )) $rc"
+}
+
+median() { # reads numbers on stdin, prints median
+  sort -n | awk '{a[NR]=$1} END{print (NR%2)?a[(NR+1)/2]:(a[NR/2]+a[NR/2+1])/2}'
+}
+
+# bench <label> <runs> <per-run-setup> <timed-cmd>
+bench() {
+  local label="$1" runs="$2" setup="$3" cmd="$4" i walls="" worst=0
+  printf '%-26s ' "$label"
+  for i in $(seq 1 "$runs"); do
+    [ -n "$setup" ] && bash -c "$setup" >/dev/null 2>&1
+    read -r wall rx tx rc <<<"$(timeit "$cmd")"
+    walls+="$wall
+"
+    [ "$rc" != 0 ] && { printf 'FAILED (rc=%s)\n' "$rc"; tail -3 "$LOG" >&2; return 1; }
+    [ "$((rx+tx))" -gt "$worst" ] && worst=$((rx+tx))
+  done
+  printf 'median %6.2fs  (n=%s, net<=%sKB)\n' "$(printf '%s' "$walls" | median)" "$runs" "$worst"
+}
+
+# warm variant: establish state once (untimed), then time N runs with no further setup
+bench_warm() {
+  local label="$1" runs="$2" warmup="$3" cmd="$4" i walls="" worst=0
+  bash -c "$warmup" >/dev/null 2>&1
+  printf '%-26s ' "$label"
+  for i in $(seq 1 "$runs"); do
+    read -r wall rx tx rc <<<"$(timeit "$cmd")"
+    walls+="$wall
+"
+    [ "$rc" != 0 ] && { printf 'FAILED (rc=%s)\n' "$rc"; tail -3 "$LOG" >&2; return 1; }
+    [ "$((rx+tx))" -gt "$worst" ] && worst=$((rx+tx))
+  done
+  printf 'median %6.2fs  (n=%s, net<=%sKB)\n' "$(printf '%s' "$walls" | median)" "$runs" "$worst"
+}
+
+build_launcher() {
+  [ -d "$LAUNCHER" ] && return 0
+  note "Precompiling the engine to $LAUNCHER"
+  rm -rf "$LAUNCHER"; javac -d "$LAUNCHER" $(find -L build/jenesis -name '*.java')
+}
+
+build_native() {
+  [ -x "$NATIVE" ] && return 0
+  [ -n "$GRAALVM_HOME" ] || { warn "GRAALVM_HOME not set - skipping the native launcher"; return 1; }
+  build_launcher
+  note "Capturing reachability metadata and building the native launcher (one-off)"
+  local cfg; cfg="$(mktemp -d)"
+  "$GRAALVM_HOME/bin/java" -Djenesis.process.factory=fork -Djenesis.test.skip=true \
+      -agentlib:native-image-agent=config-output-dir="$cfg" \
+      -cp "$LAUNCHER" build.jenesis.Project build >/dev/null 2>&1
+  rm -rf target
+  "$GRAALVM_HOME/bin/native-image" --no-fallback -H:ConfigurationFileDirectories="$cfg" \
+      -cp "$LAUNCHER" build.jenesis.Project "$NATIVE" >/dev/null 2>&1 \
+    && echo "native launcher: $NATIVE" || { warn "native-image build failed"; return 1; }
+}
+
+# command strings (Maven compiles tests; Jenesis test-skip compiles the test module, both skip the run)
+M_NT() { echo "$1 package -o -q -ntp -DskipTests"; }
+M_F()  { echo "$1 package -o -q -ntp"; }
+SRC_NT="java -Djenesis.test.skip=true build/jenesis/Project.java build"
+JAVAC_NT="java -Djenesis.test.skip=true -cp $LAUNCHER build.jenesis.Project build"
+NATIVE_NT="$NATIVE -Djenesis.test.skip=true build"
+SRC_F="java build/jenesis/Project.java build"
+
+table_launch() {
+  note "Table: build-tool launch overhead (run 'help', no project work)"
+  build_launcher
+  bench_warm "source"      "$RUNS_WARM" "java build/jenesis/Project.java help" "java build/jenesis/Project.java help"
+  bench_warm "precompiled" "$RUNS_WARM" "java -cp $LAUNCHER build.jenesis.Project help" "java -cp $LAUNCHER build.jenesis.Project help"
+  build_native && bench_warm "native" "$RUNS_WARM" "$NATIVE help" "$NATIVE help"
+}
+
+table_compile() {
+  note "Table: compile + package, tests compiled but not run"
+  build_launcher; build_native
+  local m; m="$(M_NT "$MVN")"
+  echo "-- cold (empty target/) --"
+  bench "maven3"      "$RUNS_COLD" "rm -rf target" "$m"
+  bench "jenesis-source"  "$RUNS_COLD" "rm -rf target" "$SRC_NT"
+  bench "jenesis-precompiled" "$RUNS_COLD" "rm -rf target" "$JAVAC_NT"
+  [ -x "$NATIVE" ] && bench "jenesis-native" "$RUNS_COLD" "rm -rf target" "$NATIVE_NT"
+  echo "-- warm no-op (nothing changed) --"
+  bench_warm "maven3"      "$RUNS_WARM" "rm -rf target; $m" "$m"
+  bench_warm "jenesis-source"  "$RUNS_WARM" "rm -rf target; $SRC_NT" "$SRC_NT"
+  bench_warm "jenesis-precompiled" "$RUNS_WARM" "rm -rf target; $JAVAC_NT" "$JAVAC_NT"
+  [ -x "$NATIVE" ] && bench_warm "jenesis-native" "$RUNS_WARM" "rm -rf target; $NATIVE_NT" "$NATIVE_NT"
+  echo "-- one-line edit to a main source --"
+  if git diff --quiet -- "$EDIT" 2>/dev/null; then
+    # the edit scenario appends to $EDIT and restores it with 'git checkout'; only run it when $EDIT is
+    # committed-clean, so a contributor's uncommitted changes are never discarded.
+    bench_warm "maven3"      "$RUNS_WARM" "git checkout -- $EDIT; rm -rf target; $m" "printf '\n//e%s\n' \"\$(date +%s%N)\">>$EDIT; $m"
+    bench_warm "jenesis-source"  "$RUNS_WARM" "git checkout -- $EDIT; rm -rf target; $SRC_NT" "printf '\n//e%s\n' \"\$(date +%s%N)\">>$EDIT; $SRC_NT"
+    bench_warm "jenesis-precompiled" "$RUNS_WARM" "git checkout -- $EDIT; rm -rf target; $JAVAC_NT" "printf '\n//e%s\n' \"\$(date +%s%N)\">>$EDIT; $JAVAC_NT"
+    [ -x "$NATIVE" ] && bench_warm "jenesis-native" "$RUNS_WARM" "git checkout -- $EDIT; rm -rf target; $NATIVE_NT" "printf '\n//e%s\n' \"\$(date +%s%N)\">>$EDIT; $NATIVE_NT"
+    git checkout -- "$EDIT" 2>/dev/null
+  else
+    warn "skipping the edit table: $EDIT has uncommitted changes (commit or stash them to measure it)"
+  fi
+  echo "-- spurious touch (content identical) --"
+  bench "maven3"      "$RUNS_WARM" "rm -rf target>/dev/null 2>&1; $m>/dev/null 2>&1; touch $EDIT" "$m"
+  bench "jenesis-source"  "$RUNS_WARM" "rm -rf target>/dev/null 2>&1; $SRC_NT>/dev/null 2>&1; touch $EDIT" "$SRC_NT"
+  bench "jenesis-precompiled" "$RUNS_WARM" "rm -rf target>/dev/null 2>&1; $JAVAC_NT>/dev/null 2>&1; touch $EDIT" "$JAVAC_NT"
+  [ -x "$NATIVE" ] && bench "jenesis-native" "$RUNS_WARM" "rm -rf target>/dev/null 2>&1; $NATIVE_NT>/dev/null 2>&1; touch $EDIT" "$NATIVE_NT"
+  # 'touch' only changes mtime, not content, so $EDIT needs no restore here.
+}
+
+table_full() {
+  note "Table: full build, all tests (test-bound; ~25 KB symmetric metadata fetch, network required)"
+  local m; m="$(M_F "$MVN")"
+  bench      "jenesis cold"          1 "rm -rf target" "$SRC_F"
+  bench      "maven3 cold"           1 "rm -rf target" "$m"
+  bench_warm "maven3 warm no-op"     1 "rm -rf target; $m"     "$m"
+  bench_warm "jenesis warm no-op"    2 "rm -rf target; $SRC_F" "$SRC_F"
+}
+
+table_maven() {
+  note "Table: Maven 3 vs Maven 4 (both honour the pinned maven-compiler-plugin)"
+  [ -n "$MVN4" ] || { warn "set MVN4=<maven-4 launcher> to run this table"; return 1; }
+  local m3 m4; m3="$(M_NT "$MVN")"; m4="$(M_NT "$MVN4")"
+  echo "-- cold --"
+  bench "maven3" "$RUNS_COLD" "rm -rf target" "$m3"
+  bench "maven4" "$RUNS_COLD" "rm -rf target" "$m4"
+  echo "-- warm no-op --"
+  bench_warm "maven3" "$RUNS_WARM" "rm -rf target; $m3" "$m3"
+  bench_warm "maven4" "$RUNS_WARM" "rm -rf target; $m4" "$m4"
+}
+
+table_pinning() {
+  note "Table: dependency pinning - default (checksums verified) vs versions (checksums stripped)"
+  build_launcher
+  local def="java -Djenesis.test.skip=true -cp $LAUNCHER build.jenesis.Project build"
+  local ver="java -Djenesis.dependency.pin=versions -Djenesis.test.skip=true -cp $LAUNCHER build.jenesis.Project build"
+  echo "-- cold (Dependencies step runs; default validates artifact digests) --"
+  bench "default"      "$RUNS_COLD" "rm -rf target" "$def"
+  bench "pin=versions" "$RUNS_COLD" "rm -rf target" "$ver"
+  echo "-- warm no-op (Dependencies step cached; no validation either way) --"
+  bench_warm "default"      "$RUNS_WARM" "rm -rf target; $def" "$def"
+  bench_warm "pin=versions" "$RUNS_WARM" "rm -rf target; $ver" "$ver"
+}
+
+check_env
+case "${1:-}" in
+  launch)  table_launch ;;
+  compile) table_compile ;;
+  full)    table_full ;;
+  maven)   table_maven ;;
+  pinning) table_pinning ;;
+  all)     table_launch; table_compile; table_full; table_maven; table_pinning ;;
+  *) echo "usage: $0 {launch|compile|full|maven|pinning|all}"; exit 1 ;;
+esac
+note "done: ${1:-}"

--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -107,14 +107,21 @@ build_native() {
   [ -n "$GRAALVM_HOME" ] || { warn "GRAALVM_HOME not set - skipping the native launcher"; return 1; }
   build_launcher
   note "Capturing reachability metadata and building the native launcher (one-off)"
+  # Capture with the tools in-process so javac/jar are recorded, and keep jdk.compiler/jdk.jartool in the image:
+  # Factory.of() then runs the compiler in-process (no fork), which is markedly faster on a cold build.
   local cfg; cfg="$(mktemp -d)"
-  "$GRAALVM_HOME/bin/java" -Djenesis.process.factory=fork -Djenesis.test.skip=true \
+  "$GRAALVM_HOME/bin/java" -Djenesis.process.factory=tool -Djenesis.test.skip=true \
       -agentlib:native-image-agent=config-output-dir="$cfg" \
       -cp "$LAUNCHER" build.jenesis.Project build >/dev/null 2>&1
   rm -rf target
-  "$GRAALVM_HOME/bin/native-image" --no-fallback -H:ConfigurationFileDirectories="$cfg" \
+  # -H:IncludeResourceBundles forces javac's message bundles into the image: the agent only records bundles a
+  # captured compile happened to load, so without this the in-process compiler fails the moment it formats a
+  # diagnostic it did not record (a MissingResourceException in JavacMessages.getBundles).
+  "$GRAALVM_HOME/bin/native-image" --no-fallback --add-modules jdk.compiler,jdk.jartool \
+      -H:IncludeResourceBundles=com.sun.tools.javac.resources.compiler,com.sun.tools.javac.resources.javac,com.sun.tools.javac.resources.ct,sun.tools.jar.resources.jar \
+      -H:ConfigurationFileDirectories="$cfg" \
       -cp "$LAUNCHER" build.jenesis.Project "$NATIVE" >/dev/null 2>&1 \
-    && echo "native launcher: $NATIVE" || { warn "native-image build failed"; return 1; }
+    && echo "native launcher (in-process javac): $NATIVE" || { warn "native-image build failed"; return 1; }
 }
 
 # command strings (Maven compiles tests; Jenesis test-skip compiles the test module, both skip the run)

--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -1,27 +1,7 @@
 #!/usr/bin/env bash
-#
-# Reproducible build-performance benchmarks for the Jenesis project.
-# Reproduces the tables in the README "Build performance" section.
-#
-# Usage:
+# Reproducible build-performance benchmarks for the Jenesis project; reproduces the README
+# "Build performance" tables. Usage, methodology and configuration are in benchmark/README.md.
 #   benchmark/benchmark.sh {launch|compile|full|maven|pinning|aot|all}
-#
-# Methodology (see benchmark/README.md for the rationale):
-#   - Wall-clock is measured externally with /usr/bin/time (its %e field), never a build tool's self-report.
-#   - Every run records the network byte delta on the host interfaces, printed as net=+RX/TXKB; with warm caches
-#     the compile/incremental/launch builds transfer 0 KB (the full build does a ~25 KB symmetric metadata fetch).
-#   - The CPU should be on a "performance" power profile; the script warns if it is not (a "power-saver" profile
-#     pins the cores low and inflates every figure several-fold).
-#   - Maven compiles the tests but skips running them (-DskipTests); Jenesis's -Djenesis.test.skip likewise
-#     compiles the test module and skips only the runner, so both compile the same sources.
-#
-# Configuration (override via environment):
-#   JAVA_HOME      JDK 25+ used for the Jenesis and Maven builds (default: the java on PATH).
-#   MVN            Maven 3 launcher                 (default: mvn)
-#   MVN4           Maven 4 launcher, optional       (default: unset; the 'maven' table needs it)
-#   GRAALVM_HOME   GraalVM 25+ for the native image (default: unset; the native launcher is skipped without it)
-#   RUNS_COLD      repetitions for cold builds      (default: 5)
-#   RUNS_WARM      repetitions for warm/incremental (default: 3)
 #
 set -u
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -33,74 +13,88 @@ MVN4="${MVN4:-}"
 GRAALVM_HOME="${GRAALVM_HOME:-}"
 RUNS_COLD="${RUNS_COLD:-5}"
 RUNS_WARM="${RUNS_WARM:-3}"
+ENGINE="build/jenesis"; [ -f $ENGINE/Project.java ] || ENGINE="sources/build/jenesis"
 LAUNCHER="$ROOT/.jenesis/launcher"
+EXE=""; NICMD=""; case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) EXE=".exe"; NICMD=".cmd";; esac
 NATIVE="$ROOT/.jenesis/benchmark-image"
+NATIVE_BIN="$NATIVE$EXE"
 EDIT="sources/build/jenesis/Project.java"
-TFMT="%e %U %S %M"
 TF="$(mktemp)"; LOG="$(mktemp)"; trap 'rm -f "$TF" "$LOG"' EXIT
+HAVE_GTIME=0; /usr/bin/time -f %e true >/dev/null 2>&1 && HAVE_GTIME=1
+HAVE_NET=0; [ -r /proc/net/dev ] && HAVE_NET=1
 
 note() { printf '\n== %s ==\n' "$*"; }
 warn() { printf '!! %s\n' "$*" >&2; }
 
 check_env() {
-  command -v /usr/bin/time >/dev/null || { warn "/usr/bin/time (GNU time) is required"; exit 1; }
-  if command -v powerprofilesctl >/dev/null; then
+  if command -v powerprofilesctl >/dev/null 2>&1; then
     [ "$(powerprofilesctl get 2>/dev/null)" = performance ] \
-      || warn "CPU power profile is not 'performance' - figures will be slow and noisy (try: powerprofilesctl set performance)"
+      || warn "CPU power profile is not 'performance' - figures will be slow and noisy"
   fi
   java -version >/dev/null 2>&1 || { warn "no java on PATH / JAVA_HOME"; exit 1; }
 }
 
-rxtx() { awk -F'[: ]+' '/eth|wl|en|wlp|enp|eno/{rx+=$3;tx+=$11} END{print rx+0" "tx+0}' /proc/net/dev; }
+rxtx() { [ "$HAVE_NET" = 1 ] && awk -F'[: ]+' '/eth|wl|en|wlp|enp|eno/{rx+=$3;tx+=$11} END{print rx+0" "tx+0}' /proc/net/dev || echo "0 0"; }
 
 timeit() {
-  local b0 b1; b0=$(rxtx)
-  /usr/bin/time -f "$TFMT" -o "$TF" bash -c "$1" >"$LOG" 2>&1; local rc=$?
-  b1=$(rxtx); set -- $b0; local r0=$1 t0=$2; set -- $b1
-  local wall; wall=$(cut -d' ' -f1 "$TF")
-  echo "$wall $(( ($1-r0)/1024 )) $(( ($2-t0)/1024 )) $rc"
+  local b0 b1 rc wall r0 t0; b0=$(rxtx)
+  if [ "$HAVE_GTIME" = 1 ]; then
+    /usr/bin/time -f "%e" -o "$TF" bash -c "$1" >"$LOG" 2>&1; rc=$?
+    wall=$(cut -d' ' -f1 "$TF")
+  else
+    TIMEFORMAT=%R
+    { time bash -c "$1" >"$LOG" 2>&1; } 2>"$TF"; rc=$?
+    wall=$(tr -d '[:space:]' < "$TF" | tr ',' '.')
+  fi
+  b1=$(rxtx); set -- $b0; r0=$1; t0=$2; set -- $b1
+  if [ "$HAVE_NET" = 1 ]; then echo "$wall $(( ($1-r0)/1024 )) $(( ($2-t0)/1024 )) $rc"; else echo "$wall na na $rc"; fi
 }
 
-median() { # reads numbers on stdin, prints median
+median() {
   sort -n | awk '{a[NR]=$1} END{print (NR%2)?a[(NR+1)/2]:(a[NR/2]+a[NR/2+1])/2}'
+}
+
+result() {
+  if [ "$HAVE_NET" = 1 ]; then printf 'median %6.2fs  (n=%s, net<=%sKB)\n' "$(printf '%s' "$1" | median)" "$2" "$3"
+  else printf 'median %6.2fs  (n=%s)\n' "$(printf '%s' "$1" | median)" "$2"; fi
 }
 
 bench() {
   local label="$1" runs="$2" setup="$3" cmd="$4" i walls="" worst=0
   printf '%-26s ' "$label"
-  for i in $(seq 1 "$runs"); do
+  for (( i=1; i<=runs; i++ )); do
     [ -n "$setup" ] && bash -c "$setup" >/dev/null 2>&1
     read -r wall rx tx rc <<<"$(timeit "$cmd")"
     walls+="$wall
 "
     [ "$rc" != 0 ] && { printf 'FAILED (rc=%s)\n' "$rc"; tail -3 "$LOG" >&2; return 1; }
-    [ "$((rx+tx))" -gt "$worst" ] && worst=$((rx+tx))
+    [ "$rx" != na ] && [ "$((rx+tx))" -gt "$worst" ] && worst=$((rx+tx))
   done
-  printf 'median %6.2fs  (n=%s, net<=%sKB)\n' "$(printf '%s' "$walls" | median)" "$runs" "$worst"
+  result "$walls" "$runs" "$worst"
 }
 
 bench_warm() {
   local label="$1" runs="$2" warmup="$3" cmd="$4" i walls="" worst=0
   bash -c "$warmup" >/dev/null 2>&1
   printf '%-26s ' "$label"
-  for i in $(seq 1 "$runs"); do
+  for (( i=1; i<=runs; i++ )); do
     read -r wall rx tx rc <<<"$(timeit "$cmd")"
     walls+="$wall
 "
     [ "$rc" != 0 ] && { printf 'FAILED (rc=%s)\n' "$rc"; tail -3 "$LOG" >&2; return 1; }
-    [ "$((rx+tx))" -gt "$worst" ] && worst=$((rx+tx))
+    [ "$rx" != na ] && [ "$((rx+tx))" -gt "$worst" ] && worst=$((rx+tx))
   done
-  printf 'median %6.2fs  (n=%s, net<=%sKB)\n' "$(printf '%s' "$walls" | median)" "$runs" "$worst"
+  result "$walls" "$runs" "$worst"
 }
 
 build_launcher() {
   [ -d "$LAUNCHER" ] && return 0
   note "Precompiling the engine to $LAUNCHER"
-  rm -rf "$LAUNCHER"; javac -d "$LAUNCHER" $(find -L build/jenesis -name '*.java')
+  rm -rf "$LAUNCHER"; javac -d "$LAUNCHER" $(find -L "$ENGINE" -name '*.java')
 }
 
 build_native() {
-  [ -x "$NATIVE" ] && return 0
+  [ -x "$NATIVE_BIN" ] && return 0
   [ -n "$GRAALVM_HOME" ] || { warn "GRAALVM_HOME not set - skipping the native launcher"; return 1; }
   build_launcher
   note "Capturing reachability metadata and building the native launcher (one-off)"
@@ -109,26 +103,26 @@ build_native() {
       -agentlib:native-image-agent=config-output-dir="$cfg" \
       -cp "$LAUNCHER" build.jenesis.Project build >/dev/null 2>&1
   rm -rf target
-  "$GRAALVM_HOME/bin/native-image" --no-fallback --add-modules jdk.compiler,jdk.jartool \
+  "$GRAALVM_HOME/bin/native-image$NICMD" --no-fallback --add-modules jdk.compiler,jdk.jartool \
       -H:IncludeResourceBundles=com.sun.tools.javac.resources.compiler,com.sun.tools.javac.resources.javac,com.sun.tools.javac.resources.ct,sun.tools.jar.resources.jar \
       -H:ConfigurationFileDirectories="$cfg" \
       -cp "$LAUNCHER" build.jenesis.Project "$NATIVE" >/dev/null 2>&1 \
-    && echo "native launcher (in-process javac): $NATIVE" || { warn "native-image build failed"; return 1; }
+    && echo "native launcher (in-process javac): $NATIVE_BIN" || { warn "native-image build failed"; return 1; }
 }
 
 M_NT() { echo "$1 package -o -q -ntp -DskipTests"; }
 M_F()  { echo "$1 package -o -q -ntp"; }
-SRC_NT="java -Djenesis.test.skip=true build/jenesis/Project.java build"
+SRC_NT="java -Djenesis.test.skip=true $ENGINE/Project.java build"
 JAVAC_NT="java -Djenesis.test.skip=true -cp $LAUNCHER build.jenesis.Project build"
-NATIVE_NT="$NATIVE -Djenesis.test.skip=true build"
-SRC_F="java build/jenesis/Project.java build"
+NATIVE_NT="$NATIVE_BIN -Djenesis.test.skip=true build"
+SRC_F="java $ENGINE/Project.java build"
 
 table_launch() {
   note "Table: build-tool launch overhead (run 'help', no project work)"
   build_launcher
-  bench_warm "source"      "$RUNS_WARM" "java build/jenesis/Project.java help" "java build/jenesis/Project.java help"
+  bench_warm "source"      "$RUNS_WARM" "java $ENGINE/Project.java help" "java $ENGINE/Project.java help"
   bench_warm "precompiled" "$RUNS_WARM" "java -cp $LAUNCHER build.jenesis.Project help" "java -cp $LAUNCHER build.jenesis.Project help"
-  build_native && bench_warm "native" "$RUNS_WARM" "$NATIVE help" "$NATIVE help"
+  build_native && bench_warm "native" "$RUNS_WARM" "$NATIVE_BIN help" "$NATIVE_BIN help"
 }
 
 table_compile() {
@@ -139,18 +133,18 @@ table_compile() {
   bench "maven3"      "$RUNS_COLD" "rm -rf target" "$m"
   bench "jenesis-source"  "$RUNS_COLD" "rm -rf target" "$SRC_NT"
   bench "jenesis-precompiled" "$RUNS_COLD" "rm -rf target" "$JAVAC_NT"
-  [ -x "$NATIVE" ] && bench "jenesis-native" "$RUNS_COLD" "rm -rf target" "$NATIVE_NT"
+  [ -x "$NATIVE_BIN" ] && bench "jenesis-native" "$RUNS_COLD" "rm -rf target" "$NATIVE_NT"
   echo "-- warm no-op (nothing changed) --"
   bench_warm "maven3"      "$RUNS_WARM" "rm -rf target; $m" "$m"
   bench_warm "jenesis-source"  "$RUNS_WARM" "rm -rf target; $SRC_NT" "$SRC_NT"
   bench_warm "jenesis-precompiled" "$RUNS_WARM" "rm -rf target; $JAVAC_NT" "$JAVAC_NT"
-  [ -x "$NATIVE" ] && bench_warm "jenesis-native" "$RUNS_WARM" "rm -rf target; $NATIVE_NT" "$NATIVE_NT"
+  [ -x "$NATIVE_BIN" ] && bench_warm "jenesis-native" "$RUNS_WARM" "rm -rf target; $NATIVE_NT" "$NATIVE_NT"
   echo "-- one-line edit to a main source --"
   if git diff --quiet -- "$EDIT" 2>/dev/null; then
     bench_warm "maven3"      "$RUNS_WARM" "git checkout -- $EDIT; rm -rf target; $m" "printf '\n//e%s\n' \"\$(date +%s%N)\">>$EDIT; $m"
     bench_warm "jenesis-source"  "$RUNS_WARM" "git checkout -- $EDIT; rm -rf target; $SRC_NT" "printf '\n//e%s\n' \"\$(date +%s%N)\">>$EDIT; $SRC_NT"
     bench_warm "jenesis-precompiled" "$RUNS_WARM" "git checkout -- $EDIT; rm -rf target; $JAVAC_NT" "printf '\n//e%s\n' \"\$(date +%s%N)\">>$EDIT; $JAVAC_NT"
-    [ -x "$NATIVE" ] && bench_warm "jenesis-native" "$RUNS_WARM" "git checkout -- $EDIT; rm -rf target; $NATIVE_NT" "printf '\n//e%s\n' \"\$(date +%s%N)\">>$EDIT; $NATIVE_NT"
+    [ -x "$NATIVE_BIN" ] && bench_warm "jenesis-native" "$RUNS_WARM" "git checkout -- $EDIT; rm -rf target; $NATIVE_NT" "printf '\n//e%s\n' \"\$(date +%s%N)\">>$EDIT; $NATIVE_NT"
     git checkout -- "$EDIT" 2>/dev/null
   else
     warn "skipping the edit table: $EDIT has uncommitted changes (commit or stash them to measure it)"
@@ -159,7 +153,7 @@ table_compile() {
   bench "maven3"      "$RUNS_WARM" "rm -rf target>/dev/null 2>&1; $m>/dev/null 2>&1; touch $EDIT" "$m"
   bench "jenesis-source"  "$RUNS_WARM" "rm -rf target>/dev/null 2>&1; $SRC_NT>/dev/null 2>&1; touch $EDIT" "$SRC_NT"
   bench "jenesis-precompiled" "$RUNS_WARM" "rm -rf target>/dev/null 2>&1; $JAVAC_NT>/dev/null 2>&1; touch $EDIT" "$JAVAC_NT"
-  [ -x "$NATIVE" ] && bench "jenesis-native" "$RUNS_WARM" "rm -rf target>/dev/null 2>&1; $NATIVE_NT>/dev/null 2>&1; touch $EDIT" "$NATIVE_NT"
+  [ -x "$NATIVE_BIN" ] && bench "jenesis-native" "$RUNS_WARM" "rm -rf target>/dev/null 2>&1; $NATIVE_NT>/dev/null 2>&1; touch $EDIT" "$NATIVE_NT"
 }
 
 table_full() {

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,11 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.15.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
                         <excludes>

--- a/sources/build/jenesis/Pinning.java
+++ b/sources/build/jenesis/Pinning.java
@@ -6,6 +6,8 @@ public enum Pinning {
 
     STRICT,
 
+    VERSIONS,
+
     IGNORE;
 
     public static Pinning fromProperty() {

--- a/sources/build/jenesis/Project.java
+++ b/sources/build/jenesis/Project.java
@@ -399,8 +399,9 @@ public record Project(
                     %{header}Pinning (-Djenesis.dependency.pin=<mode>):%{reset}
                       %{name}strict%{reset} fails the build on any unpinned artifact; %{name}ignore%{reset} floats
                       versions to the latest and skips checksum verification (refresh the
-                      pins by running the %{name}pin%{reset} step under it). Unset keeps existing pins
-                      but tolerates missing ones.
+                      pins by running the %{name}pin%{reset} step under it); %{name}versions%{reset} keeps the
+                      pinned versions but skips checksum verification. Unset keeps existing
+                      pins but tolerates missing ones.
 
                     %{header}Platform (-Djenesis.platform.<token>=<true|false>):%{reset}
                       The active platform starts from the detected operating system and
@@ -720,11 +721,13 @@ public record Project(
                                                   (Ctrl+C to stop).
                     
                     Pinning:
-                      -Djenesis.dependency.pin=strict|ignore  strict fails on
-                                                  any unpinned artifact; ignore
-                                                  floats to the latest and skips
-                                                  checksums (refresh pins via
-                                                  the pin step).
+                      -Djenesis.dependency.pin=strict|versions|ignore
+                                                  strict fails on any unpinned
+                                                  artifact; ignore floats to the
+                                                  latest and skips checksums
+                                                  (refresh pins via the pin step);
+                                                  versions keeps pinned versions
+                                                  but skips checksum verification.
 
                     Platform:
                       -Djenesis.platform.<token>=true|false  The active platform

--- a/sources/build/jenesis/step/Dependencies.java
+++ b/sources/build/jenesis/step/Dependencies.java
@@ -163,9 +163,6 @@ public class Dependencies implements BuildStep {
                     SequencedMap<String, String> bom = new LinkedHashMap<>();
                     for (SequencedMap<String, String> pins : scoped) {
                         if (pinning == Pinning.VERSIONS) {
-                            // Versions-only pins keep the resolved version but drop the trailing
-                            // checksum, so the resolver selects the pinned version without validating
-                            // any artifact digest.
                             pins.forEach((coordinate, value) -> {
                                 int space = value.indexOf(' ');
                                 bom.putIfAbsent(coordinate, space < 0 ? value : value.substring(0, space));

--- a/sources/build/jenesis/step/Dependencies.java
+++ b/sources/build/jenesis/step/Dependencies.java
@@ -170,9 +170,6 @@ public class Dependencies implements BuildStep {
                         } else if (pinned) {
                             pins.forEach(bom::putIfAbsent);
                         } else {
-                            // Ignored pins drop versions and checksums, but a classifier qualifier
-                            // is a variant choice, not a derived version: it survives as a floating
-                            // classifier-only selection.
                             pins.forEach((coordinate, value) -> {
                                 if (value.startsWith(":")) {
                                     int space = value.indexOf(' ');

--- a/sources/build/jenesis/step/Dependencies.java
+++ b/sources/build/jenesis/step/Dependencies.java
@@ -162,7 +162,15 @@ public class Dependencies implements BuildStep {
                     }
                     SequencedMap<String, String> bom = new LinkedHashMap<>();
                     for (SequencedMap<String, String> pins : scoped) {
-                        if (pinned) {
+                        if (pinning == Pinning.VERSIONS) {
+                            // Versions-only pins keep the resolved version but drop the trailing
+                            // checksum, so the resolver selects the pinned version without validating
+                            // any artifact digest.
+                            pins.forEach((coordinate, value) -> {
+                                int space = value.indexOf(' ');
+                                bom.putIfAbsent(coordinate, space < 0 ? value : value.substring(0, space));
+                            });
+                        } else if (pinned) {
                             pins.forEach(bom::putIfAbsent);
                         } else {
                             // Ignored pins drop versions and checksums, but a classifier qualifier

--- a/sources/build/jenesis/step/ProcessHandler.java
+++ b/sources/build/jenesis/step/ProcessHandler.java
@@ -25,7 +25,12 @@ public sealed interface ProcessHandler permits ProcessHandler.OfTool, ProcessHan
         public static Factory of() {
             String factory = System.getProperty("jenesis.process.factory");
             if (factory == null) {
-                return System.getProperty("org.graalvm.nativeimage.imagecode") != null ? FORK : TOOL;
+                if (System.getProperty("org.graalvm.nativeimage.imagecode") == null) {
+                    return TOOL;
+                }
+                // A native image normally has no in-process JDK tools and must fork them, but one built with
+                // jdk.compiler/jdk.jartool on its module path carries javac/jar in-process; prefer that when present.
+                return ToolProvider.findFirst("javac").isPresent() ? TOOL : FORK;
             }
             return switch (factory) {
                 case "tool" -> TOOL;

--- a/sources/build/jenesis/step/ProcessHandler.java
+++ b/sources/build/jenesis/step/ProcessHandler.java
@@ -28,8 +28,6 @@ public sealed interface ProcessHandler permits ProcessHandler.OfTool, ProcessHan
                 if (System.getProperty("org.graalvm.nativeimage.imagecode") == null) {
                     return TOOL;
                 }
-                // A native image normally has no in-process JDK tools and must fork them, but one built with
-                // jdk.compiler/jdk.jartool on its module path carries javac/jar in-process; prefer that when present.
                 return ToolProvider.findFirst("javac").isPresent() ? TOOL : FORK;
             }
             return switch (factory) {


### PR DESCRIPTION
A measured build-performance comparison of Jenesis against Maven, the supporting docs, a reproducible benchmark suite, and the small build-tool changes the investigation motivated. Commits:

**1. README "Build performance" + "Building the launcher with Jenesis itself".** Maven 3 vs the Jenesis source / `javac`-precompiled / `native-image` launchers across launch overhead, compile-and-package (cold / warm no-op / one-line edit / spurious `touch`), and the full 1049-test build. Methodology is explicit: external `/usr/bin/time`; CPU pinned to `performance` (the `power-saver` default inflates everything ~2.6x); warm caches with networking ruled out by direct measurement; like-for-like flags (`-DskipTests` / `jenesis.test.skip`, both compile tests); JFR-attributed deviations. Headline: a no-op rebuild re-runs every test under Maven (~279 s) vs ~6.6 s under Jenesis (content hash).

**2. Pin `maven-compiler-plugin` 3.15.0** so Maven 4.0.0-rc-5 can build Java 25 (its default 3.13.0's ASM rejects class major 69). With it, Maven 3 and 4 are equivalent bar ~0.9 s of Maven 4 startup.

**3. A versions-only dependency pinning mode** (`jenesis.dependency.pin=versions`): keep pinned versions, strip checksums before the `Resolver` runs. (Benchmarked: no measurable effect; the warm hot path is the incremental cache's MD5, not the SHA-256 validate, which only runs on a cold `Dependencies` step.)

**4. A reproducible `benchmark/` folder** - `benchmark/benchmark.sh {launch|compile|full|maven|pinning|aot|all}` regenerates every table, recording a per-run network byte delta as proof of zero traffic.

**5. native-image: run `javac` in-process when the JDK tools are in the image.** `Factory.of()` prefers the in-process factory in a native image when `javac` is present, so a launcher built with `--add-modules jdk.compiler,jdk.jartool` (plus `-H:IncludeResourceBundles` for javac's/jar's bundles, required for determinism) compiles with the AOT-compiled `javac` - no fork, no JVM startup, no JIT warm-up. It is the fastest configuration: cold ~6.8 s (vs ~12.5 s forking, 10.6 s precompiled, 11.5 s Maven) and a one-line edit ~0.9 s.

**6. A JDK 25 AOT-cache benchmark variant** (`aot`): a JEP 514/515 recording run on the precompiled launcher - a plain-JVM speedup (cold ~10.8 s -> 9.5 s, warm ~0.42 s -> 0.34 s) that does not reach the native's in-process `javac`; documented with the recording-run mechanics (and the requirement that the engine be a jar).

**7. An on-demand cross-platform CI workflow.** `.github/workflows/benchmark.yml` (`workflow_dispatch`) runs the chosen tables on Linux, macOS and Windows via `graalvm/setup-graalvm` and uploads a `benchmark-<os>.txt` per runner. `benchmark.sh` is made portable for it: a shell-`time` fallback where GNU `time` is absent, the network column dropped where `/proc/net/dev` is absent, and `.exe`/`.cmd` launcher-suffix handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

