### PR TITLE
Discover dependency licenses from an embedded SBOM

### DIFF
--- a/sources/build/jenesis/Json.java
+++ b/sources/build/jenesis/Json.java
@@ -1,0 +1,124 @@
+package build.jenesis;
+
+import module java.base;
+
+public final class Json {
+
+    private static final int MAX_DEPTH = 1000;
+
+    private final String text;
+    private int pos;
+
+    private Json(String text) {
+        this.text = text;
+    }
+
+    public static Object parse(String text) {
+        Json json = new Json(text);
+        json.skip();
+        Object value = json.value(0);
+        json.skip();
+        return value;
+    }
+
+    private Object value(int depth) {
+        if (depth > MAX_DEPTH) {
+            throw new IllegalStateException("JSON nesting exceeds " + MAX_DEPTH + " levels");
+        }
+        skip();
+        return switch (text.charAt(pos)) {
+            case '{' -> object(depth);
+            case '[' -> array(depth);
+            case '"' -> string();
+            case 't' -> literal("true", Boolean.TRUE);
+            case 'f' -> literal("false", Boolean.FALSE);
+            case 'n' -> literal("null", null);
+            default -> number();
+        };
+    }
+
+    private Map<String, Object> object(int depth) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        pos++;
+        skip();
+        if (text.charAt(pos) == '}') {
+            pos++;
+            return map;
+        }
+        while (true) {
+            skip();
+            String key = string();
+            skip();
+            pos++;
+            map.put(key, value(depth + 1));
+            skip();
+            if (text.charAt(pos++) == '}') {
+                return map;
+            }
+        }
+    }
+
+    private List<Object> array(int depth) {
+        List<Object> list = new ArrayList<>();
+        pos++;
+        skip();
+        if (text.charAt(pos) == ']') {
+            pos++;
+            return list;
+        }
+        while (true) {
+            list.add(value(depth + 1));
+            skip();
+            if (text.charAt(pos++) == ']') {
+                return list;
+            }
+        }
+    }
+
+    private String string() {
+        StringBuilder builder = new StringBuilder();
+        pos++;
+        while (true) {
+            char c = text.charAt(pos++);
+            if (c == '"') {
+                return builder.toString();
+            }
+            if (c != '\\') {
+                builder.append(c);
+                continue;
+            }
+            char escaped = text.charAt(pos++);
+            switch (escaped) {
+                case 'n' -> builder.append('\n');
+                case 't' -> builder.append('\t');
+                case 'r' -> builder.append('\r');
+                case 'b' -> builder.append('\b');
+                case 'f' -> builder.append('\f');
+                case 'u' -> {
+                    builder.append((char) Integer.parseInt(text.substring(pos, pos + 4), 16));
+                    pos += 4;
+                }
+                default -> builder.append(escaped);
+            }
+        }
+    }
+
+    private Object number() {
+        int start = pos;
+        while (pos < text.length() && "+-0123456789.eE".indexOf(text.charAt(pos)) >= 0) {
+            pos++;
+        }
+        return Double.parseDouble(text.substring(start, pos));
+    }
+
+    private Object literal(String token, Object value) {
+        pos += token.length();
+        return value;
+    }
+
+    private void skip() {
+        while (pos < text.length() && Character.isWhitespace(text.charAt(pos))) {
+            pos++;
+        }
+    }
+}

--- a/sources/build/jenesis/step/LicenseCheck.java
+++ b/sources/build/jenesis/step/LicenseCheck.java
@@ -5,6 +5,7 @@ import build.jenesis.BuildStep;
 import build.jenesis.BuildStepArgument;
 import build.jenesis.BuildStepContext;
 import build.jenesis.BuildStepResult;
+import build.jenesis.Json;
 import build.jenesis.SequencedProperties;
 import build.jenesis.maven.MavenDependencyKey;
 
@@ -93,6 +94,7 @@ public class LicenseCheck implements BuildStep {
         }
         SequencedMap<String, List<String[]>> licensesByCoordinate = new TreeMap<>();
         SequencedMap<String, Path> jarByCoordinate = new LinkedHashMap<>();
+        SequencedSet<String> strict = new LinkedHashSet<>();
         for (BuildStepArgument argument : arguments.values()) {
             Path index = argument.folder().resolve(DEPENDENCIES);
             if (!Files.exists(index)) {
@@ -105,9 +107,7 @@ public class LicenseCheck implements BuildStep {
                     : new SequencedProperties();
             for (String key : dependencies.stringPropertyNames()) {
                 int first = key.indexOf('/'), second = key.indexOf('/', first + 1), third = key.indexOf('/', second + 1);
-                if (third < 0
-                        || !key.substring(0, first).equals("main")
-                        || !key.substring(second + 1, third).equals("maven")) {
+                if (third < 0 || !key.substring(0, first).equals("main")) {
                     continue;
                 }
                 String coordinate = key.substring(third + 1);
@@ -116,6 +116,9 @@ public class LicenseCheck implements BuildStep {
                     continue;
                 }
                 licensesByCoordinate.put(coordinate, licenses(licenses, key.substring(second + 1)));
+                if (key.substring(second + 1, third).equals("maven")) {
+                    strict.add(coordinate);
+                }
                 String value = dependencies.getProperty(key);
                 int space = value.indexOf(' ');
                 jarByCoordinate.put(coordinate,
@@ -129,6 +132,9 @@ public class LicenseCheck implements BuildStep {
             List<String[]> licenses = resolve(coordinate, entry.getValue(), jarByCoordinate.get(coordinate), overrideMap);
             String verdict;
             if (licenses.isEmpty()) {
+                if (!strict.contains(coordinate)) {
+                    continue;
+                }
                 verdict = switch (unknown) {
                     case FAIL -> "MISSING";
                     case WARN -> "WARN";
@@ -161,8 +167,7 @@ public class LicenseCheck implements BuildStep {
         if (!declared.isEmpty()) {
             return declared;
         }
-        String embedded = jarLicense(jar);
-        return embedded == null ? declared : Collections.singletonList(new String[]{embedded, null});
+        return jarLicenses(jar);
     }
 
     // Overrides are keyed by the internal dependency coordinate, with the maven/ repository
@@ -274,24 +279,102 @@ public class LicenseCheck implements BuildStep {
         return null;
     }
 
-    private static String jarLicense(Path jar) {
+    private static List<String[]> jarLicenses(Path jar) {
         if (jar == null || !Files.isRegularFile(jar)) {
-            return null;
+            return List.of();
         }
         try (JarFile file = new JarFile(jar.toFile())) {
             Manifest manifest = file.getManifest();
-            if (manifest == null) {
-                return null;
+            if (manifest != null) {
+                List<String[]> embedded = sbomLicenses(file, manifest);
+                if (!embedded.isEmpty()) {
+                    return embedded;
+                }
+                String bundle = bundleLicense(manifest);
+                if (bundle != null) {
+                    return Collections.singletonList(new String[]{bundle, null});
+                }
             }
-            String value = manifest.getMainAttributes().getValue("Bundle-License");
-            if (value == null || value.isBlank()) {
-                return null;
-            }
-            int semicolon = value.indexOf(';');
-            return (semicolon < 0 ? value : value.substring(0, semicolon)).trim();
+            String text = licenseFile(file);
+            return text == null ? List.of() : Collections.singletonList(new String[]{text, null});
         } catch (IOException _) {
+            return List.of();
+        }
+    }
+
+    private static List<String[]> sbomLicenses(JarFile file, Manifest manifest) {
+        String location = manifest.getMainAttributes().getValue("Sbom-Location");
+        if (location == null || location.isBlank()) {
+            return List.of();
+        }
+        JarEntry entry = file.getJarEntry(location.trim());
+        if (entry == null) {
+            return List.of();
+        }
+        Object document;
+        try (InputStream in = file.getInputStream(entry)) {
+            document = Json.parse(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+        } catch (IOException | RuntimeException _) {
+            return List.of();
+        }
+        if (!(document instanceof Map<?, ?> root)
+                || !(root.get("metadata") instanceof Map<?, ?> metadata)
+                || !(metadata.get("component") instanceof Map<?, ?> component)
+                || !(component.get("licenses") instanceof List<?> licenses)) {
+            return List.of();
+        }
+        List<String[]> result = new ArrayList<>();
+        for (Object element : licenses) {
+            if (!(element instanceof Map<?, ?> wrapper)) {
+                continue;
+            }
+            if (wrapper.get("license") instanceof Map<?, ?> license) {
+                String id = string(license.get("id"));
+                String name = string(license.get("name"));
+                String url = string(license.get("url"));
+                if (id != null) {
+                    result.add(new String[]{id, url});
+                } else if (name != null || url != null) {
+                    result.add(new String[]{name, url});
+                }
+            } else {
+                String expression = string(wrapper.get("expression"));
+                if (expression != null) {
+                    result.add(new String[]{expression, null});
+                }
+            }
+        }
+        return result;
+    }
+
+    private static String bundleLicense(Manifest manifest) {
+        String value = manifest.getMainAttributes().getValue("Bundle-License");
+        if (value == null || value.isBlank()) {
             return null;
         }
+        int semicolon = value.indexOf(';');
+        return (semicolon < 0 ? value : value.substring(0, semicolon)).trim();
+    }
+
+    private static String licenseFile(JarFile file) throws IOException {
+        for (String name : List.of("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/LICENSE.md", "LICENSE", "LICENSE.txt")) {
+            JarEntry entry = file.getJarEntry(name);
+            if (entry == null) {
+                continue;
+            }
+            String[] spdx;
+            try (InputStream in = file.getInputStream(entry)) {
+                spdx = identify(new String(in.readAllBytes(), StandardCharsets.UTF_8), null);
+            }
+            if (spdx != null) {
+                return spdx[0];
+            }
+        }
+        return null;
+    }
+
+    private static String string(Object value) {
+        return value instanceof String text && !text.isBlank() ? text : null;
     }
 
     private static String describe(List<String[]> licenses) {

--- a/sources/build/jenesis/step/OsvDownload.java
+++ b/sources/build/jenesis/step/OsvDownload.java
@@ -5,6 +5,7 @@ import build.jenesis.BuildStep;
 import build.jenesis.BuildStepArgument;
 import build.jenesis.BuildStepContext;
 import build.jenesis.BuildStepResult;
+import build.jenesis.Json;
 import build.jenesis.SequencedProperties;
 import build.jenesis.maven.MavenDependencyKey;
 
@@ -236,7 +237,7 @@ public class OsvDownload implements BuildStep {
 
     private static Object parse(String response) {
         try {
-            return new Json(response).parse();
+            return Json.parse(response);
         } catch (RuntimeException _) {
             return null;
         }
@@ -310,118 +311,4 @@ public class OsvDownload implements BuildStep {
         }
     }
 
-    private static final class Json {
-
-        private final String text;
-        private int pos;
-
-        private Json(String text) {
-            this.text = text;
-        }
-
-        private Object parse() {
-            skip();
-            Object value = value();
-            skip();
-            return value;
-        }
-
-        private Object value() {
-            skip();
-            return switch (text.charAt(pos)) {
-                case '{' -> object();
-                case '[' -> array();
-                case '"' -> string();
-                case 't' -> literal("true", Boolean.TRUE);
-                case 'f' -> literal("false", Boolean.FALSE);
-                case 'n' -> literal("null", null);
-                default -> number();
-            };
-        }
-
-        private Map<String, Object> object() {
-            Map<String, Object> map = new LinkedHashMap<>();
-            pos++;
-            skip();
-            if (text.charAt(pos) == '}') {
-                pos++;
-                return map;
-            }
-            while (true) {
-                skip();
-                String key = string();
-                skip();
-                pos++;
-                map.put(key, value());
-                skip();
-                if (text.charAt(pos++) == '}') {
-                    return map;
-                }
-            }
-        }
-
-        private List<Object> array() {
-            List<Object> list = new ArrayList<>();
-            pos++;
-            skip();
-            if (text.charAt(pos) == ']') {
-                pos++;
-                return list;
-            }
-            while (true) {
-                list.add(value());
-                skip();
-                if (text.charAt(pos++) == ']') {
-                    return list;
-                }
-            }
-        }
-
-        private String string() {
-            StringBuilder builder = new StringBuilder();
-            pos++;
-            while (true) {
-                char c = text.charAt(pos++);
-                if (c == '"') {
-                    return builder.toString();
-                }
-                if (c != '\\') {
-                    builder.append(c);
-                    continue;
-                }
-                char escaped = text.charAt(pos++);
-                switch (escaped) {
-                    case 'n' -> builder.append('\n');
-                    case 't' -> builder.append('\t');
-                    case 'r' -> builder.append('\r');
-                    case 'b' -> builder.append('\b');
-                    case 'f' -> builder.append('\f');
-                    case 'u' -> {
-                        builder.append((char) Integer.parseInt(text.substring(pos, pos + 4), 16));
-                        pos += 4;
-                    }
-                    default -> builder.append(escaped);
-                }
-            }
-        }
-
-        private Object number() {
-            int start = pos;
-            while (pos < text.length() && "+-0123456789.eE".indexOf(text.charAt(pos)) >= 0) {
-                pos++;
-            }
-            return Double.parseDouble(text.substring(start, pos));
-        }
-
-        private Object literal(String token, Object value) {
-            pos += token.length();
-            return value;
-        }
-
-        private void skip() {
-            while (pos < text.length() && Character.isWhitespace(text.charAt(pos))) {
-                pos++;
-            }
-        }
-    }
 }

--- a/tests/build/jenesis/test/JsonTest.java
+++ b/tests/build/jenesis/test/JsonTest.java
@@ -1,0 +1,104 @@
+package build.jenesis.test;
+
+import module java.base;
+import module org.junit.jupiter.api;
+import build.jenesis.Json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class JsonTest {
+
+    @Test
+    public void parses_an_object_into_an_insertion_ordered_map() {
+        Object value = Json.parse("{\"b\": 1, \"a\": 2}");
+        assertThat(value).isInstanceOf(Map.class);
+        Map<?, ?> map = (Map<?, ?>) value;
+        Iterator<?> keys = map.keySet().iterator();
+        assertThat(keys.next()).isEqualTo("b");
+        assertThat(keys.next()).isEqualTo("a");
+        assertThat(map.get("a")).isEqualTo(2.0);
+    }
+
+    @Test
+    public void parses_an_array_of_mixed_values() {
+        Object value = Json.parse("[1, \"x\", true, false, null]");
+        assertThat(value).isInstanceOf(List.class);
+        List<?> list = (List<?>) value;
+        assertThat(list).hasSize(5);
+        assertThat(list.get(0)).isEqualTo(1.0);
+        assertThat(list.get(1)).isEqualTo("x");
+        assertThat(list.get(2)).isEqualTo(true);
+        assertThat(list.get(3)).isEqualTo(false);
+        assertThat(list.get(4)).isNull();
+    }
+
+    @Test
+    public void parses_numbers_as_doubles() {
+        assertThat(Json.parse("42")).isEqualTo(42.0);
+        assertThat(Json.parse("-3.5")).isEqualTo(-3.5);
+        assertThat(Json.parse("1e3")).isEqualTo(1000.0);
+    }
+
+    @Test
+    public void unescapes_strings() {
+        assertThat(Json.parse("\"a\\tb\\nc\"")).isEqualTo("a\tb\nc");
+        assertThat(Json.parse("\"quote: \\\" backslash: \\\\\"")).isEqualTo("quote: \" backslash: \\");
+    }
+
+    @Test
+    public void unescapes_a_unicode_escape() {
+        assertThat(Json.parse("\"\\u00e9\"")).isEqualTo(String.valueOf((char) 0xe9));
+    }
+
+    @Test
+    public void parses_nested_structures() {
+        Map<?, ?> root = (Map<?, ?>) Json.parse("{\"a\": [ {\"b\": 2} ]}");
+        List<?> a = (List<?>) root.get("a");
+        Map<?, ?> first = (Map<?, ?>) a.getFirst();
+        assertThat(first.get("b")).isEqualTo(2.0);
+    }
+
+    @Test
+    public void ignores_surrounding_whitespace() {
+        Map<?, ?> map = (Map<?, ?>) Json.parse("  \n { \"a\" : 1 } \t ");
+        assertThat(map.get("a")).isEqualTo(1.0);
+    }
+
+    @Test
+    public void parses_empty_object_and_array() {
+        assertThat((Map<?, ?>) Json.parse("{}")).isEmpty();
+        assertThat((List<?>) Json.parse("[]")).isEmpty();
+    }
+
+    @Test
+    public void duplicate_keys_keep_the_last_value() {
+        Map<?, ?> map = (Map<?, ?>) Json.parse("{\"a\": 1, \"a\": 2}");
+        assertThat(map).hasSize(1);
+        assertThat(map.get("a")).isEqualTo(2.0);
+    }
+
+    @Test
+    public void rejects_a_deeply_nested_array_without_a_stack_overflow() {
+        String bomb = "[".repeat(100_000);
+        assertThatThrownBy(() -> Json.parse(bomb))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("nesting");
+    }
+
+    @Test
+    public void rejects_a_deeply_nested_object_without_a_stack_overflow() {
+        String bomb = "{\"a\":".repeat(100_000);
+        assertThatThrownBy(() -> Json.parse(bomb)).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void truncated_input_fails_with_a_runtime_exception() {
+        assertThatThrownBy(() -> Json.parse("{\"a\":")).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    public void an_unterminated_string_fails_with_a_runtime_exception() {
+        assertThatThrownBy(() -> Json.parse("\"abc")).isInstanceOf(RuntimeException.class);
+    }
+}

--- a/tests/build/jenesis/test/step/LicenseCheckTest.java
+++ b/tests/build/jenesis/test/step/LicenseCheckTest.java
@@ -193,4 +193,85 @@ public class LicenseCheckTest {
             restore("jenesis.license.allowed", previous);
         }
     }
+
+    @Test
+    public void reads_an_embedded_sbom_license_when_no_pom_license_is_declared() throws Exception {
+        Path jar = argument.resolve("resolved/lib.jar");
+        resolveJarOnly("jenesis", "org.example.lib/1.0.0", jar);
+        writeSbomJar(jar, "META-INF/sbom/lib.cdx.json", """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.6",
+                  "metadata": {
+                    "component": {
+                      "type": "library",
+                      "name": "org.example.lib",
+                      "version": "1.0.0",
+                      "licenses": [ { "license": { "id": "Apache-2.0" } } ]
+                    }
+                  }
+                }
+                """);
+        assertThat(run(new LicenseCheck().allowed(new LinkedHashSet<>(List.of("Apache-2.0")))).next()).isTrue();
+        assertThat(report()).content().contains("org.example.lib/1.0.0 [OK]").contains("Apache-2.0");
+    }
+
+    @Test
+    public void reads_an_embedded_sbom_license_in_name_and_url_form() throws Exception {
+        Path jar = argument.resolve("resolved/lib.jar");
+        resolveJarOnly("jenesis", "org.example.lib/2.0.0", jar);
+        writeSbomJar(jar, "META-INF/sbom/lib.cdx.json", """
+                {
+                  "metadata": {
+                    "component": {
+                      "licenses": [ { "license": { "name": "Custom", "url": "https://opensource.org/licenses/MIT" } } ]
+                    }
+                  }
+                }
+                """);
+        assertThat(run(new LicenseCheck().allowed(new LinkedHashSet<>(List.of("MIT")))).next()).isTrue();
+    }
+
+    @Test
+    public void reads_a_license_text_file_when_the_manifest_has_no_license() throws Exception {
+        Path jar = argument.resolve("resolved/lib.jar");
+        resolveJarOnly("jenesis", "org.example.lib/3.0.0", jar);
+        writeFileJar(jar, "META-INF/LICENSE", """
+                Apache License
+                Version 2.0, January 2004
+                http://www.apache.org/licenses/
+                """);
+        assertThat(run(new LicenseCheck().allowed(new LinkedHashSet<>(List.of("Apache-2.0")))).next()).isTrue();
+        assertThat(report()).content().contains("org.example.lib/3.0.0 [OK]").contains("Apache-2.0");
+    }
+
+    private void resolveJarOnly(String repository, String coordinate, Path jar) throws IOException {
+        SequencedProperties dependencies = new SequencedProperties();
+        dependencies.setProperty("main/compile/" + repository + "/" + coordinate,
+                argument.relativize(jar).toString());
+        dependencies.store(argument.resolve(BuildStep.DEPENDENCIES));
+    }
+
+    private static void writeSbomJar(Path jar, String sbomLocation, String sbom) throws IOException {
+        Files.createDirectories(jar.getParent());
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().putValue("Manifest-Version", "1.0");
+        manifest.getMainAttributes().putValue("Sbom-Location", sbomLocation);
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar), manifest)) {
+            out.putNextEntry(new JarEntry(sbomLocation));
+            out.write(sbom.getBytes(StandardCharsets.UTF_8));
+            out.closeEntry();
+        }
+    }
+
+    private static void writeFileJar(Path jar, String entryName, String content) throws IOException {
+        Files.createDirectories(jar.getParent());
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().putValue("Manifest-Version", "1.0");
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar), manifest)) {
+            out.putNextEntry(new JarEntry(entryName));
+            out.write(content.getBytes(StandardCharsets.UTF_8));
+            out.closeEntry();
+        }
+    }
 }


### PR DESCRIPTION
## What

Lets a Jenesis consumer discover the license of a dependency that ships **no POM**, such as a native modular jar published to the Jenesis repository.

The emit side already exists: the `Sbom` step embeds the project's own license (from `metadata.properties` / `project.properties`) into the CycloneDX SBOM it bundles at `META-INF/sbom/<artifact>.cdx.json`, pointed to by the `Sbom-Location` manifest header. This change makes the consumer read it back.

## Changes

- **`build.jenesis.Json` (new)** — a minimal general-purpose JSON reader (`Json.parse` into `Map`/`List`/`String`/`Double`/`Boolean`/`null`), extracted from the parser that was private to `OsvDownload`.
- **`OsvDownload`** — delegates to the shared `Json`; its private parser copy is removed (behavior unchanged, covered by `OsvDownloadTest`).
- **`LicenseCheck`** — for a dependency whose POM declares no license, reads its embedded SBOM's `metadata.component.licenses` (via `Sbom-Location`), accepting the `{license:{id|name,url}}` and `{expression}` encodings, then falls back to the OSGi `Bundle-License` header. The check now covers every repository, not just Maven; a native module exposing no license is best-effort (surfaced when discoverable, a denied one still caught, a missing one skipped), while Maven keeps its strict missing-license policy.

## Tests

Two new `LicenseCheckTest` cases build a real jar with an embedded SBOM (SPDX-id form and name/url form) under a native coordinate. Full engine build run locally: `LicenseCheckTest`, `OsvDownloadTest`, and `SbomTest` all pass.

> Note: the local full-suite run shows 12 failures in the quality-tool `*ModuleRunTest` classes (Checkstyle/PMD/ktlint/etc.). These are pre-existing and unrelated: they are byte-identical to `main`, are green in CI's `project` job, and fail only locally because they resolve the tool at the floating Maven version `RELEASE`, whose transitive resolution does not complete in the sandbox. This PR does not touch that path.

## Base

Targets `compliance-module` because `LicenseCheck`/`OsvDownload` exist only on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
