### PR TITLE
Rename CycloneDxEmitter to CycloneDx and move it to build.jenesis

### DIFF
--- a/sources/build/jenesis/CycloneDx.java
+++ b/sources/build/jenesis/CycloneDx.java
@@ -1,10 +1,9 @@
-package build.jenesis.step;
+package build.jenesis;
 
 import module java.base;
 import module java.xml;
-import build.jenesis.License;
 
-public class CycloneDxEmitter {
+public class CycloneDx {
 
     public enum Format {
 

--- a/sources/build/jenesis/project/InferredMultiProjectAssembler.java
+++ b/sources/build/jenesis/project/InferredMultiProjectAssembler.java
@@ -5,12 +5,12 @@ import build.jenesis.BuildStep;
 import build.jenesis.BuildStepArgument;
 import build.jenesis.BuildStepContext;
 import build.jenesis.BuildStepResult;
+import build.jenesis.CycloneDx;
 import build.jenesis.PathPlacement;
 import build.jenesis.Repository;
 import build.jenesis.Resolver;
 import build.jenesis.SequencedProperties;
 import build.jenesis.step.Bundle;
-import build.jenesis.step.CycloneDxEmitter;
 import build.jenesis.step.Inventory;
 import build.jenesis.step.JLink;
 import build.jenesis.step.JMod;
@@ -27,7 +27,7 @@ public record InferredMultiProjectAssembler(String packaging,
                                             boolean bundle,
                                             boolean launcher,
                                             boolean nativeImage,
-                                            CycloneDxEmitter.Format sbom,
+                                            CycloneDx.Format sbom,
                                             UnaryOperator<InferredSourceCodeQualityModule> check,
                                             UnaryOperator<InferredSourceFormattingModule> format,
                                             UnaryOperator<InferredByteCodeQualityModule> validate,
@@ -45,8 +45,8 @@ public record InferredMultiProjectAssembler(String packaging,
                 Boolean.getBoolean("jenesis.java.launcher"),
                 Boolean.getBoolean("jenesis.java.native"),
                 sbomFormat == null ? null : switch (sbomFormat) {
-                    case "", "json" -> CycloneDxEmitter.Format.JSON;
-                    case "xml" -> CycloneDxEmitter.Format.XML;
+                    case "", "json" -> CycloneDx.Format.JSON;
+                    case "xml" -> CycloneDx.Format.XML;
                     default -> throw new IllegalArgumentException(
                             "Unknown SBOM format: " + sbomFormat + " (expected json or xml)");
                 },
@@ -82,7 +82,7 @@ public record InferredMultiProjectAssembler(String packaging,
         return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, launcher, nativeImage, sbom, check, format, validate, observe, test, compliance);
     }
 
-    public InferredMultiProjectAssembler sbom(CycloneDxEmitter.Format sbom) {
+    public InferredMultiProjectAssembler sbom(CycloneDx.Format sbom) {
         return new InferredMultiProjectAssembler(packaging, jmod, jlink, bundle, launcher, nativeImage, sbom, check, format, validate, observe, test, compliance);
     }
 

--- a/sources/build/jenesis/step/Sbom.java
+++ b/sources/build/jenesis/step/Sbom.java
@@ -5,6 +5,7 @@ import build.jenesis.BuildStep;
 import build.jenesis.BuildStepArgument;
 import build.jenesis.BuildStepContext;
 import build.jenesis.BuildStepResult;
+import build.jenesis.CycloneDx;
 import build.jenesis.HashDigestFunction;
 import build.jenesis.License;
 import build.jenesis.Resolver;
@@ -13,17 +14,17 @@ import build.jenesis.maven.MavenDependencyKey;
 
 public class Sbom implements BuildStep {
 
-    private final CycloneDxEmitter.Format format;
+    private final CycloneDx.Format format;
 
     public Sbom() {
-        this(CycloneDxEmitter.Format.JSON);
+        this(CycloneDx.Format.JSON);
     }
 
-    private Sbom(CycloneDxEmitter.Format format) {
+    private Sbom(CycloneDx.Format format) {
         this.format = format;
     }
 
-    public Sbom format(CycloneDxEmitter.Format format) {
+    public Sbom format(CycloneDx.Format format) {
         return new Sbom(format);
     }
 
@@ -48,7 +49,7 @@ public class Sbom implements BuildStep {
             throw new IllegalStateException("Missing project/artifact/version in metadata.properties for the SBOM");
         }
         HashDigestFunction hash = new HashDigestFunction("SHA-256");
-        SequencedMap<String, CycloneDxEmitter.Component> components = new LinkedHashMap<>();
+        SequencedMap<String, CycloneDx.Component> components = new LinkedHashMap<>();
         List<Path> graphFiles = new ArrayList<>();
         for (BuildStepArgument argument : arguments.values()) {
             Path graphFile = argument.folder().resolve("graph.properties");
@@ -82,15 +83,15 @@ public class Sbom implements BuildStep {
             }
         }
         String projectRef = groupId + "/" + artifactId + "/" + version;
-        CycloneDxEmitter.Component project = new CycloneDxEmitter.Component(projectRef,
+        CycloneDx.Component project = new CycloneDx.Component(projectRef,
                 groupId,
                 artifactId,
                 version,
                 "pkg:maven/" + groupId + "/" + artifactId + "@" + version,
                 null,
                 ownLicenses(metadata));
-        List<CycloneDxEmitter.Dependency> dependencies = relationships(projectRef, components.keySet(), graphFiles);
-        String document = new CycloneDxEmitter().emit(format, project, new ArrayList<>(components.values()), dependencies);
+        List<CycloneDx.Dependency> dependencies = relationships(projectRef, components.keySet(), graphFiles);
+        String document = new CycloneDx().emit(format, project, new ArrayList<>(components.values()), dependencies);
 
         Path embedded = Files.createDirectories(context.next()
                 .resolve(RESOURCES).resolve("META-INF").resolve("sbom"));
@@ -109,7 +110,7 @@ public class Sbom implements BuildStep {
         return CompletableFuture.completedStage(new BuildStepResult(true));
     }
 
-    private static CycloneDxEmitter.Component component(String coordinate, String sha256, List<License> licenses) {
+    private static CycloneDx.Component component(String coordinate, String sha256, List<License> licenses) {
         try {
             MavenDependencyKey.Versioned parsed = MavenDependencyKey.tryParse(coordinate);
             if (parsed.version() != null) {
@@ -126,13 +127,13 @@ public class Sbom implements BuildStep {
                 if (!qualifiers.isEmpty()) {
                     purl.append("?").append(String.join("&", qualifiers));
                 }
-                return new CycloneDxEmitter.Component(coordinate, key.groupId(), key.artifactId(), parsed.version(),
+                return new CycloneDx.Component(coordinate, key.groupId(), key.artifactId(), parsed.version(),
                         purl.toString(), sha256, licenses);
             }
         } catch (RuntimeException _) {
         }
         int last = coordinate.lastIndexOf('/');
-        return new CycloneDxEmitter.Component(coordinate,
+        return new CycloneDx.Component(coordinate,
                 null,
                 last < 0 ? coordinate : coordinate.substring(0, last),
                 last < 0 ? "" : coordinate.substring(last + 1),
@@ -141,7 +142,7 @@ public class Sbom implements BuildStep {
                 licenses);
     }
 
-    private static List<CycloneDxEmitter.Dependency> relationships(String projectRef,
+    private static List<CycloneDx.Dependency> relationships(String projectRef,
                                                                    Set<String> componentRefs,
                                                                    List<Path> graphFiles) throws IOException {
         if (graphFiles.isEmpty()) {
@@ -179,8 +180,8 @@ public class Sbom implements BuildStep {
                 dependsOn.get(parentRef).add(childRef);
             }
         }
-        List<CycloneDxEmitter.Dependency> result = new ArrayList<>();
-        dependsOn.forEach((ref, on) -> result.add(new CycloneDxEmitter.Dependency(ref, new ArrayList<>(on))));
+        List<CycloneDx.Dependency> result = new ArrayList<>();
+        dependsOn.forEach((ref, on) -> result.add(new CycloneDx.Dependency(ref, new ArrayList<>(on))));
         return result;
     }
 

--- a/tests/build/jenesis/test/CycloneDxTest.java
+++ b/tests/build/jenesis/test/CycloneDxTest.java
@@ -1,34 +1,34 @@
-package build.jenesis.test.step;
+package build.jenesis.test;
 
 import module java.base;
 import module org.junit.jupiter.api;
+import build.jenesis.CycloneDx;
 import build.jenesis.License;
-import build.jenesis.step.CycloneDxEmitter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CycloneDxEmitterTest {
+public class CycloneDxTest {
 
-    private final CycloneDxEmitter emitter = new CycloneDxEmitter();
+    private final CycloneDx emitter = new CycloneDx();
 
-    private static final CycloneDxEmitter.Component PROJECT = new CycloneDxEmitter.Component(
+    private static final CycloneDx.Component PROJECT = new CycloneDx.Component(
             "build.jenesis/demo/1.0.0", "build.jenesis", "demo", "1.0.0", "pkg:maven/build.jenesis/demo@1.0.0", null,
             List.of(new License("Apache-2.0", "https://www.apache.org/licenses/LICENSE-2.0.txt")));
 
-    private static final List<CycloneDxEmitter.Component> COMPONENTS = List.of(
-            new CycloneDxEmitter.Component("org.foo/bar/1.2.3", "org.foo", "bar", "1.2.3", "pkg:maven/org.foo/bar@1.2.3", "abc123",
+    private static final List<CycloneDx.Component> COMPONENTS = List.of(
+            new CycloneDx.Component("org.foo/bar/1.2.3", "org.foo", "bar", "1.2.3", "pkg:maven/org.foo/bar@1.2.3", "abc123",
                     List.of(new License("The Apache Software License, Version 2.0", "https://apache.org/"))),
-            new CycloneDxEmitter.Component("org.baz/qux/4.5", "org.baz", "qux", "4.5", "pkg:maven/org.baz/qux@4.5", "def456",
+            new CycloneDx.Component("org.baz/qux/4.5", "org.baz", "qux", "4.5", "pkg:maven/org.baz/qux@4.5", "def456",
                     List.of(new License("Some Custom License", "https://example.com/license"))));
 
-    private static final List<CycloneDxEmitter.Dependency> DEPENDENCIES = List.of(
-            new CycloneDxEmitter.Dependency("build.jenesis/demo/1.0.0", List.of("org.foo/bar/1.2.3")),
-            new CycloneDxEmitter.Dependency("org.foo/bar/1.2.3", List.of("org.baz/qux/4.5")),
-            new CycloneDxEmitter.Dependency("org.baz/qux/4.5", List.of()));
+    private static final List<CycloneDx.Dependency> DEPENDENCIES = List.of(
+            new CycloneDx.Dependency("build.jenesis/demo/1.0.0", List.of("org.foo/bar/1.2.3")),
+            new CycloneDx.Dependency("org.foo/bar/1.2.3", List.of("org.baz/qux/4.5")),
+            new CycloneDx.Dependency("org.baz/qux/4.5", List.of()));
 
     @Test
     public void emits_cyclonedx_json() {
-        String json = emitter.emit(CycloneDxEmitter.Format.JSON, PROJECT, COMPONENTS, DEPENDENCIES);
+        String json = emitter.emit(CycloneDx.Format.JSON, PROJECT, COMPONENTS, DEPENDENCIES);
         assertThat(json)
                 .contains("\"bomFormat\": \"CycloneDX\"")
                 .contains("\"specVersion\": \"1.6\"")
@@ -49,7 +49,7 @@ public class CycloneDxEmitterTest {
 
     @Test
     public void emits_cyclonedx_xml() {
-        String xml = emitter.emit(CycloneDxEmitter.Format.XML, PROJECT, COMPONENTS, DEPENDENCIES);
+        String xml = emitter.emit(CycloneDx.Format.XML, PROJECT, COMPONENTS, DEPENDENCIES);
         assertThat(xml)
                 .contains("<bom")
                 .contains("cyclonedx.org/schema/bom/1.6")
@@ -62,8 +62,8 @@ public class CycloneDxEmitterTest {
 
     @Test
     public void is_deterministic_and_order_independent() {
-        String first = emitter.emit(CycloneDxEmitter.Format.JSON, PROJECT, COMPONENTS, DEPENDENCIES);
-        String reversed = emitter.emit(CycloneDxEmitter.Format.JSON, PROJECT,
+        String first = emitter.emit(CycloneDx.Format.JSON, PROJECT, COMPONENTS, DEPENDENCIES);
+        String reversed = emitter.emit(CycloneDx.Format.JSON, PROJECT,
                 List.of(COMPONENTS.get(1), COMPONENTS.get(0)),
                 List.of(DEPENDENCIES.get(2), DEPENDENCIES.get(1), DEPENDENCIES.get(0)));
         assertThat(reversed)


### PR DESCRIPTION
Moves `CycloneDxEmitter` to the main `build.jenesis` package and renames it `CycloneDx` (it's a general-purpose CycloneDX SBOM emitter, like `Json` is a parser, not a build step). `Sbom`, `InferredMultiProjectAssembler`, and the test (now `build.jenesis.test.CycloneDxTest`) are updated. No module-info or config changes (both packages were already exported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
