### PR TITLE
Resolve a group once, and cover the code the tests ran against

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
           - { name: vulnerabilities, dir: demo-14-vulnerabilities, entry: build/Demo.java }
           - { name: profiles, dir: demo-15-profiles, entry: build/jenesis/Project.java, flags: -Djenesis.project.properties=release, verify: 'find target -type d -path "*assemble/sources*" | grep -q .' }
           - { name: test-selection, dir: demo-24-test-selection, entry: build/Demo.java }
-          - { name: pitest, dir: demo-25-pitest, entry: build/jenesis/Project.java, verify: 'find target -type d -name mutate | grep -q .' }
+          - { name: pitest, dir: demo-25-pitest, entry: build/jenesis/Project.java, verify: 'find target -path "*reports/pitest/mutations.xml" -exec grep -l "calc.Calculator" {} + | grep -q .' }
           - { name: agents, dir: demo-26-agents, entry: build/Demo.java, verify: 'find target -name classes.jar | grep -q .' }
           - { name: bom, dir: demo-28-bom, entry: build/jenesis/Project.java, verify: 'find target -name classes.jar | grep -q .' }
           - { name: module-alias, dir: demo-31-module-alias, entry: 'build/jenesis/Execute.java -name Ada -shout', verify: 'find target -name classes.jar | grep -q .' }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           - { name: groovy, dir: demo-21-groovy, entry: build/jenesis/Project.java, verify: 'find target -name classes.jar | grep -q .' }
           - { name: groovy-documentation, dir: demo-21-groovy, entry: build/jenesis/Project.java, flags: -Djenesis.project.documentation=true, verify: 'find target -type d -name documentation | grep -q .' }
           - { name: groovy-quality, dir: demo-22-groovy-quality, entry: build/jenesis/Project.java, verify: 'find target -type d -name codenarc | grep -q .' }
-          - { name: code-coverage, dir: demo-23-code-coverage, entry: build/jenesis/Project.java, verify: 'find target -type d -path "*jacoco*" | grep -q .' }
+          - { name: code-coverage, dir: demo-23-code-coverage, entry: build/jenesis/Project.java, verify: 'find target -path "*reports/jacoco/coverage/Calculator.html" | grep -q .' }
           - { name: maven-exclusions, dir: demo-27-maven-exclusions, entry: build/jenesis/Project.java, verify: 'find target -name classes.jar | grep -q . && ! find target -path "*resolved*" -name "commons-lang3*" | grep -q .' }
           - { name: module-layout, dir: demo-29-module-layout, entry: build/jenesis/Project.java, verify: 'find target -name classes.jar | grep -q .' }
           - { name: module-classifier, dir: demo-30-module-classifier, entry: build/jenesis/Execute.java }

--- a/sources/build/jenesis/project/CheckstyleModule.java
+++ b/sources/build/jenesis/project/CheckstyleModule.java
@@ -84,7 +84,7 @@ public class CheckstyleModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/CodeNarcModule.java
+++ b/sources/build/jenesis/project/CodeNarcModule.java
@@ -81,7 +81,7 @@ public class CodeNarcModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/DetektModule.java
+++ b/sources/build/jenesis/project/DetektModule.java
@@ -84,7 +84,7 @@ public class DetektModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/DokkaDocumentationModule.java
+++ b/sources/build/jenesis/project/DokkaDocumentationModule.java
@@ -92,7 +92,7 @@ public class DokkaDocumentationModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(upstream);
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> documentInputs = new LinkedHashSet<>();
         documentInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/GoogleJavaFormatModule.java
+++ b/sources/build/jenesis/project/GoogleJavaFormatModule.java
@@ -71,7 +71,7 @@ public class GoogleJavaFormatModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(group),
                 resolveInputs);
         SequencedSet<String> formatInputs = new LinkedHashSet<>();
         formatInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/GroovyCompilerModule.java
+++ b/sources/build/jenesis/project/GroovyCompilerModule.java
@@ -93,7 +93,7 @@ public class GroovyCompilerModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(upstream);
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> compileInputs = new LinkedHashSet<>();
         compileInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/GroovyDocumentationModule.java
+++ b/sources/build/jenesis/project/GroovyDocumentationModule.java
@@ -100,7 +100,7 @@ public class GroovyDocumentationModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(upstream);
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> documentInputs = new LinkedHashSet<>();
         documentInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/JaCoCoModule.java
+++ b/sources/build/jenesis/project/JaCoCoModule.java
@@ -104,10 +104,10 @@ public class JaCoCoModule implements BuildExecutorModule {
                                                      SequencedMap<String, BuildStepArgument> arguments,
                                                      SequencedMap<String, SequencedMap<String, String>> properties)
                 throws IOException {
-            List<String> jars = new ArrayList<>(), classes = new ArrayList<>(), sources = new ArrayList<>();
-            List<Path> resolved = new ArrayList<>();
+            List<String> jars = new ArrayList<>(), sources = new ArrayList<>();
+            SequencedSet<String> classes = new LinkedHashSet<>();
+            SequencedMap<String, Path> covered = new LinkedHashMap<>();
             Path data = null;
-            String artifact = null, version = null;
             for (BuildStepArgument argument : arguments.values()) {
                 if (argument.removed()) {
                     continue;
@@ -127,30 +127,10 @@ public class JaCoCoModule implements BuildExecutorModule {
                 if (Files.isDirectory(source)) {
                     sources.add(source.toString());
                 }
-                Path metadata = argument.folder().resolve(BuildStep.METADATA);
-                if (Files.isRegularFile(metadata)) {
-                    SequencedProperties descriptor = SequencedProperties.ofFiles(metadata);
-                    if (artifact == null) {
-                        artifact = descriptor.getProperty("artifact");
-                    }
-                    if (version == null) {
-                        version = descriptor.getProperty("version");
-                    }
-                }
-                Path folder = argument.folder().resolve(Dependencies.RESOLVED);
-                if (Files.isDirectory(folder)) {
-                    try (Stream<Path> files = Files.list(folder)) {
-                        files.filter(file -> file.getFileName().toString().endsWith(".jar")).forEach(resolved::add);
-                    }
-                }
+                Dependencies.internal(argument.folder()).forEach(covered::putIfAbsent);
             }
-            if (artifact != null && version != null) {
-                String suffix = artifact + "-" + version + ".jar";
-                for (Path jar : resolved) {
-                    if (jar.getFileName().toString().endsWith(suffix)) {
-                        classes.add(jar.toString());
-                    }
-                }
+            for (Path jar : covered.values()) {
+                classes.add(jar.toString());
             }
             if (data == null || classes.isEmpty()) {
                 return CompletableFuture.completedStage(null);

--- a/sources/build/jenesis/project/JaCoCoModule.java
+++ b/sources/build/jenesis/project/JaCoCoModule.java
@@ -62,7 +62,7 @@ public class JaCoCoModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> reportInputs = new LinkedHashSet<>();
         reportInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/KotlinCompilerModule.java
+++ b/sources/build/jenesis/project/KotlinCompilerModule.java
@@ -93,7 +93,7 @@ public class KotlinCompilerModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(upstream);
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> compileInputs = new LinkedHashSet<>();
         compileInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/KtlintFormatModule.java
+++ b/sources/build/jenesis/project/KtlintFormatModule.java
@@ -75,7 +75,7 @@ public class KtlintFormatModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(group),
                 resolveInputs);
         SequencedSet<String> formatInputs = new LinkedHashSet<>();
         formatInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/KtlintModule.java
+++ b/sources/build/jenesis/project/KtlintModule.java
@@ -77,7 +77,7 @@ public class KtlintModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/LauncherModule.java
+++ b/sources/build/jenesis/project/LauncherModule.java
@@ -60,7 +60,7 @@ public class LauncherModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(group),
                 resolveInputs);
         SequencedSet<String> bundleInputs = new LinkedHashSet<>();
         bundleInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/PalantirJavaFormatModule.java
+++ b/sources/build/jenesis/project/PalantirJavaFormatModule.java
@@ -71,7 +71,7 @@ public class PalantirJavaFormatModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(group),
                 resolveInputs);
         SequencedSet<String> formatInputs = new LinkedHashSet<>();
         formatInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/PiTestModule.java
+++ b/sources/build/jenesis/project/PiTestModule.java
@@ -163,12 +163,15 @@ public class PiTestModule implements BuildExecutorModule {
                 for (Path jar : Dependencies.select(argument.folder(), tool, "classpath")) {
                     external.add(jar.toString());
                 }
+                SequencedMap<String, Path> mutable = Dependencies.internal(argument.folder());
+                for (Map.Entry<String, Path> entry : mutable.entrySet()) {
+                    if (expanded.add(entry.getKey())) {
+                        extract(entry.getValue(), code);
+                    }
+                }
                 for (Path jar : Dependencies.select(argument.folder(), group, "runtime")) {
-                    String fileName = jar.getFileName().toString();
-                    if (fileName.contains("%2F")) {
+                    if (!mutable.containsValue(jar)) {
                         external.add(jar.toString());
-                    } else if (expanded.add(fileName)) {
-                        extract(jar, code);
                     }
                 }
                 Path classes = argument.folder().resolve(BuildStep.CLASSES);

--- a/sources/build/jenesis/project/PiTestModule.java
+++ b/sources/build/jenesis/project/PiTestModule.java
@@ -76,7 +76,7 @@ public class PiTestModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> mutateInputs = new LinkedHashSet<>();
         mutateInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/PmdModule.java
+++ b/sources/build/jenesis/project/PmdModule.java
@@ -84,7 +84,7 @@ public class PmdModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/ScalaCompilerModule.java
+++ b/sources/build/jenesis/project/ScalaCompilerModule.java
@@ -93,7 +93,7 @@ public class ScalaCompilerModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(upstream);
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> compileInputs = new LinkedHashSet<>();
         compileInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/ScalaDocumentationModule.java
+++ b/sources/build/jenesis/project/ScalaDocumentationModule.java
@@ -93,7 +93,7 @@ public class ScalaDocumentationModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(upstream);
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> documentInputs = new LinkedHashSet<>();
         documentInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/ScalafmtFormatModule.java
+++ b/sources/build/jenesis/project/ScalafmtFormatModule.java
@@ -82,7 +82,7 @@ public class ScalafmtFormatModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(group),
                 resolveInputs);
         SequencedSet<String> formatInputs = new LinkedHashSet<>();
         formatInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/ScalafmtModule.java
+++ b/sources/build/jenesis/project/ScalafmtModule.java
@@ -84,7 +84,7 @@ public class ScalafmtModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/ScalastyleModule.java
+++ b/sources/build/jenesis/project/ScalastyleModule.java
@@ -84,7 +84,7 @@ public class ScalastyleModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/project/SpotBugsModule.java
+++ b/sources/build/jenesis/project/SpotBugsModule.java
@@ -90,7 +90,7 @@ public class SpotBugsModule implements BuildExecutorModule {
         resolveInputs.add(REQUIRED);
         resolveInputs.addAll(inherited.sequencedKeySet());
         buildExecutor.addStep(DEPENDENCIES,
-                new Dependencies(repositories, resolvers).pinning(pinning),
+                new Dependencies(repositories, resolvers).pinning(pinning).group(tool),
                 resolveInputs);
         SequencedSet<String> checkInputs = new LinkedHashSet<>();
         checkInputs.add(DEPENDENCIES);

--- a/sources/build/jenesis/step/Dependencies.java
+++ b/sources/build/jenesis/step/Dependencies.java
@@ -210,8 +210,10 @@ public class Dependencies implements BuildStep {
         if (group != null) {
             requires.keySet().retainAll(Set.of(group));
             moduleAliases.keySet().retainAll(Set.of(group));
-            bomTokens.keySet().removeIf(token -> !token.startsWith("bom/" + group + "/")
-                    && !token.startsWith("entry/" + group + "/"));
+            bomTokens.keySet().removeIf(token -> {
+                int first = token.indexOf('/'), second = token.indexOf('/', first + 1);
+                return second < 0 || !group.equals(token.substring(first + 1, second));
+            });
             exclusions.keySet().retainAll(Set.of(group));
             versions.keySet().retainAll(Set.of(group));
         }

--- a/sources/build/jenesis/step/Dependencies.java
+++ b/sources/build/jenesis/step/Dependencies.java
@@ -30,21 +30,28 @@ public class Dependencies implements BuildStep {
     private final transient Map<String, Repository> repositories;
     private final Map<String, Resolver> resolvers;
     private final Pinning pinning;
+    private final String group;
 
     public Dependencies(Map<String, Repository> repositories, Map<String, Resolver> resolvers) {
-        this(repositories, resolvers, null);
+        this(repositories, resolvers, null, null);
     }
 
     private Dependencies(Map<String, Repository> repositories,
                          Map<String, Resolver> resolvers,
-                         Pinning pinning) {
+                         Pinning pinning,
+                         String group) {
         this.repositories = repositories;
         this.resolvers = new LinkedHashMap<>(resolvers);
         this.pinning = pinning;
+        this.group = group;
     }
 
     public Dependencies pinning(Pinning pinning) {
-        return new Dependencies(repositories, resolvers, pinning);
+        return new Dependencies(repositories, resolvers, pinning, group);
+    }
+
+    public Dependencies group(String group) {
+        return new Dependencies(repositories, resolvers, pinning, group);
     }
 
     public static SequencedMap<String, String> bomEntries(SequencedProperties properties, String group) {
@@ -199,6 +206,14 @@ public class Dependencies implements BuildStep {
                             .put(parts[3], excludes);
                 }
             }
+        }
+        if (group != null) {
+            requires.keySet().retainAll(Set.of(group));
+            moduleAliases.keySet().retainAll(Set.of(group));
+            bomTokens.keySet().removeIf(token -> !token.startsWith("bom/" + group + "/")
+                    && !token.startsWith("entry/" + group + "/"));
+            exclusions.keySet().retainAll(Set.of(group));
+            versions.keySet().retainAll(Set.of(group));
         }
         Path libs = Files.createDirectories(context.next().resolve(RESOLVED));
         Path previousLibs = context.previous() == null ? null : context.previous().resolve(RESOLVED);

--- a/sources/build/jenesis/step/Dependencies.java
+++ b/sources/build/jenesis/step/Dependencies.java
@@ -727,6 +727,33 @@ public class Dependencies implements BuildStep {
         return new ArrayList<>(selected);
     }
 
+    public static SequencedMap<String, Path> internal(Path folder) throws IOException {
+        Path file = index(folder), graphFile = folder.resolve(GRAPH);
+        if (file == null || !Files.exists(graphFile)) {
+            return new LinkedHashMap<>();
+        }
+        SequencedProperties properties = SequencedProperties.ofFiles(file);
+        SequencedMap<String, Path> selected = new LinkedHashMap<>();
+        for (Map.Entry<String, Resolver.Resolution> entry : graph(List.of(graphFile), List.of()).entrySet()) {
+            for (Map.Entry<String, Resolver.Vertex> vertex : entry.getValue().vertices().entrySet()) {
+                if (!vertex.getValue().internal() || vertex.getValue().resolvedVersion() == null) {
+                    continue;
+                }
+                String coordinate = vertex.getKey() + "/" + vertex.getValue().resolvedVersion();
+                String value = properties.getProperty(entry.getKey() + "/" + coordinate);
+                if (value == null) {
+                    continue;
+                }
+                int space = value.indexOf(' ');
+                Path jar = folder.resolve(space < 0 ? value : value.substring(0, space)).normalize();
+                if (Files.exists(jar)) {
+                    selected.putIfAbsent(coordinate, jar);
+                }
+            }
+        }
+        return selected;
+    }
+
     private static final Map<String, String> DEFAULT_ALIASES = Map.ofEntries(
             Map.entry("apache license 2.0", "Apache-2.0"),
             Map.entry("apache license, version 2.0", "Apache-2.0"),

--- a/tests/build/jenesis/test/project/CheckstyleModuleTest.java
+++ b/tests/build/jenesis/test/project/CheckstyleModuleTest.java
@@ -36,6 +36,10 @@ public class CheckstyleModuleTest {
 
     @Test
     public void tool_emits_an_independent_resolution_trail() throws IOException {
+        SequencedProperties requires = new SequencedProperties();
+        requires.setProperty("main/compile/maven/org.example/library/1.0", "");
+        requires.store(project.resolve(BuildStep.REQUIRES));
+
         BuildExecutor executor = newExecutor();
         executor.addSource("project", project);
         executor.addModule(
@@ -48,6 +52,7 @@ public class CheckstyleModuleTest {
         Path resolvedOutput = root.resolve("checkstyle").resolve("dependencies").resolve("output");
         SequencedProperties resolved = SequencedProperties.ofFiles(resolvedOutput.resolve(BuildStep.DEPENDENCIES));
         assertThat(resolved.stringPropertyNames())
+                .as("the module's own closure is resolved by the module, not again by every tool")
                 .containsExactly("custom/runtime/maven/com.puppycrawl.tools/checkstyle/RELEASE");
     }
 

--- a/tests/build/jenesis/test/project/JaCoCoModuleTest.java
+++ b/tests/build/jenesis/test/project/JaCoCoModuleTest.java
@@ -1,6 +1,7 @@
 package build.jenesis.test.project;
 
 import module java.base;
+import module java.compiler;
 import module org.junit.jupiter.api;
 import build.jenesis.BuildExecutor;
 import build.jenesis.BuildExecutorCache;
@@ -8,15 +9,22 @@ import build.jenesis.BuildExecutorCallback;
 import build.jenesis.BuildStep;
 import build.jenesis.BuildStepHashFunction;
 import build.jenesis.HashDigestFunction;
+import build.jenesis.Repository;
+import build.jenesis.RepositoryItem;
+import build.jenesis.Resolver;
 import build.jenesis.SequencedProperties;
 import build.jenesis.project.JaCoCoModule;
+import build.jenesis.step.Dependencies;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import javax.tools.ToolProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JaCoCoModuleTest {
 
     @TempDir
-    private Path root, project;
+    private Path root, project, tool;
 
     @Test
     public void requires_step_emits_the_jacoco_cli_coordinate() throws IOException {
@@ -29,6 +37,76 @@ public class JaCoCoModuleTest {
         SequencedProperties requires = SequencedProperties.ofFiles(requiredOutput.resolve(BuildStep.REQUIRES));
         assertThat(requires.stringPropertyNames())
                 .containsExactly("jacoco/runtime/maven/org.jacoco/org.jacoco.cli/RELEASE");
+    }
+
+    @Test
+    public void report_reads_the_first_party_jar_from_the_resolved_closure() throws IOException {
+        Path resolved = Files.createDirectory(project.resolve(Dependencies.RESOLVED));
+        Path first = Files.write(resolved.resolve("maven%2Forg.example%2Flibrary%2F1.0.jar"), new byte[0]);
+        Path third = Files.write(resolved.resolve("maven%2Forg.example%2Fexternal%2F2.0.jar"), new byte[0]);
+        Files.write(project.resolve("jacoco.exec"), new byte[0]);
+        SequencedProperties index = new SequencedProperties();
+        index.setProperty("main/compile/maven/org.example/library/1.0",
+                Dependencies.RESOLVED + first.getFileName());
+        index.setProperty("main/compile/maven/org.example/external/2.0",
+                Dependencies.RESOLVED + third.getFileName());
+        index.store(project.resolve(BuildStep.DEPENDENCIES));
+        SequencedProperties graph = new SequencedProperties();
+        graph.setProperty("vertex/main/compile/maven/org.example/library", "1.0\t\tfalse\ttrue");
+        graph.setProperty("vertex/main/compile/maven/org.example/external", "2.0\t\tfalse\tfalse");
+        graph.store(project.resolve(Dependencies.GRAPH));
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule(
+                "jacoco",
+                new JaCoCoModule(Map.of("maven", serving(cli())), Map.of("maven", Resolver.identity())),
+                "project");
+        executor.execute("jacoco/report");
+
+        Path command = root.resolve("jacoco").resolve("report").resolve("supplement").resolve("command");
+        assertThat(command)
+                .as("the report runs once the closure yields code under test")
+                .exists();
+        assertThat(Files.readString(command))
+                .as("a first-party jar is recognised by its coordinate, whatever its file name")
+                .contains("--classfiles " + first)
+                .as("a third-party jar is not code under test")
+                .doesNotContain(third.toString());
+    }
+
+    private Path cli() throws IOException {
+        Path source = tool.resolve("Main.java");
+        Files.writeString(source, """
+                package org.jacoco.cli.internal;
+                public class Main {
+                    public static void main(String[] args) {
+                    }
+                }
+                """);
+        Path classes = Files.createDirectory(tool.resolve("classes"));
+        if (ToolProvider.getSystemJavaCompiler().run(null,
+                null,
+                null,
+                "-d", classes.toString(),
+                source.toString()) != 0) {
+            throw new IllegalStateException("Failed to compile the JaCoCo CLI double");
+        }
+        Path jar = tool.resolve("cli.jar");
+        try (JarOutputStream stream = new JarOutputStream(Files.newOutputStream(jar))) {
+            stream.putNextEntry(new JarEntry("org/jacoco/cli/internal/Main.class"));
+            stream.write(Files.readAllBytes(classes.resolve("org")
+                    .resolve("jacoco")
+                    .resolve("cli")
+                    .resolve("internal")
+                    .resolve("Main.class")));
+            stream.closeEntry();
+        }
+        return jar;
+    }
+
+    private static Repository serving(Path jar) {
+        return (_, _) -> Optional.of(RepositoryItem.ofFile(jar));
     }
 
     private BuildExecutor newExecutor() throws IOException {

--- a/tests/build/jenesis/test/project/PiTestModuleTest.java
+++ b/tests/build/jenesis/test/project/PiTestModuleTest.java
@@ -1,6 +1,7 @@
 package build.jenesis.test.project;
 
 import module java.base;
+import module java.compiler;
 import module org.junit.jupiter.api;
 import build.jenesis.BuildExecutor;
 import build.jenesis.BuildExecutorCache;
@@ -13,6 +14,8 @@ import build.jenesis.RepositoryItem;
 import build.jenesis.Resolver;
 import build.jenesis.SequencedProperties;
 import build.jenesis.project.PiTestModule;
+import build.jenesis.step.Dependencies;
+import javax.tools.ToolProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -20,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class PiTestModuleTest {
 
     @TempDir
-    private Path root, project;
+    private Path root, project, tool;
 
     @Test
     public void requires_step_emits_the_pitest_maven_coordinates() throws IOException {
@@ -87,8 +90,11 @@ public class PiTestModuleTest {
     @Test
     public void mutate_step_rejects_a_jar_entry_that_escapes_the_extraction_root() throws IOException {
         SequencedProperties index = new SequencedProperties();
-        index.setProperty("main/runtime/maven/org.evil/evil", "evil.jar");
+        index.setProperty("main/runtime/maven/org.evil/evil/1.0", "evil.jar");
         index.store(project.resolve(BuildStep.DEPENDENCIES));
+        SequencedProperties graph = new SequencedProperties();
+        graph.setProperty("vertex/main/runtime/maven/org.evil/evil", "1.0\t\tfalse\ttrue");
+        graph.store(project.resolve(Dependencies.GRAPH));
         try (JarOutputStream jar = new JarOutputStream(Files.newOutputStream(project.resolve("evil.jar")))) {
             jar.putNextEntry(new JarEntry("../escape.class"));
             jar.write(new byte[] {1, 2, 3});
@@ -104,6 +110,83 @@ public class PiTestModuleTest {
 
         assertThatThrownBy(() -> executor.execute("pitest/mutate"))
                 .hasStackTraceContaining("Resolved path escapes");
+    }
+
+    @Test
+    public void mutate_step_extracts_the_first_party_jar_and_leaves_a_library_on_the_class_path()
+            throws IOException {
+        Files.createDirectory(project.resolve(BuildStep.SOURCES));
+        jar(project.resolve("app.jar"), "app/App.class");
+        jar(project.resolve("library.jar"), "library/Library.class");
+        SequencedProperties index = new SequencedProperties();
+        index.setProperty("main/runtime/maven/org.example/app/1.0", "app.jar");
+        index.setProperty("main/runtime/maven/org.example/library/1.0", "library.jar");
+        index.store(project.resolve(BuildStep.DEPENDENCIES));
+        SequencedProperties graph = new SequencedProperties();
+        graph.setProperty("vertex/main/runtime/maven/org.example/app", "1.0\t\tfalse\ttrue");
+        graph.setProperty("vertex/main/runtime/maven/org.example/library", "1.0\t\tfalse\tfalse");
+        graph.store(project.resolve(Dependencies.GRAPH));
+
+        BuildExecutor executor = newExecutor();
+        executor.addSource("project", project);
+        executor.addModule(
+                "pitest",
+                new PiTestModule(Map.of("maven", serving(cli())), Map.of("maven", Resolver.identity())),
+                "project");
+        executor.execute("pitest/mutate");
+
+        Path mutate = root.resolve("pitest").resolve("mutate").resolve("supplement");
+        assertThat(mutate.resolve("code").resolve("app").resolve("App.class"))
+                .as("the code under test reaches the mutable code path as its own classes")
+                .exists();
+        assertThat(mutate.resolve("code").resolve("library"))
+                .as("a library is never mutated, whatever its jar is called")
+                .doesNotExist();
+        assertThat(Files.readString(mutate.resolve("command")))
+                .as("a library stays on the class path so the mutated code still resolves")
+                .contains(project.resolve("library.jar").toString());
+    }
+
+    private static void jar(Path jar, String entry) throws IOException {
+        try (JarOutputStream stream = new JarOutputStream(Files.newOutputStream(jar))) {
+            stream.putNextEntry(new JarEntry(entry));
+            stream.write(new byte[] {1, 2, 3});
+            stream.closeEntry();
+        }
+    }
+
+    private Path cli() throws IOException {
+        Path source = tool.resolve("MutationCoverageReport.java");
+        Files.writeString(source, """
+                package org.pitest.mutationtest.commandline;
+                public class MutationCoverageReport {
+                    public static void main(String[] args) {
+                    }
+                }
+                """);
+        Path classes = Files.createDirectory(tool.resolve("classes"));
+        if (ToolProvider.getSystemJavaCompiler().run(null,
+                null,
+                null,
+                "-d", classes.toString(),
+                source.toString()) != 0) {
+            throw new IllegalStateException("Failed to compile the PIT double");
+        }
+        Path jar = tool.resolve("pitest.jar");
+        try (JarOutputStream stream = new JarOutputStream(Files.newOutputStream(jar))) {
+            stream.putNextEntry(new JarEntry("org/pitest/mutationtest/commandline/MutationCoverageReport.class"));
+            stream.write(Files.readAllBytes(classes.resolve("org")
+                    .resolve("pitest")
+                    .resolve("mutationtest")
+                    .resolve("commandline")
+                    .resolve("MutationCoverageReport.class")));
+            stream.closeEntry();
+        }
+        return jar;
+    }
+
+    private static Repository serving(Path jar) {
+        return (_, _) -> Optional.of(RepositoryItem.ofFile(jar));
     }
 
     private Repository files() {

--- a/tests/build/jenesis/test/step/DependenciesMavenBomTest.java
+++ b/tests/build/jenesis/test/step/DependenciesMavenBomTest.java
@@ -121,6 +121,27 @@ public class DependenciesMavenBomTest {
     }
 
     @Test
+    public void a_scoped_step_ignores_a_maven_bom_of_another_group() throws IOException {
+        SequencedProperties requires = new SequencedProperties();
+        requires.setProperty("tool/runtime/maven/org.acme/tool/1.0", "");
+        requires.store(dependencies.resolve(BuildStep.REQUIRES));
+        SequencedProperties boms = new SequencedProperties();
+        boms.setProperty("bom/main/maven/org.acme/platform-bom", "1.0");
+        boms.store(dependencies.resolve(BuildStep.BOMS));
+        BuildStepResult result = apply(new Dependencies(
+                Map.of("maven", maven(Map.of("org.acme/tool/pom/1.0", """
+                        <project xmlns="http://maven.apache.org/POM/4.0.0">
+                            <modelVersion>4.0.0</modelVersion>
+                        </project>
+                        """))),
+                Map.of("maven", new MavenPomResolver())).group("tool"));
+        assertThat(result.next()).isTrue();
+        assertThat(SequencedProperties.ofFiles(next.resolve(BuildStep.DEPENDENCIES)).stringPropertyNames())
+                .as("a tool never fetches the bill of materials that manages the module's own closure")
+                .containsExactly("tool/runtime/maven/org.acme/tool/1.0");
+    }
+
+    @Test
     public void local_pin_wins_over_maven_bom_entry() throws IOException {
         SequencedProperties requires = new SequencedProperties();
         requires.setProperty("main/compile/maven/org.acme/lib", "");

--- a/tests/build/jenesis/test/step/DependenciesResolutionTest.java
+++ b/tests/build/jenesis/test/step/DependenciesResolutionTest.java
@@ -98,6 +98,57 @@ public class DependenciesResolutionTest {
     }
 
     @Test
+    public void a_scoped_step_resolves_nothing_but_its_own_group() throws IOException {
+        SequencedProperties properties = new SequencedProperties();
+        properties.setProperty("main/compile/foo/qux", "");
+        properties.setProperty("tool/runtime/foo/baz", "");
+        properties.store(dependencies.resolve(BuildStep.REQUIRES));
+        BuildStepResult result = new Dependencies(Map.of("foo", files(Map.of())), Map.of("foo", (executor, prefix, repositories, descriptors, _, _) -> {
+                    SequencedMap<String, String> resolved = new LinkedHashMap<>();
+                    descriptors.sequencedKeySet().forEach(descriptor -> resolved.put(prefix + "/" + descriptor, ""));
+                    return new Resolver.Resolution(Resolver.materializeAll(executor, repositories, prefix, resolved), List.of(), new LinkedHashMap<>());
+                })).group("tool").apply(
+                Runnable::run,
+                new BuildStepContext(previous, next, supplement),
+                new LinkedHashMap<>(Map.of("dependencies", new BuildStepArgument(
+                        dependencies,
+                        Map.of(
+                                Path.of(BuildStep.REQUIRES),
+                                Checksum.of(ChecksumStatus.ADDED)))))).toCompletableFuture().join();
+        assertThat(result.next()).isTrue();
+        assertThat(SequencedProperties.ofFiles(next.resolve(BuildStep.DEPENDENCIES)).stringPropertyNames())
+                .as("a tool reads the module's requirements for its pins, but resolves only what it declares")
+                .containsExactly("tool/runtime/foo/baz");
+    }
+
+    @Test
+    public void a_scoped_step_leaves_an_alias_of_another_group_alone() throws IOException {
+        SequencedProperties properties = new SequencedProperties();
+        properties.setProperty("main/compile/foo/org.example/plain-lib", "");
+        properties.setProperty("tool/runtime/foo/baz", "");
+        properties.store(dependencies.resolve(BuildStep.REQUIRES));
+        SequencedProperties aliases = new SequencedProperties();
+        aliases.setProperty("main/foo/toolkit.lib", "org.example/plain-lib");
+        aliases.store(dependencies.resolve(BuildStep.ALIASES));
+        BuildStepResult result = new Dependencies(Map.of("foo", files(Map.of())), Map.of("foo", (executor, prefix, repositories, descriptors, _, _) -> {
+                    SequencedMap<String, String> resolved = new LinkedHashMap<>();
+                    descriptors.sequencedKeySet().forEach(descriptor -> resolved.put(prefix + "/" + descriptor, ""));
+                    return new Resolver.Resolution(Resolver.materializeAll(executor, repositories, prefix, resolved), List.of(), new LinkedHashMap<>());
+                })).group("tool").apply(
+                Runnable::run,
+                new BuildStepContext(previous, next, supplement),
+                new LinkedHashMap<>(Map.of("dependencies", new BuildStepArgument(
+                        dependencies,
+                        Map.of(
+                                Path.of(BuildStep.REQUIRES),
+                                Checksum.of(ChecksumStatus.ADDED)))))).toCompletableFuture().join();
+        assertThat(result.next()).isTrue();
+        assertThat(next.resolve(Dependencies.ALIASED))
+                .as("the module renames its own jars; a tool step is not the place that fails over it")
+                .doesNotExist();
+    }
+
+    @Test
     public void routes_declared_exclusions_to_the_resolver() throws IOException {
         SequencedProperties properties = new SequencedProperties();
         properties.setProperty("main/compile/foo/qux", "");


### PR DESCRIPTION
Two independent fixes, one commit each.

## Find the code under test by its coordinate, not by its file name

The JaCoCo report step looked for the first-party jar in `resolved/` by matching a file name it built as `<artifact>-<version>.jar`. That folder never carries such a name: every artifact is materialized under its encoded coordinate, so the branch could not match. `--classfiles` therefore only ever saw the test module's own classes, and `demo-23-code-coverage` reported nothing but `CalculatorTest` while the class it exercises was missing from the report.

`Dependencies.internal` joins the resolution graph, which flags every vertex internal, to the dependency index and returns the first-party artifacts keyed by coordinate. The report step reads that instead, deduplicating the jars that reach it from several resolutions at once. The demo now renders `Calculator` with `add` covered and `subtract` missed, as its README has always described:

```
coverage/Calculator
    add       missed/covered: (0, 4)
    subtract  missed/covered: (4, 0)
```

The demo's verify asserted that a `jacoco` folder existed, which an empty report satisfies. It now asserts the class under test.

## Let a tool step resolve its own group and nothing else

A tool module wires its own dependency step so it can resolve the tool in a group named after it. That step inherits the module's `manifests` folder, because the pins for its group live there, and `Dependencies` merges `requires.properties` from every argument it is handed - so it also resolved the module's own requirements, which the same folder declares, while the module's fully resolved closure was already one of its arguments.

In `demo-20-scala-quality` the closure was resolved five times: once for the module and once each for scalac, scalafmt, scalastyle and scalafmt-format. In the coverage demo the redundant resolutions cost 3.29 s and 5.55 s on a project with two dependencies.

A step now takes the group it is responsible for and narrows every group-keyed input to it once the arguments are merged and before anything is resolved. Aliases are part of that: a scoped step that read the module's aliases would fail over a rename whose target it never resolved. The module's own step keeps resolving everything it is given, and so does the test step, which extends the module's group with the console runner and the coverage agent rather than repeating it.

## Verification

- `mvn test`: 144 classes, 0 failures.
- Each new test fails without the part of the fix it guards - the scoped resolution, the alias, and the bill of materials a scoped step would otherwise fetch.
- 15 demo builds green under `-Djenesis.dependency.pin=strict`, including `demo-20` and `demo-23` rebuilt from a wiped `target`.
- Across 167 recorded tool command lines, no jar is lost; jars that appeared twice now appear once.
- `pin` on `demo-20` rewrites nothing, so pins still reach the scoped steps.

## Known trade-offs

- The second fix scopes the consumer rather than separating the inputs. The cause is that `manifests/` holds the module's requirements next to the project's pins, so a step that needs the pins is handed the requirements too. Splitting them is the structural fix, but pins are group-keyed in one file by design, so splitting per group multiplies folders and complicates `pin`.
- The default stays permissive: a new tool module that forgets `.group(...)` gets the old behaviour back. The step cannot infer its group without inspecting predecessor names.
