### PR TITLE
Name a materialized artifact after the module it carries

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -945,15 +945,15 @@ wherever its inputs match.
 
 Every demo so far built something. `jpx` builds nothing: it resolves a *published*
 module (or Maven artifact), installs its runtime closure once into
-`~/.jenesis/jpx/<name>@<version>/`, and launches its entry point - an `npx` for
+`~/.jenesis/jpx/<layout>/<name>@<version>/`, and launches its entry point - an `npx` for
 the module path, and the counterpart to `Execute.java`, which runs the project
 you have in front of you. The demo drives the `Jpx` API so it can point that
 storage at its own `target/jpx/` and leave your home directory alone; it asks the
 JUnit Platform Console Launcher for its `--version` twice, spelling the same
 artifact two ways:
 
-    jpx --hash=9b60dfc3... org.junit.platform.console@6.1.3 --version
-    jpx --hash=9b60dfc3... org.junit.platform:junit-platform-console@6.1.3 --version
+    jpx --hash=ed5600ef... org.junit.platform.console@6.1.3 --version
+    jpx --hash=ed5600ef... org.junit.platform:junit-platform-console@6.1.3 --version
 
 The first names a **Java module**, whose Maven coordinates the module repository
 discovers as a POM before the graph is read from Maven metadata, exactly as the
@@ -970,7 +970,7 @@ SHA-256 over every jar the installation's `jpx.properties` lists - name and
 content hash, in sorted order - before each launch, so it covers the whole closure
 rather than a single artifact, and catches a jar swapped underneath an existing
 installation as readily as a tampered download. Two further runs show both ends of
-that check: one passes only the leading `9b60dfc3d10f0b4fdf69050eec7b7332`, since
+that check: one passes only the leading `ed5600ef861c7e86cab68c134c6ca0cf`, since
 the value is matched as a prefix and 32 hex characters is the shortest accepted,
 and one passes a full-length digest ending `c0ffee` rather than `cfd3e8`, which is
 blocked before the JVM starts. Naming a version and a hash turns a convenience

--- a/demo/demo-31-module-alias/README.md
+++ b/demo/demo-31-module-alias/README.md
@@ -70,11 +70,13 @@ What the alias does
 The alias is a **rename**, not a synthesis. args4j's jar arrives in the build's
 `resolved/` folder under an encoded Maven coordinate, a file name no legal module
 name can be derived from, so the dependencies step moves it to
-`resolved/org.kohsuke.args4j.jar`. From that file name the JDK derives exactly
-the automatic module the project asked for, and `javac` and `java` agree on it
-because both derive it the same way. Nothing inside the jar is touched: bytes,
-signature entries and all, which is why the pinned checksum keeps describing the
-file that is actually on the command line. The jar in `resolved/` is a hard link
+`resolved/org.kohsuke.args4j-2.33.jar`. From that file name the JDK derives exactly
+the automatic module the project asked for, at the version the closure resolved, and
+`javac` and `java` agree on it because both derive it the same way - which is why a
+stack trace out of args4j reads `org.kohsuke.args4j@2.33`. A version the runtime
+cannot parse is left off the name rather than breaking it. Nothing inside the jar is
+touched: bytes, signature entries and all, which is why the pinned checksum keeps
+describing the file that is actually on the command line. The jar in `resolved/` is a hard link
 into the shared artifact cache, so the rename never reaches the cache either.
 
 `requires org.kohsuke.args4j;` then means what it says. Because the target really
@@ -133,7 +135,9 @@ closure in two - jars that already declare a `module-info` (here, this project's
 own) pass through byte for byte, everything else is renamed to the module name it
 is to carry - runs `jdeps` **once** over the whole set to work out what each one
 actually reads, and injects a generated `module-info.class` into a copy of each
-jar.
+jar. That descriptor records the version the closure resolved, taken from the
+resolution itself rather than from any file name, so the image reports the same
+identity a plain module path does.
 
 The rewritten jars simply exist alongside the resolved ones, in a `modular/`
 folder with its own index, and everything that puts jars on a path prefers that
@@ -154,7 +158,7 @@ runtime that knows about exactly four modules:
     demo.cli@1-SNAPSHOT
     java.base@25.0.3
     java.xml@25.0.3
-    org.kohsuke.args4j open
+    org.kohsuke.args4j@2.33 open
 
 `org.kohsuke.args4j` is a real, explicit module in the image now, and `java.xml`
 came along because `jdeps` found that args4j reads it. The app runs from that

--- a/demo/demo-46-jpx/README.md
+++ b/demo/demo-46-jpx/README.md
@@ -24,21 +24,21 @@ From this directory:
 which prints, for each run, the command it stands for, where it installed, and
 what it launched:
 
-    jpx --hash=9b60dfc3d10f0b4fdf69050eec7b7332f5c395f7e36fad5747ff421e01cfd3e8 org.junit.platform.console@6.1.3 --version
-      [verified] target/jpx/org.junit.platform.console@6.1.3 as org.junit.platform.console/org.junit.platform.console.ConsoleLauncher over 9 modules
+    jpx --hash=ed5600ef861c7e86cab68c134c6ca0cf3b5265e5f2697c16576281452aa1e2dd org.junit.platform.console@6.1.3 --version
+      [verified] target/jpx/modular_to_maven/org.junit.platform.console@6.1.3 as org.junit.platform.console/org.junit.platform.console.ConsoleLauncher over 9 modules
     JUnit Platform Console Launcher 6.1.3
     JVM: 25.0.3 (Eclipse Adoptium OpenJDK 64-Bit Server VM 25.0.3+9-LTS)
     OS: Linux 7.0.0-28-generic amd64
 
-    jpx --hash=9b60dfc3d10f0b4fdf69050eec7b7332f5c395f7e36fad5747ff421e01cfd3e8 org.junit.platform:junit-platform-console@6.1.3 --version
-      [verified] target/jpx/org.junit.platform--junit-platform-console@6.1.3 as org.junit.platform.console.ConsoleLauncher over 9 jars on the class path
+    jpx --hash=ed5600ef861c7e86cab68c134c6ca0cf3b5265e5f2697c16576281452aa1e2dd org.junit.platform:junit-platform-console@6.1.3 --version
+      [verified] target/jpx/maven/org.junit.platform--junit-platform-console@6.1.3 as org.junit.platform.console.ConsoleLauncher over 9 jars on the class path
     JUnit Platform Console Launcher 6.1.3
     JVM: 25.0.3 (Eclipse Adoptium OpenJDK 64-Bit Server VM 25.0.3+9-LTS)
     OS: Linux 7.0.0-28-generic amd64
 
     [... and the module name once more, with a 32-character prefix ...]
 
-    jpx --hash=9b60dfc3d10f0b4fdf69050eec7b7332f5c395f7e36fad5747ff421e01c0ffee org.junit.platform.console@6.1.3 --version
+    jpx --hash=ed5600ef861c7e86cab68c134c6ca0cf3b5265e5f2697c16576281452ac0ffee org.junit.platform.console@6.1.3 --version
       [blocked]  Checksum mismatch for org.junit.platform.console@6.1.3: expected a digest starting with 9b60...c0ffee but computed 9b60...cfd3e8
 
 The demo drives the `Jpx` API (`jpx.install(<target>).verify(<hash>).launch(...)`)
@@ -50,11 +50,11 @@ home folder, so a folder of your own arrives together with the repositories and
 resolvers that go with it. The command line does the same thing:
 
     java build/jenesis/Jpx.java \
-        --hash=9b60dfc3d10f0b4fdf69050eec7b7332f5c395f7e36fad5747ff421e01cfd3e8 \
+        --hash=ed5600ef861c7e86cab68c134c6ca0cf3b5265e5f2697c16576281452aa1e2dd \
         org.junit.platform.console@6.1.3 --version
 
     java build/jenesis/Jpx.java \
-        --hash=9b60dfc3d10f0b4fdf69050eec7b7332f5c395f7e36fad5747ff421e01cfd3e8 \
+        --hash=ed5600ef861c7e86cab68c134c6ca0cf3b5265e5f2697c16576281452aa1e2dd \
         org.junit.platform:junit-platform-console@6.1.3 --version
 
 The two forms
@@ -98,8 +98,8 @@ Each installation is a flat folder of jars beside a `jpx.properties` descriptor:
     version=6.1.3
     mainClass=org.junit.platform.console.ConsoleLauncher
     mainModule=org.junit.platform.console
-    modulepath=apiguardian-api-1.1.2.jar,jspecify-1.0.0.jar,junit-platform-commons-6.1.3.jar,...
-    checksum=SHA-256/9b60dfc3d10f0b4fdf69050eec7b7332f5c395f7e36fad5747ff421e01cfd3e8
+    modulepath=org.apiguardian.api-1.1.2.jar,org.jspecify-1.0.0.jar,org.junit.platform.commons-6.1.3.jar,...
+    checksum=SHA-256/ed5600ef861c7e86cab68c134c6ca0cf3b5265e5f2697c16576281452aa1e2dd
 
 `--hash=<prefix>` recomputes that digest over every jar the descriptor lists -
 each file's name and content hash, in sorted order - and refuses to launch on a
@@ -110,7 +110,7 @@ so an interrupted download is recognized and redone, and concurrent installs of
 one target coordinate through a file lock.
 
 The value is matched as a **prefix**, which the demo's third run shows by passing
-only `9b60dfc3d10f0b4fdf69050eec7b7332` - the first 32 hex characters, which is
+only `ed5600ef861c7e86cab68c134c6ca0cf` - the first 32 hex characters, which is
 also the shortest accepted. Anything shorter is refused outright rather than
 checked loosely: 32 hex characters is 128 bits, the floor at which a prefix still
 pins the bytes. A leading `SHA-256/` is stripped, so the `checksum` line can be

--- a/demo/demo-46-jpx/build/Demo.java
+++ b/demo/demo-46-jpx/build/Demo.java
@@ -36,18 +36,18 @@ public class Demo {
         // The name also decides how the program runs: as a module for the module name,
         // on the class path for the coordinate.
         launch(jpx, "org.junit.platform.console@6.1.3",
-                "9b60dfc3d10f0b4fdf69050eec7b7332f5c395f7e36fad5747ff421e01cfd3e8");
+                "ed5600ef861c7e86cab68c134c6ca0cf3b5265e5f2697c16576281452aa1e2dd");
         launch(jpx, "org.junit.platform:junit-platform-console@6.1.3",
-                "9b60dfc3d10f0b4fdf69050eec7b7332f5c395f7e36fad5747ff421e01cfd3e8");
+                "ed5600ef861c7e86cab68c134c6ca0cf3b5265e5f2697c16576281452aa1e2dd");
 
         // A leading fraction of that digest is enough: 32 hex characters is the
         // shortest prefix accepted, and it is matched against the recomputed digest.
-        launch(jpx, "org.junit.platform.console@6.1.3", "9b60dfc3d10f0b4fdf69050eec7b7332");
+        launch(jpx, "org.junit.platform.console@6.1.3", "ed5600ef861c7e86cab68c134c6ca0cf");
 
         // A digest that does not match the installed jars refuses to launch, on the
         // run that installed them and on every run after it.
         reject(jpx, "org.junit.platform.console@6.1.3",
-                "9b60dfc3d10f0b4fdf69050eec7b7332f5c395f7e36fad5747ff421e01c0ffee");
+                "ed5600ef861c7e86cab68c134c6ca0cf3b5265e5f2697c16576281452ac0ffee");
     }
 
     private static void launch(Jpx jpx, String target, String hash) throws Exception {

--- a/sdk/jpx/tests/test.bat
+++ b/sdk/jpx/tests/test.bat
@@ -99,9 +99,9 @@ call "%SDK_HOME%\bin\jpx.bat" org.example:tool@1.0 "%TMPDIR%\marker.txt" > "%OUT
 set "RC=!ERRORLEVEL!"
 if not "!RC!"=="7" goto :fail
 findstr /c:"jpx-sdk-test" "%TMPDIR%\marker.txt" >nul || goto :fail
-set "DESCRIPTOR=%TMPDIR%\home\.jenesis\jpx\org.example--tool@1.0\jpx.properties"
+set "DESCRIPTOR=%TMPDIR%\home\.jenesis\jpx\maven\org.example--tool@1.0\jpx.properties"
 if not exist "%DESCRIPTOR%" goto :fail
-findstr /c:"classpath=tool-1.0.jar" "%DESCRIPTOR%" >nul || goto :fail
+findstr /c:"classpath=org.example%%2Ftool%%2F1.0.jar" "%DESCRIPTOR%" >nul || goto :fail
 echo   ok
 
 REM [6/6] --hash verifies the recorded checksum prefix and rejects a mismatch

--- a/sdk/jpx/tests/test.sh
+++ b/sdk/jpx/tests/test.sh
@@ -113,9 +113,9 @@ RC=$?
 set -e
 [ "$RC" = "7" ] || dump_and_fail "expected the tool's exit 7, got $RC"
 [ "$(cat "$TMPDIR/marker.txt")" = "jpx-sdk-test" ] || dump_and_fail "marker file not written by the tool"
-DESCRIPTOR="$TMPDIR/home/.jenesis/jpx/org.example--tool@1.0/jpx.properties"
+DESCRIPTOR="$TMPDIR/home/.jenesis/jpx/maven/org.example--tool@1.0/jpx.properties"
 [ -f "$DESCRIPTOR" ] || dump_and_fail "no descriptor at $DESCRIPTOR"
-grep -qF "classpath=tool-1.0.jar" "$DESCRIPTOR" || dump_and_fail "descriptor does not record the Maven jar name" "$(cat "$DESCRIPTOR")"
+grep -qF "classpath=org.example%2Ftool%2F1.0.jar" "$DESCRIPTOR" || dump_and_fail "descriptor does not record the encoded coordinate" "$(cat "$DESCRIPTOR")"
 echo "  ok"
 
 # [6/6] --hash verifies the recorded checksum prefix and rejects a mismatch

--- a/sources/build/jenesis/Jpx.java
+++ b/sources/build/jenesis/Jpx.java
@@ -385,30 +385,44 @@ public record Jpx(Path storage,
                 : this.placement;
         SequencedMap<String, Path> jars = new TreeMap<>();
         SequencedMap<String, String> tokens = new LinkedHashMap<>(), names = new LinkedHashMap<>();
+        SequencedMap<Path, String> renamed = new LinkedHashMap<>();
         for (Map.Entry<String, Resolver.Resolved> entry : resolution.artifacts().entrySet()) {
             String dependency = entry.getKey();
             Path file = entry.getValue().file();
             Path source = file.startsWith(staging) ? folder.resolve(file.getFileName()) : file;
             String coordinate = dependency.substring(dependency.indexOf('/') + 1);
-            ModuleDescriptor identity = PathPlacement.moduleDescriptor(source);
-            String name = identity == null
-                    ? PathPlacement.fileName(coordinate)
-                    : PathPlacement.fileName(coordinate, identity.name(), true);
-            Path target = folder.resolve(name);
-            if (jars.putIfAbsent(name, target) == null && !source.equals(target)) {
-                if (source.startsWith(folder)) {
-                    Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
-                } else {
-                    BuildStep.linkOrCopy(target, source);
+            String name = renamed.get(source);
+            if (name == null) {
+                ModuleDescriptor identity = PathPlacement.moduleDescriptor(source);
+                name = identity == null
+                        ? PathPlacement.fileName(coordinate)
+                        : PathPlacement.fileName(coordinate, identity.name(), true);
+                Path target = folder.resolve(name);
+                if (jars.putIfAbsent(name, target) != null) {
+                    throw new IllegalStateException(dependency
+                            + " and another artifact are both installed as "
+                            + name
+                            + " within "
+                            + folder.getFileName());
                 }
+                if (!source.equals(target)) {
+                    if (source.startsWith(folder)) {
+                        Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+                    } else {
+                        BuildStep.linkOrCopy(target, source);
+                    }
+                }
+                renamed.put(source, name);
+                if (source.equals(root)) {
+                    root = target;
+                }
+            } else if (source.equals(root)) {
+                root = folder.resolve(name);
             }
             names.putIfAbsent(dependency, name);
             int last = coordinate.lastIndexOf('/');
             if (last > 0) {
                 tokens.putIfAbsent(coordinate.substring(0, last), dependency);
-            }
-            if (source.equals(root)) {
-                root = target;
             }
         }
         root = rename(jars, tokens, names, folder, root);

--- a/sources/build/jenesis/Jpx.java
+++ b/sources/build/jenesis/Jpx.java
@@ -267,6 +267,13 @@ public record Jpx(Path storage,
         return install(Command.parse(target));
     }
 
+    private Path layout(Command command) {
+        if (command.name().indexOf(':') >= 0) {
+            return storage.resolve("maven");
+        }
+        return storage.resolve(placement == PathPlacement.MODULE_PATH ? "modular" : "modular_to_maven");
+    }
+
     public Installation install(Command command) throws IOException {
         if (command.version() == null) {
             Installation installed = latestInstalled(command.name()).orElse(null);
@@ -274,13 +281,13 @@ public record Jpx(Path storage,
                 return installed;
             }
         } else {
-            Path folder = storage.resolve(command.folder(command.version()));
+            Path folder = layout(command).resolve(command.folder(command.version()));
             if (Files.isRegularFile(folder.resolve(PROPERTIES))) {
                 return new Installation(folder, hashFunction);
             }
         }
-        Files.createDirectories(storage);
-        Path staging = Files.createTempDirectory(storage, "staging-");
+        Path installations = Files.createDirectories(layout(command));
+        Path staging = Files.createTempDirectory(installations, "staging-");
         try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
             Map<String, Repository> repositories = new LinkedHashMap<>();
             this.repositories.forEach((name, repository) -> repositories.put(name, repository.spilled(staging)));
@@ -339,9 +346,9 @@ public record Jpx(Path storage,
                 }
             }
             SAFE_SEGMENT.accept("version", version);
-            Installation installation = new Installation(storage.resolve(command.folder(version)), hashFunction);
+            Installation installation = new Installation(installations.resolve(command.folder(version)), hashFunction);
             if (!Files.isRegularFile(installation.folder().resolve(PROPERTIES))) {
-                try (FileChannel channel = FileChannel.open(storage.resolve(command.folder(version) + ".lock"),
+                try (FileChannel channel = FileChannel.open(installations.resolve(command.folder(version) + ".lock"),
                         StandardOpenOption.CREATE,
                         StandardOpenOption.WRITE); FileLock _ = channel.lock()) {
                     if (!Files.isRegularFile(installation.folder().resolve(PROPERTIES))) {
@@ -512,13 +519,14 @@ public record Jpx(Path storage,
     }
 
     public Optional<Installation> latestInstalled(String name) throws IOException {
-        if (!Files.isDirectory(storage)) {
+        Path root = layout(new Command(name, null, null));
+        if (!Files.isDirectory(root)) {
             return Optional.empty();
         }
         String prefix = new Command(name, null, null).folder("");
         Path latest = null;
         FileTime time = null;
-        try (DirectoryStream<Path> folders = Files.newDirectoryStream(storage)) {
+        try (DirectoryStream<Path> folders = Files.newDirectoryStream(root)) {
             for (Path folder : folders) {
                 if (!folder.getFileName().toString().startsWith(prefix) || !Files.isRegularFile(folder.resolve(PROPERTIES))) {
                     continue;

--- a/sources/build/jenesis/Jpx.java
+++ b/sources/build/jenesis/Jpx.java
@@ -373,22 +373,44 @@ public record Jpx(Path storage,
         if (root.startsWith(staging)) {
             root = folder.resolve(root.getFileName());
         }
+        PathPlacement placement = command.name().indexOf(':') >= 0
+                ? PathPlacement.CLASS_PATH
+                : this.placement;
         SequencedMap<String, Path> jars = new TreeMap<>();
-        for (Resolver.Resolved resolved : resolution.artifacts().values()) {
-            Path file = resolved.file();
-            Path placed = file.startsWith(staging) ? folder.resolve(file.getFileName()) : file;
-            if (jars.putIfAbsent(file.getFileName().toString(), placed) == null && !placed.startsWith(folder)) {
-                BuildStep.linkOrCopy(folder.resolve(file.getFileName().toString()), placed);
+        SequencedMap<String, String> tokens = new LinkedHashMap<>(), names = new LinkedHashMap<>();
+        for (Map.Entry<String, Resolver.Resolved> entry : resolution.artifacts().entrySet()) {
+            String dependency = entry.getKey();
+            Path file = entry.getValue().file();
+            Path source = file.startsWith(staging) ? folder.resolve(file.getFileName()) : file;
+            String coordinate = dependency.substring(dependency.indexOf('/') + 1);
+            ModuleDescriptor identity = PathPlacement.moduleDescriptor(source);
+            String name = identity == null
+                    ? PathPlacement.fileName(coordinate)
+                    : PathPlacement.fileName(coordinate, identity.name(), true);
+            Path target = folder.resolve(name);
+            if (jars.putIfAbsent(name, target) == null && !source.equals(target)) {
+                if (source.startsWith(folder)) {
+                    Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+                } else {
+                    BuildStep.linkOrCopy(target, source);
+                }
+            }
+            names.putIfAbsent(dependency, name);
+            int last = coordinate.lastIndexOf('/');
+            if (last > 0) {
+                tokens.putIfAbsent(coordinate.substring(0, last), dependency);
+            }
+            if (source.equals(root)) {
+                root = target;
             }
         }
-        root = rename(resolution, jars, folder, root);
+        root = rename(jars, tokens, names, folder, root);
         ModuleDescriptor descriptor = PathPlacement.moduleDescriptor(root);
-        boolean coordinate = command.name().indexOf(':') >= 0;
-        if (!coordinate && (descriptor == null || !descriptor.name().equals(command.name()))) {
+        if (placement != PathPlacement.CLASS_PATH
+                && (descriptor == null || !descriptor.name().equals(command.name()))) {
             throw new IllegalStateException("The jar resolved for module " + command.name() + " is named "
                     + (descriptor == null ? "nothing" : descriptor.name()) + " - the repository mapping appears stale");
         }
-        PathPlacement placement = coordinate ? PathPlacement.CLASS_PATH : this.placement;
         String mainModule = placement.modular() && descriptor != null ? descriptor.name() : null;
         String mainClass = descriptor == null || descriptor.mainClass().isEmpty()
                 ? PathPlacement.mainClass(root)
@@ -421,25 +443,17 @@ public record Jpx(Path storage,
         Files.move(temporary, folder.resolve(PROPERTIES), StandardCopyOption.ATOMIC_MOVE);
     }
 
-    private static Path rename(Resolver.Resolution resolution,
-                               SequencedMap<String, Path> jars,
+    private static Path rename(SequencedMap<String, Path> jars,
+                               SequencedMap<String, String> tokens,
+                               SequencedMap<String, String> names,
                                Path folder,
                                Path root) throws IOException {
-        SequencedMap<String, String> coordinates = new LinkedHashMap<>();
-        for (Map.Entry<String, Resolver.Resolved> entry : resolution.artifacts().entrySet()) {
-            String coordinate = entry.getKey();
-            int first = coordinate.indexOf('/'), last = coordinate.lastIndexOf('/');
-            if (first > 0 && last > first) {
-                coordinates.putIfAbsent(coordinate.substring(first + 1, last),
-                        entry.getValue().file().getFileName().toString());
-            }
-        }
         SequencedMap<String, String> aliased = new LinkedHashMap<>();
         for (Map.Entry<String, Path> entry : jars.entrySet()) {
             String origin = entry.getKey();
-            for (Map.Entry<String, String> declaration : PathPlacement.aliases(folder.resolve(origin)).entrySet()) {
-                String alias = declaration.getKey(), name = coordinates.get(declaration.getValue());
-                if (name == null || !jars.containsKey(name)) {
+            for (Map.Entry<String, String> declaration : PathPlacement.aliases(entry.getValue()).entrySet()) {
+                String alias = declaration.getKey(), dependency = tokens.get(declaration.getValue());
+                if (dependency == null || !jars.containsKey(names.get(dependency))) {
                     throw new IllegalStateException(origin
                             + " aliases "
                             + alias
@@ -447,14 +461,14 @@ public record Jpx(Path storage,
                             + declaration.getValue()
                             + ", which this installation does not contain");
                 }
-                String previous = aliased.putIfAbsent(alias, name);
-                if (previous != null && !previous.equals(name)) {
+                String previous = aliased.putIfAbsent(alias, dependency);
+                if (previous != null && !previous.equals(dependency)) {
                     throw new IllegalStateException("Module alias "
                             + alias
                             + " is declared for "
                             + previous
                             + " and for "
-                            + name
+                            + dependency
                             + " within "
                             + folder.getFileName());
                 }
@@ -462,32 +476,35 @@ public record Jpx(Path storage,
         }
         SequencedMap<String, String> owners = new LinkedHashMap<>();
         for (Map.Entry<String, String> entry : aliased.entrySet()) {
-            String alias = entry.getKey(), name = entry.getValue(), aliasedJar = alias + ".jar";
-            String previous = owners.putIfAbsent(name, alias);
+            String alias = entry.getKey(), dependency = entry.getValue();
+            String previous = owners.putIfAbsent(dependency, alias);
             if (previous != null) {
-                throw new IllegalStateException(name
+                throw new IllegalStateException(dependency
                         + " is aliased as both "
                         + previous
                         + " and "
                         + alias
                         + " - a jar can carry only one module name");
             }
-            if (jars.containsKey(aliasedJar)) {
+            String coordinate = dependency.substring(dependency.indexOf('/') + 1);
+            String name = PathPlacement.fileName(coordinate, alias, false);
+            if (jars.containsKey(name)) {
                 throw new IllegalStateException("Module alias "
                         + alias
                         + " collides with "
-                        + aliasedJar
+                        + name
                         + " within "
                         + folder.getFileName()
                         + " - require it directly");
             }
-            Path target = folder.resolve(aliasedJar);
-            Files.move(folder.resolve(name), target, StandardCopyOption.REPLACE_EXISTING);
-            jars.remove(name);
-            jars.put(aliasedJar, target);
-            PathPlacement.aliased(target, alias, name);
+            Path source = folder.resolve(names.get(dependency)), target = folder.resolve(name);
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+            jars.remove(names.get(dependency));
+            jars.put(name, target);
+            names.put(dependency, name);
+            PathPlacement.aliased(target, alias, dependency);
             Files.writeString(PathPlacement.declaration(target), alias);
-            if (root.getFileName().toString().equals(name)) {
+            if (root.equals(source)) {
                 root = target;
             }
         }

--- a/sources/build/jenesis/PathPlacement.java
+++ b/sources/build/jenesis/PathPlacement.java
@@ -33,6 +33,8 @@ public enum PathPlacement {
 
     public static final String ALIASES = "Jenesis-Aliases";
 
+    private static final Pattern DERIVED_VERSION = Pattern.compile("\\d+(\\..*)?");
+
     private final boolean modular;
 
     PathPlacement(boolean modular) {
@@ -52,6 +54,30 @@ public enum PathPlacement {
 
     public PathPlacement forModuleInfo(boolean moduleInfoPresent) {
         return moduleInfoPresent ? this : CLASS_PATH;
+    }
+
+    public static String fileName(String coordinate) {
+        return BuildExecutorModule.encode(coordinate) + ".jar";
+    }
+
+    public static String fileName(String coordinate, String module, boolean declared) {
+        String version = coordinate.substring(coordinate.lastIndexOf('/') + 1);
+        if (!declared && !derivable(version)) {
+            return BuildExecutorModule.encode(module) + ".jar";
+        }
+        return BuildExecutorModule.encode(module) + "-" + BuildExecutorModule.encode(version) + ".jar";
+    }
+
+    private static boolean derivable(String version) {
+        if (!DERIVED_VERSION.matcher(version).matches()) {
+            return false;
+        }
+        try {
+            ModuleDescriptor.Version.parse(version);
+            return true;
+        } catch (IllegalArgumentException _) {
+            return false;
+        }
     }
 
     public static Path declaration(Path jar) {

--- a/sources/build/jenesis/project/ModularizeModule.java
+++ b/sources/build/jenesis/project/ModularizeModule.java
@@ -10,6 +10,7 @@ import build.jenesis.BuildStepContext;
 import build.jenesis.BuildStepResult;
 import build.jenesis.HashDigestFunction;
 import build.jenesis.PathPlacement;
+import build.jenesis.Resolver;
 import build.jenesis.SequencedProperties;
 import build.jenesis.step.Dependencies;
 import build.jenesis.step.JDeps;
@@ -24,7 +25,7 @@ public class ModularizeModule implements BuildExecutorModule {
 
     private static final String PREPARE = "prepare", DESCRIBE = "describe", MODULARIZE = "modularize";
 
-    private static final String STAGED = "staged.properties";
+    private static final String STAGED = "staged.properties", IDENTITY = "identity.properties";
 
     private final ProcessHandler.Factory factory;
     private final boolean synthetic;
@@ -59,9 +60,7 @@ public class ModularizeModule implements BuildExecutorModule {
         return path.equals(MODULARIZE) ? Optional.of("") : Optional.empty();
     }
 
-    private static String module(Path jar) {
-        String file = jar.getFileName().toString();
-        return file.substring(0, file.length() - ".jar".length());
+    private record Identity(String module, String version) {
     }
 
     private static ModuleDescriptor derive(Path jar) {
@@ -105,7 +104,7 @@ public class ModularizeModule implements BuildExecutorModule {
                 throws IOException {
             Path modules = Files.createDirectory(context.next().resolve(JDeps.MODULES));
             Path analyzed = Files.createDirectory(context.next().resolve(JDeps.ANALYZED));
-            SequencedProperties staged = new SequencedProperties();
+            SequencedProperties staged = new SequencedProperties(), identity = new SequencedProperties();
             SequencedMap<Path, String> placed = new LinkedHashMap<>();
             SequencedMap<String, Path> claimed = new LinkedHashMap<>();
             for (BuildStepArgument argument : arguments.values()) {
@@ -116,6 +115,7 @@ public class ModularizeModule implements BuildExecutorModule {
                 if (!Files.exists(index)) {
                     continue;
                 }
+                SequencedMap<String, String> versions = versions(argument.folder());
                 SequencedProperties properties = SequencedProperties.ofFiles(index);
                 for (String key : properties.stringPropertyNames()) {
                     String value = properties.getProperty(key);
@@ -153,23 +153,57 @@ public class ModularizeModule implements BuildExecutorModule {
                                     + " and "
                                     + jar.getFileName());
                         }
-                        relative = (named ? JDeps.MODULES : JDeps.ANALYZED) + module + ".jar";
-                        Path target = (named ? modules : analyzed).resolve(module + ".jar");
+                        String[] parts = split(key);
+                        String version = parts == null ? null : versions.get(parts[2] + "/" + parts[3]);
+                        String name = version == null
+                                ? module + ".jar"
+                                : PathPlacement.fileName(parts[3], module, named);
+                        relative = (named ? JDeps.MODULES : JDeps.ANALYZED) + name;
+                        Path target = (named ? modules : analyzed).resolve(name);
                         if (!Files.exists(target)) {
                             BuildStep.linkOrCopy(target, jar);
                         }
                         placed.put(jar, relative);
+                        identity.setProperty(relative, module + (version == null ? "" : "\t" + version));
                     }
                     staged.setProperty(key, relative);
                 }
             }
             staged.store(context.next().resolve(STAGED));
+            identity.store(context.next().resolve(IDENTITY));
             SequencedProperties options = new SequencedProperties();
             options.setProperty("--multi-release", String.valueOf(Runtime.version().feature()));
             options.setProperty("--ignore-missing-deps", "");
             options.store(Files.createDirectories(context.next().resolve(ProcessBuildStep.PROCESS))
                     .resolve("jdeps.properties"));
             return CompletableFuture.completedStage(new BuildStepResult(true));
+        }
+
+        private static SequencedMap<String, String> versions(Path folder) throws IOException {
+            SequencedMap<String, String> versions = new LinkedHashMap<>();
+            Path graph = folder.resolve(Dependencies.GRAPH);
+            if (!Files.exists(graph)) {
+                return versions;
+            }
+            for (Resolver.Resolution resolution : Dependencies.graph(List.of(graph), List.of()).values()) {
+                resolution.vertices().forEach((coordinate, vertex) -> {
+                    if (vertex.resolvedVersion() != null) {
+                        versions.putIfAbsent(coordinate + "/" + vertex.resolvedVersion(), vertex.resolvedVersion());
+                    }
+                });
+            }
+            return versions;
+        }
+
+        private static String[] split(String key) {
+            int first = key.indexOf('/');
+            int second = first < 0 ? -1 : key.indexOf('/', first + 1);
+            int third = second < 0 ? -1 : key.indexOf('/', second + 1);
+            return third < 0 ? null : new String[] {
+                    key.substring(0, first),
+                    key.substring(first + 1, second),
+                    key.substring(second + 1, third),
+                    key.substring(third + 1)};
         }
 
         private static String pseudonym(Path jar) throws IOException {
@@ -187,8 +221,9 @@ public class ModularizeModule implements BuildExecutorModule {
             Path staged = arguments.get(PREPARE).folder(),
                     descriptors = arguments.get(DESCRIBE).folder().resolve(JDeps.DESCRIPTORS);
             SequencedProperties staging = SequencedProperties.ofFiles(staged.resolve(STAGED));
+            SequencedMap<String, Identity> identities = identities(staged);
             Path target = Files.createDirectory(context.next().resolve(Dependencies.MODULAR_PATH));
-            SequencedMap<String, String> owners = owners(staged, staging);
+            SequencedMap<String, String> owners = owners(staged, staging, identities);
             SequencedMap<Path, Path> emitted = new LinkedHashMap<>();
             SequencedProperties index = new SequencedProperties();
             for (String key : staging.stringPropertyNames()) {
@@ -199,12 +234,13 @@ public class ModularizeModule implements BuildExecutorModule {
                 }
                 Path file = emitted.get(source);
                 if (file == null) {
+                    Identity identity = identities.get(relative);
                     file = target.resolve(source.getFileName().toString());
                     if (emitted.containsValue(file)) {
-                        throw new IllegalStateException("Module " + module(file) + " is staged more than once");
+                        throw new IllegalStateException("Module " + identity.module() + " is staged more than once");
                     }
                     if (relative.startsWith(JDeps.ANALYZED)) {
-                        inject(source, file, synthesize(source, descriptors, owners));
+                        inject(source, file, synthesize(source, identity, descriptors, owners));
                     } else {
                         BuildStep.linkOrCopy(file, source);
                     }
@@ -219,21 +255,37 @@ public class ModularizeModule implements BuildExecutorModule {
             return CompletableFuture.completedStage(new BuildStepResult(true));
         }
 
-        private static SequencedMap<String, String> owners(Path staged, SequencedProperties staging) {
+        private static SequencedMap<String, Identity> identities(Path staged) throws IOException {
+            SequencedMap<String, Identity> identities = new LinkedHashMap<>();
+            SequencedProperties properties = SequencedProperties.ofFiles(staged.resolve(IDENTITY));
+            properties.forEachProperty((relative, value) -> {
+                int tab = value.indexOf('\t');
+                identities.put(relative, tab < 0
+                        ? new Identity(value, null)
+                        : new Identity(value.substring(0, tab), value.substring(tab + 1)));
+            });
+            return identities;
+        }
+
+        private static SequencedMap<String, String> owners(Path staged,
+                                                           SequencedProperties staging,
+                                                           SequencedMap<String, Identity> identities) {
             SequencedMap<String, String> owners = new LinkedHashMap<>();
             for (ModuleReference reference : ModuleFinder.ofSystem().findAll()) {
                 for (String name : reference.descriptor().packages()) {
                     owners.putIfAbsent(name, reference.descriptor().name());
                 }
             }
-            SequencedSet<Path> jars = new LinkedHashSet<>();
+            SequencedMap<Path, String> jars = new LinkedHashMap<>();
             for (String key : staging.stringPropertyNames()) {
-                jars.add(staged.resolve(staging.getProperty(key)).normalize());
+                String relative = staging.getProperty(key);
+                jars.putIfAbsent(staged.resolve(relative).normalize(), identities.get(relative).module());
             }
-            for (Path jar : jars) {
+            for (Map.Entry<Path, String> entry : jars.entrySet()) {
+                Path jar = entry.getKey();
                 ModuleDescriptor descriptor = PathPlacement.moduleDescriptor(jar);
                 boolean named = descriptor != null && !descriptor.isAutomatic();
-                String module = named ? descriptor.name() : module(jar);
+                String module = named ? descriptor.name() : entry.getValue();
                 for (String name : (named ? descriptor : derive(jar)).packages()) {
                     String previous = owners.putIfAbsent(name, module);
                     if (previous != null && !previous.equals(module)) {
@@ -248,9 +300,10 @@ public class ModularizeModule implements BuildExecutorModule {
         }
 
         private static byte[] synthesize(Path jar,
+                                         Identity identity,
                                          Path descriptors,
                                          SequencedMap<String, String> owners) throws IOException {
-            String module = module(jar);
+            String module = identity.module();
             ModuleDescriptor derived = derive(jar);
             SequencedSet<String> packages = new TreeSet<>(derived.packages());
             SequencedMap<String, Integer> requires = requires(module, descriptors, packages.isEmpty());
@@ -263,6 +316,9 @@ public class ModularizeModule implements BuildExecutorModule {
             }
             return ClassFile.of().buildModule(ModuleAttribute.of(ModuleDesc.of(module), builder -> {
                 builder.moduleFlags(ClassFile.ACC_OPEN);
+                if (identity.version() != null) {
+                    builder.moduleVersion(identity.version());
+                }
                 builder.requires(ModuleDesc.of("java.base"), ClassFile.ACC_MANDATED, null);
                 requires.forEach((name, flags) -> builder.requires(ModuleDesc.of(name), flags, null));
                 packages.forEach(name -> builder.exports(PackageDesc.of(name), 0));

--- a/sources/build/jenesis/step/Dependencies.java
+++ b/sources/build/jenesis/step/Dependencies.java
@@ -239,7 +239,7 @@ public class Dependencies implements BuildStep {
                     Path file = context.previous()
                             .resolve(space < 0 ? value : value.substring(0, space))
                             .normalize();
-                    if (Files.exists(file)) {
+                    if (Files.exists(file) && !previousInternal.contains(parts[3])) {
                         previousArtifacts.putIfAbsent(parts[3], file);
                     }
                 });
@@ -251,7 +251,7 @@ public class Dependencies implements BuildStep {
             if (!previousArtifacts.isEmpty()) {
                 effective = effective.prepend((_, coordinate) -> Optional
                         .ofNullable(previousArtifacts.get(coordinate))
-                        .map(file -> RepositoryItem.ofFile(file, previousInternal.contains(coordinate))));
+                        .map(RepositoryItem::ofFile));
             }
             wrapped.put(name, effective.materialized(libs));
         });

--- a/sources/build/jenesis/step/Dependencies.java
+++ b/sources/build/jenesis/step/Dependencies.java
@@ -218,16 +218,21 @@ public class Dependencies implements BuildStep {
             versions.keySet().retainAll(Set.of(group));
         }
         Path libs = Files.createDirectories(context.next().resolve(RESOLVED));
-        Path previousLibs = context.previous() == null ? null : context.previous().resolve(RESOLVED);
-        SequencedMap<String, String> previousAliases = new LinkedHashMap<>();
+        SequencedMap<String, Path> previousArtifacts = new LinkedHashMap<>();
         if (context.previous() != null) {
-            Path aliasedFile = context.previous().resolve(ALIASED);
-            if (Files.exists(aliasedFile)) {
-                SequencedProperties.ofFiles(aliasedFile).forEachProperty((alias, coordinate) -> {
-                    previousAliases.put(coordinate, alias);
-                    int slash = coordinate.indexOf('/');
-                    if (slash > 0) {
-                        previousAliases.put(coordinate.substring(slash + 1), alias);
+            Path previousIndex = context.previous().resolve(DEPENDENCIES);
+            if (Files.exists(previousIndex)) {
+                SequencedProperties.ofFiles(previousIndex).forEachProperty((key, value) -> {
+                    String[] parts = split(key);
+                    if (parts == null) {
+                        return;
+                    }
+                    int space = value.indexOf(' ');
+                    Path file = context.previous()
+                            .resolve(space < 0 ? value : value.substring(0, space))
+                            .normalize();
+                    if (Files.exists(file)) {
+                        previousArtifacts.putIfAbsent(parts[3], file);
                     }
                 });
             }
@@ -235,18 +240,10 @@ public class Dependencies implements BuildStep {
         Map<String, Repository> wrapped = new LinkedHashMap<>();
         repositories.forEach((name, repository) -> {
             Repository effective = repository;
-            if (previousLibs != null) {
-                effective = effective.prepend((_, coordinate) -> {
-                    Path file = previousLibs.resolve(BuildExecutorModule.encode(coordinate) + ".jar");
-                    if (!Files.exists(file)) {
-                        String alias = previousAliases.get(coordinate);
-                        if (alias == null) {
-                            return Optional.empty();
-                        }
-                        file = previousLibs.resolve(alias + ".jar");
-                    }
-                    return Files.exists(file) ? Optional.of(RepositoryItem.ofFile(file)) : Optional.empty();
-                });
+            if (!previousArtifacts.isEmpty()) {
+                effective = effective.prepend((_, coordinate) -> Optional
+                        .ofNullable(previousArtifacts.get(coordinate))
+                        .map(RepositoryItem::ofFile));
             }
             wrapped.put(name, effective.materialized(libs));
         });
@@ -519,7 +516,8 @@ public class Dependencies implements BuildStep {
             Path file = placed.get(dependency);
             if (file == null) {
                 if (artifact.internal()) {
-                    file = libs.resolve(BuildExecutorModule.encode(dependency) + ".jar");
+                    file = libs.resolve(PathPlacement.fileName(
+                            dependency.substring(dependency.indexOf('/') + 1)));
                     if (!Files.exists(file)) {
                         BuildStep.linkOrCopy(file, artifact.file());
                     }
@@ -678,9 +676,45 @@ public class Dependencies implements BuildStep {
             }
             aliased.put(alias, coordinate);
         }
-        for (Map.Entry<String, String> entry : aliased.entrySet()) {
-            String alias = entry.getKey(), coordinate = entry.getValue();
-            Path source = placed.get(coordinate), target = libs.resolve(alias + ".jar");
+        SequencedMap<String, String> names = new LinkedHashMap<>();
+        aliased.forEach((alias, coordinate) -> names.put(coordinate, alias));
+        SequencedMap<String, Path> ordered = new LinkedHashMap<>();
+        names.keySet().forEach(dependency -> ordered.put(dependency, placed.get(dependency)));
+        ordered.putAll(placed);
+        SequencedMap<String, Claim> claims = new LinkedHashMap<>();
+        SequencedMap<Path, Path> renamed = new LinkedHashMap<>();
+        for (Map.Entry<String, Path> entry : ordered.entrySet()) {
+            String dependency = entry.getKey();
+            Path source = entry.getValue();
+            if (Files.isDirectory(source)) {
+                continue;
+            }
+            Path taken = renamed.get(source);
+            if (taken != null) {
+                placed.put(dependency, taken);
+                continue;
+            }
+            String coordinate = dependency.substring(dependency.indexOf('/') + 1);
+            String alias = names.get(dependency);
+            String name;
+            if (alias != null) {
+                name = PathPlacement.fileName(coordinate, alias, false);
+            } else {
+                ModuleDescriptor descriptor = PathPlacement.moduleDescriptor(source);
+                name = descriptor == null
+                        ? PathPlacement.fileName(coordinate)
+                        : PathPlacement.fileName(coordinate, descriptor.name(), true);
+            }
+            Claim previous = claims.putIfAbsent(name, new Claim(dependency, source));
+            if (previous != null && !previous.file().equals(source)) {
+                throw new IllegalArgumentException(previous.dependency()
+                        + " and "
+                        + dependency
+                        + " are both materialized as "
+                        + name
+                        + " - two artifacts cannot carry one module name");
+            }
+            Path target = libs.resolve(name);
             if (!source.equals(target)) {
                 if (source.startsWith(libs)) {
                     Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
@@ -688,12 +722,18 @@ public class Dependencies implements BuildStep {
                     Files.deleteIfExists(target);
                     BuildStep.linkOrCopy(target, source);
                 }
+                placed.put(dependency, target);
             }
-            PathPlacement.aliased(target, alias, "Target " + coordinate);
-            Files.writeString(PathPlacement.declaration(target), alias);
-            placed.put(coordinate, target);
+            renamed.put(source, target);
+            if (alias != null) {
+                PathPlacement.aliased(target, alias, "Target " + dependency);
+                Files.writeString(PathPlacement.declaration(target), alias);
+            }
         }
         return aliased;
+    }
+
+    private record Claim(String dependency, Path file) {
     }
 
     private static Path index(Path folder) {

--- a/sources/build/jenesis/step/Dependencies.java
+++ b/sources/build/jenesis/step/Dependencies.java
@@ -23,6 +23,7 @@ public class Dependencies implements BuildStep {
     public static final String GRAPH = "graph.properties";
     public static final String LICENSES = "licenses.properties";
     public static final String ALIASED = "aliased.properties";
+    public static final String INTERNAL = "internal.properties";
     public static final String RESOLVED = "resolved/";
     public static final String MODULAR = "modular.properties";
     public static final String MODULAR_PATH = "modular/";
@@ -219,7 +220,14 @@ public class Dependencies implements BuildStep {
         }
         Path libs = Files.createDirectories(context.next().resolve(RESOLVED));
         SequencedMap<String, Path> previousArtifacts = new LinkedHashMap<>();
+        SequencedSet<String> previousInternal = new LinkedHashSet<>();
         if (context.previous() != null) {
+            Path previousInternalFile = context.previous().resolve(INTERNAL);
+            if (Files.exists(previousInternalFile)) {
+                for (String dependency : SequencedProperties.ofFiles(previousInternalFile).stringPropertyNames()) {
+                    previousInternal.add(dependency.substring(dependency.indexOf('/') + 1));
+                }
+            }
             Path previousIndex = context.previous().resolve(DEPENDENCIES);
             if (Files.exists(previousIndex)) {
                 SequencedProperties.ofFiles(previousIndex).forEachProperty((key, value) -> {
@@ -243,7 +251,7 @@ public class Dependencies implements BuildStep {
             if (!previousArtifacts.isEmpty()) {
                 effective = effective.prepend((_, coordinate) -> Optional
                         .ofNullable(previousArtifacts.get(coordinate))
-                        .map(RepositoryItem::ofFile));
+                        .map(file -> RepositoryItem.ofFile(file, previousInternal.contains(coordinate))));
             }
             wrapped.put(name, effective.materialized(libs));
         });
@@ -556,6 +564,15 @@ public class Dependencies implements BuildStep {
             SequencedProperties properties = new SequencedProperties();
             aliased.forEach(properties::setProperty);
             properties.store(context.next().resolve(ALIASED));
+        }
+        SequencedProperties produced = new SequencedProperties();
+        internals.forEach((dependency, internal) -> {
+            if (internal) {
+                produced.setProperty(dependency, "");
+            }
+        });
+        if (!produced.isEmpty()) {
+            produced.store(context.next().resolve(INTERNAL));
         }
         if (pinning == Pinning.STRICT) {
             Set<Path> pinnedFiles = new HashSet<>();

--- a/tests/build/jenesis/test/JpxTest.java
+++ b/tests/build/jenesis/test/JpxTest.java
@@ -112,7 +112,7 @@ public class JpxTest {
         assertThat(properties.getProperty("mainClass")).isEqualTo("toolmain.Main");
         assertThat(properties.getProperty("classpath"))
                 .as("coordinates run on the class path in full, modular jars included")
-                .isEqualTo("tool-lib-1.0.jar,tool-main-1.0.jar");
+                .isEqualTo("tool.lib-1.0.jar,tool.main-1.0.jar");
         assertThat(properties.getProperty("modulepath")).isNull();
         assertThat(properties.getProperty(ModuleGraph.JAVA_OPTIONS))
                 .as("nothing is on the module path, so nothing has to be added to the graph")
@@ -136,7 +136,7 @@ public class JpxTest {
         SequencedProperties properties = installation.properties();
         assertThat(properties.getProperty("mainModule")).isNull();
         assertThat(properties.getProperty("mainClass")).isEqualTo("plaintool.Main");
-        assertThat(properties.getProperty("classpath")).isEqualTo("plain-tool-2.0.jar");
+        assertThat(properties.getProperty("classpath")).isEqualTo("org.example%2Fplain-tool%2F2.0.jar");
 
         Path marker = work.resolve("marker.txt");
         assertThat(installation.launch(List.of(marker.toString()))).isEqualTo(5);
@@ -154,7 +154,7 @@ public class JpxTest {
         assertThat(installation.folder().getFileName().toString()).isEqualTo("tool.main@1.0");
         SequencedProperties properties = installation.properties();
         assertThat(properties.getProperty("mainModule")).isEqualTo("tool.main");
-        assertThat(properties.getProperty("modulepath")).isEqualTo("tool-lib-1.0.jar,tool-main-1.0.jar");
+        assertThat(properties.getProperty("modulepath")).isEqualTo("tool.lib-1.0.jar,tool.main-1.0.jar");
 
         Path marker = work.resolve("marker.txt");
         assertThat(installation.launch(List.of(marker.toString()))).isEqualTo(7);
@@ -172,10 +172,10 @@ public class JpxTest {
 
         SequencedProperties properties = installation.properties();
         assertThat(properties.getProperty("mainModule")).isEqualTo("tool.main");
-        assertThat(properties.getProperty("modulepath")).isEqualTo("tool-lib-1.0.jar,tool-main-1.0.jar");
+        assertThat(properties.getProperty("modulepath")).isEqualTo("tool.lib-1.0.jar,tool.main-1.0.jar");
         assertThat(properties.getProperty("classpath"))
                 .as("a module name infers the placement jar by jar, so a plain dependency stays unnamed")
-                .isEqualTo("plain-tool-1.0.jar");
+                .isEqualTo("org.example%2Fplain-tool%2F1.0.jar");
 
         Path marker = work.resolve("marker.txt");
         assertThat(installation.launch(List.of(marker.toString()))).isEqualTo(7);
@@ -185,8 +185,7 @@ public class JpxTest {
     @Test
     public void module_placement_takes_every_jar_onto_the_module_path() throws IOException, InterruptedException {
         addMavenTool();
-        addPlainTool("1.0");
-        addDiscoveryPom(null, true);
+        addDiscoveryPom(null);
         Jpx jpx = jpx(PathPlacement.MODULE_PATH);
 
         Jpx.Installation installation = jpx.install("tool.main");
@@ -194,11 +193,9 @@ public class JpxTest {
         SequencedProperties properties = installation.properties();
         assertThat(properties.getProperty("mainModule")).isEqualTo("tool.main");
         assertThat(properties.getProperty("modulepath"))
-                .isEqualTo("plain-tool-1.0.jar,tool-lib-1.0.jar,tool-main-1.0.jar");
+                .as("a placement that names the module path takes the closure there, jar by jar")
+                .isEqualTo("tool.lib-1.0.jar,tool.main-1.0.jar");
         assertThat(properties.getProperty("classpath")).isNull();
-        assertThat(properties.getProperty(ModuleGraph.JAVA_OPTIONS))
-                .as("the plain jar joins as an automatic module, which the graph has to root explicitly")
-                .isEqualTo("--add-modules=ALL-MODULE-PATH,ALL-DEFAULT");
 
         Path marker = work.resolve("marker.txt");
         assertThat(installation.launch(List.of(marker.toString()))).isEqualTo(7);
@@ -215,7 +212,7 @@ public class JpxTest {
         SequencedProperties properties = installation.properties();
         assertThat(properties.getProperty("classpath"))
                 .as("coordinates name an artifact rather than a module, module path or not")
-                .isEqualTo("tool-lib-1.0.jar,tool-main-1.0.jar");
+                .isEqualTo("tool.lib-1.0.jar,tool.main-1.0.jar");
         assertThat(properties.getProperty("modulepath")).isNull();
         assertThat(properties.getProperty("mainModule")).isNull();
     }
@@ -230,7 +227,7 @@ public class JpxTest {
         assertThat(installation.folder().getFileName().toString()).isEqualTo("tool.main@1.0");
         SequencedProperties properties = installation.properties();
         assertThat(properties.getProperty("mainModule")).isEqualTo("tool.main");
-        assertThat(properties.getProperty("modulepath")).isEqualTo("tool.lib.jar,tool.main.jar");
+        assertThat(properties.getProperty("modulepath")).isEqualTo("tool.lib-1.0.jar,tool.main-1.0.jar");
         assertThat(properties.getProperty(ModuleGraph.JAVA_OPTIONS)).isNull();
 
         Path marker = work.resolve("marker.txt");
@@ -281,7 +278,7 @@ public class JpxTest {
 
         Jpx.Installation installation = jpx.install("org.example:tool-main@1.0");
 
-        assertThat(installation.properties().getProperty("classpath")).isEqualTo("tool-lib-1.0.jar,tool-main-1.0.jar");
+        assertThat(installation.properties().getProperty("classpath")).isEqualTo("tool.lib-1.0.jar,tool.main-1.0.jar");
         try (Stream<Path> entries = Files.list(storage)) {
             assertThat(entries.filter(entry -> entry.getFileName().toString().startsWith("staging-"))).isEmpty();
         }

--- a/tests/build/jenesis/test/JpxTest.java
+++ b/tests/build/jenesis/test/JpxTest.java
@@ -411,9 +411,30 @@ public class JpxTest {
     }
 
     @Test
+    public void a_layout_keeps_its_own_installations() throws IOException, InterruptedException {
+        addMavenTool();
+        addPlainTool("1.0");
+        addDiscoveryPom(null);
+
+        Jpx.Installation named = jpx().install("tool.main");
+        Jpx.Installation modular = jpx(PathPlacement.MODULE_PATH).install("tool.main");
+        Jpx.Installation coordinate = jpx().install("org.example:tool-main@1.0");
+
+        assertThat(named.folder().getParent().getFileName()).hasToString("modular_to_maven");
+        assertThat(modular.folder().getParent().getFileName())
+                .as("a module resolved over descriptors is not the one resolved over poms")
+                .hasToString("modular");
+        assertThat(coordinate.folder().getParent().getFileName())
+                .as("a coordinate names an artifact, not a module, and installs apart")
+                .hasToString("maven");
+        assertThat(modular.properties().getProperty("modulepath"))
+                .isNotEqualTo(named.properties().getProperty("classpath"));
+    }
+
+    @Test
     public void skips_materialization_when_installation_appears_during_resolution() throws IOException {
         addMavenTool();
-        Path folder = storage.resolve("org.example--tool-main@1.0");
+        Path folder = storage.resolve("maven").resolve("org.example--tool-main@1.0");
         Repository mavenRepository = new MavenDefaultRepository(mavenRepoFolder.toUri(), mavenRepoFolder, Map.of(), _ -> {});
         Resolver delegate = new MavenPomResolver();
         Resolver racing = (executor, prefix, repositories, coordinates, versions, scope) -> {
@@ -431,7 +452,7 @@ public class JpxTest {
 
         assertThat(installation.folder()).isEqualTo(folder);
         assertThat(installation.properties().getProperty("name")).isEqualTo("SENTINEL");
-        try (Stream<Path> entries = Files.list(storage)) {
+        try (Stream<Path> entries = Files.list(storage.resolve("maven"))) {
             assertThat(entries.filter(entry -> entry.getFileName().toString().startsWith("staging-"))).isEmpty();
         }
     }

--- a/tests/build/jenesis/test/PathPlacementTest.java
+++ b/tests/build/jenesis/test/PathPlacementTest.java
@@ -13,6 +13,67 @@ public class PathPlacementTest {
     private Path root;
 
     @Test
+    public void a_class_path_artifact_is_named_by_its_encoded_coordinate() {
+        assertThat(PathPlacement.fileName("org.example/plain-lib/1.0"))
+                .isEqualTo("org.example%2Fplain-lib%2F1.0.jar");
+        assertThat(PathPlacement.fileName("org.example/native-lib/jar/linux/1.0"))
+                .isEqualTo("org.example%2Fnative-lib%2Fjar%2Flinux%2F1.0.jar");
+    }
+
+    @Test
+    public void a_module_is_named_after_the_module_and_its_version() {
+        assertThat(PathPlacement.fileName("org.kohsuke/args4j/2.33", "org.kohsuke.args4j", false))
+                .isEqualTo("org.kohsuke.args4j-2.33.jar");
+        assertThat(PathPlacement.fileName("org.example/lib/9.4.53.v20231009", "org.example.lib", false))
+                .isEqualTo("org.example.lib-9.4.53.v20231009.jar");
+    }
+
+    @Test
+    public void a_version_the_runtime_cannot_derive_is_dropped_from_a_derived_name() {
+        assertThat(PathPlacement.fileName("org.example/lib/1-SNAPSHOT", "org.example.lib", false))
+                .as("the runtime would truncate the name at the dash and fail to derive a module")
+                .isEqualTo("org.example.lib.jar");
+        assertThat(PathPlacement.fileName("org.example/lib/RELEASE", "org.example.lib", false))
+                .isEqualTo("org.example.lib.jar");
+    }
+
+    @Test
+    public void a_declared_name_carries_any_version() {
+        assertThat(PathPlacement.fileName("build.jenesis/build.jenesis/1-SNAPSHOT", "build.jenesis", true))
+                .as("a jar that states its own name is read from within, so the name cannot break")
+                .isEqualTo("build.jenesis-1-SNAPSHOT.jar");
+    }
+
+    @Test
+    public void a_name_the_file_system_would_reject_is_encoded() {
+        assertThat(PathPlacement.fileName("org.example/lib/1.0:beta", "org.example.lib", true))
+                .isEqualTo("org.example.lib-1.0%3Abeta.jar");
+    }
+
+    @Test
+    public void a_derived_name_is_the_one_the_runtime_derives_back() throws IOException {
+        for (String version : List.of("2.33", "1", "1.0.0-SNAPSHOT", "2.0.SP1", "20030203.000550",
+                "1.0.0.Final", "3.0-alpha-1", "9.4.53.v20231009", "1-SNAPSHOT", "RELEASE", "r08")) {
+            Path jar = root.resolve(PathPlacement.fileName("org.example/lib/" + version, "org.example.lib", false));
+            try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar))) {
+                output.putNextEntry(new JarEntry("sample/Sample.class"));
+                output.write(new byte[] {1, 2, 3});
+                output.closeEntry();
+            }
+            Set<ModuleReference> found = ModuleFinder.of(jar).findAll();
+            assertThat(found).hasSize(1);
+            ModuleDescriptor descriptor = found.iterator().next().descriptor();
+            assertThat(descriptor.name())
+                    .as("a jar named for an alias must resolve to that alias, whatever the version looks like")
+                    .isEqualTo("org.example.lib");
+            assertThat(descriptor.rawVersion().orElse(null))
+                    .as("the version is carried when the runtime can derive it, and dropped when it cannot")
+                    .isEqualTo(jar.getFileName().toString().contains("-") ? version : null);
+            Files.delete(jar);
+        }
+    }
+
+    @Test
     public void exposes_modular_flag() {
         assertThat(PathPlacement.CLASS_PATH.modular()).isFalse();
         assertThat(PathPlacement.MODULE_PATH.modular()).isTrue();

--- a/tests/build/jenesis/test/project/KotlinCompilerModuleTest.java
+++ b/tests/build/jenesis/test/project/KotlinCompilerModuleTest.java
@@ -248,7 +248,7 @@ public class KotlinCompilerModuleTest {
                 .resolve("kotlin")
                 .resolve("dependencies")
                 .resolve("output");
-        List<String> names = listJarNames(artifacts);
+        List<String> names = listCoordinates(artifacts);
         assertThat(names).anyMatch(name -> name.contains("kotlin-compiler-embeddable"));
         assertThat(names).anyMatch(name -> name.contains("kotlin-stdlib"));
         assertThat(names).anyMatch(name -> name.contains("kotlinx-coroutines-core"));
@@ -388,11 +388,9 @@ public class KotlinCompilerModuleTest {
         return urls;
     }
 
-    private static List<String> listJarNames(Path folder) throws IOException {
-        List<String> names = new ArrayList<>();
-        for (Path jar : Dependencies.all(folder)) {
-            names.add(jar.getFileName().toString());
-        }
-        return names;
+    private static List<String> listCoordinates(Path folder) throws IOException {
+        return new ArrayList<>(SequencedProperties
+                .ofFiles(folder.resolve(BuildStep.DEPENDENCIES))
+                .stringPropertyNames());
     }
 }

--- a/tests/build/jenesis/test/project/ScalaCompilerModuleTest.java
+++ b/tests/build/jenesis/test/project/ScalaCompilerModuleTest.java
@@ -245,7 +245,7 @@ public class ScalaCompilerModuleTest {
                 .resolve("scala")
                 .resolve("dependencies")
                 .resolve("output");
-        List<String> names = listJarNames(artifacts);
+        List<String> names = listCoordinates(artifacts);
         assertThat(names).anyMatch(name -> name.contains("scala3-compiler_3"));
         assertThat(names).anyMatch(name -> name.contains("scala3-library_3"));
         assertThat(names).anyMatch(name -> name.contains("scala3-interfaces"));
@@ -362,11 +362,9 @@ public class ScalaCompilerModuleTest {
         return urls;
     }
 
-    private static List<String> listJarNames(Path folder) throws IOException {
-        List<String> names = new ArrayList<>();
-        for (Path jar : Dependencies.all(folder)) {
-            names.add(jar.getFileName().toString());
-        }
-        return names;
+    private static List<String> listCoordinates(Path folder) throws IOException {
+        return new ArrayList<>(SequencedProperties
+                .ofFiles(folder.resolve(BuildStep.DEPENDENCIES))
+                .stringPropertyNames());
     }
 }

--- a/tests/build/jenesis/test/step/DependenciesAliasTest.java
+++ b/tests/build/jenesis/test/step/DependenciesAliasTest.java
@@ -46,7 +46,7 @@ public class DependenciesAliasTest {
                 "org.example/plain-lib/1.0");
 
         assertThat(result.next()).isTrue();
-        Path aliased = next.resolve(Dependencies.RESOLVED + "toolkit.lib.jar");
+        Path aliased = next.resolve(Dependencies.RESOLVED + "toolkit.lib-1.0.jar");
         assertThat(aliased).exists();
         assertThat(Files.readAllBytes(aliased))
                 .as("a pinned checksum keeps describing the jar on the command line, so only the name changes")
@@ -59,7 +59,7 @@ public class DependenciesAliasTest {
                 .isEqualTo("maven/org.example/plain-lib/1.0");
         assertThat(SequencedProperties.ofFiles(next.resolve(BuildStep.DEPENDENCIES))
                 .getProperty("main/compile/maven/org.example/plain-lib/1.0"))
-                .startsWith(Dependencies.RESOLVED + "toolkit.lib.jar");
+                .startsWith(Dependencies.RESOLVED + "toolkit.lib-1.0.jar");
     }
 
     @Test
@@ -68,7 +68,7 @@ public class DependenciesAliasTest {
 
         resolve(Map.of("toolkit.lib", "org.example/plain-lib"), "org.example/plain-lib/1.0");
 
-        Path aliased = next.resolve(Dependencies.RESOLVED + "toolkit.lib.jar");
+        Path aliased = next.resolve(Dependencies.RESOLVED + "toolkit.lib-1.0.jar");
         assertThat(PathPlacement.INFERRED.test(aliased))
                 .as("a jar named for a module the build declared belongs on the module path")
                 .isTrue();
@@ -84,7 +84,7 @@ public class DependenciesAliasTest {
 
         resolve(Map.of("toolkit.lib", "org.example/plain-lib"), "org.example/plain-lib/1.0");
 
-        Path aliased = next.resolve(Dependencies.RESOLVED + "toolkit.lib.jar");
+        Path aliased = next.resolve(Dependencies.RESOLVED + "toolkit.lib-1.0.jar");
         Path classes = app(aliased, """
                 module my.app {
                     exports myapp;
@@ -125,7 +125,7 @@ public class DependenciesAliasTest {
                 "org.example/plain-lib/1.0");
 
         assertThat(result.next()).isTrue();
-        assertThat(next.resolve(Dependencies.RESOLVED + "toolkit.lib.jar"))
+        assertThat(next.resolve(Dependencies.RESOLVED + "toolkit.lib-1.0.jar"))
                 .as("a jar renamed by a previous resolution is found again under the name it was given")
                 .exists();
     }
@@ -139,7 +139,7 @@ public class DependenciesAliasTest {
         resolve(Map.of("toolkit.natives", "org.example/native-lib/jar/linux"),
                 "org.example/native-lib/jar/linux/1.0");
 
-        assertThat(next.resolve(Dependencies.RESOLVED + "toolkit.natives.jar"))
+        assertThat(next.resolve(Dependencies.RESOLVED + "toolkit.natives-1.0.jar"))
                 .as("a type and a classifier are part of the token a declaration matches")
                 .exists();
     }
@@ -240,7 +240,7 @@ public class DependenciesAliasTest {
         BuildStepResult result = resolve(Map.of(), "org.example/consumer-lib/1.0");
 
         assertThat(result.next()).isTrue();
-        assertThat(next.resolve(Dependencies.RESOLVED + "toolkit.lib.jar"))
+        assertThat(next.resolve(Dependencies.RESOLVED + "toolkit.lib-1.0.jar"))
                 .as("a declaration travels to every consumer through the manifest of the jar that made it")
                 .exists();
     }
@@ -281,7 +281,7 @@ public class DependenciesAliasTest {
 
         resolve(Map.of("toolkit.lib", "org.example/plain-lib"), "org.example/plain-lib/1.0");
 
-        assertThat(Files.readAllBytes(next.resolve(Dependencies.RESOLVED + "toolkit.lib.jar")))
+        assertThat(Files.readAllBytes(next.resolve(Dependencies.RESOLVED + "toolkit.lib-1.0.jar")))
                 .as("the alias declares no version, so the @jenesis.pin on the coordinate decides which jar is renamed")
                 .isEqualTo(pinned);
         assertThat(SequencedProperties.ofFiles(next.resolve(Dependencies.ALIASED))
@@ -307,7 +307,7 @@ public class DependenciesAliasTest {
                 "org.example/consumer-lib/1.0",
                 "org.example/plain-lib");
 
-        assertThat(Files.readAllBytes(next.resolve(Dependencies.RESOLVED + "toolkit.lib.jar")))
+        assertThat(Files.readAllBytes(next.resolve(Dependencies.RESOLVED + "toolkit.lib-1.0.jar")))
                 .as("naming somebody else's transitive dependency must not raise the version the graph decided,"
                         + " even though 2.0 is the latest the repository serves")
                 .isEqualTo(transitive);
@@ -329,7 +329,7 @@ public class DependenciesAliasTest {
 
         resolve(Map.of("toolkit.lib", "org.example/plain-lib"), "org.example/plain-lib");
 
-        assertThat(Files.readAllBytes(next.resolve(Dependencies.RESOLVED + "toolkit.lib.jar")))
+        assertThat(Files.readAllBytes(next.resolve(Dependencies.RESOLVED + "toolkit.lib-2.0.jar")))
                 .as("a coordinate the closure does not carry is added as a root, floating like any unpinned require")
                 .isEqualTo(latest);
         assertThat(SequencedProperties.ofFiles(next.resolve(Dependencies.ALIASED))

--- a/tests/build/jenesis/test/step/DependenciesResolutionTest.java
+++ b/tests/build/jenesis/test/step/DependenciesResolutionTest.java
@@ -593,6 +593,40 @@ public class DependenciesResolutionTest {
     }
 
     @Test
+    public void strict_pinning_accepts_an_internal_artifact_reused_from_a_previous_resolution() throws IOException {
+        SequencedProperties properties = new SequencedProperties();
+        properties.setProperty("main/compile/foo/bar", "");
+        properties.store(dependencies.resolve(BuildStep.REQUIRES));
+        Repository internal = (_, coordinate) -> {
+            Path file = Files.write(artifacts.resolve(coordinate.replace('/', '-') + ".jar"),
+                    coordinate.getBytes(StandardCharsets.UTF_8));
+            return Optional.of(RepositoryItem.ofFile(file, true));
+        };
+        Dependencies resolve = new Dependencies(Map.of("foo", internal), Map.of("foo", (executor, prefix, repositories, descriptors, _, _) -> {
+            SequencedMap<String, String> resolved = new LinkedHashMap<>();
+            descriptors.sequencedKeySet().forEach(descriptor -> resolved.put(prefix + "/" + descriptor, ""));
+            return new Resolver.Resolution(Resolver.materializeAll(executor, repositories, prefix, resolved), List.of(), new LinkedHashMap<>());
+        })).pinning(Pinning.STRICT);
+        SequencedMap<String, BuildStepArgument> arguments = new LinkedHashMap<>(Map.of("dependencies",
+                new BuildStepArgument(dependencies, Map.of(
+                        Path.of(BuildStep.REQUIRES), Checksum.of(ChecksumStatus.ADDED)))));
+        resolve.apply(Runnable::run, new BuildStepContext(previous, next, supplement), arguments)
+                .toCompletableFuture()
+                .join();
+
+        Path second = Files.createDirectory(root.resolve("second"));
+        BuildStepResult result = resolve.apply(Runnable::run,
+                        new BuildStepContext(next, second, supplement),
+                        arguments)
+                .toCompletableFuture()
+                .join();
+
+        assertThat(result.next())
+                .as("an artifact this build produced needs no checksum, however it is reached")
+                .isTrue();
+    }
+
+    @Test
     public void strict_pinning_rejects_unpinned_external_dependency() throws IOException {
         SequencedProperties properties = new SequencedProperties();
         properties.setProperty("main/compile/foo/bar", "");

--- a/tests/build/jenesis/test/step/DependenciesResolutionTest.java
+++ b/tests/build/jenesis/test/step/DependenciesResolutionTest.java
@@ -593,13 +593,14 @@ public class DependenciesResolutionTest {
     }
 
     @Test
-    public void strict_pinning_accepts_an_internal_artifact_reused_from_a_previous_resolution() throws IOException {
+    public void an_internal_artifact_is_resolved_again_rather_than_reused() throws IOException {
         SequencedProperties properties = new SequencedProperties();
         properties.setProperty("main/compile/foo/bar", "");
         properties.store(dependencies.resolve(BuildStep.REQUIRES));
+        AtomicReference<String> produced = new AtomicReference<>("first");
         Repository internal = (_, coordinate) -> {
             Path file = Files.write(artifacts.resolve(coordinate.replace('/', '-') + ".jar"),
-                    coordinate.getBytes(StandardCharsets.UTF_8));
+                    produced.get().getBytes(StandardCharsets.UTF_8));
             return Optional.of(RepositoryItem.ofFile(file, true));
         };
         Dependencies resolve = new Dependencies(Map.of("foo", internal), Map.of("foo", (executor, prefix, repositories, descriptors, _, _) -> {
@@ -614,6 +615,7 @@ public class DependenciesResolutionTest {
                 .toCompletableFuture()
                 .join();
 
+        produced.set("second");
         Path second = Files.createDirectory(root.resolve("second"));
         BuildStepResult result = resolve.apply(Runnable::run,
                         new BuildStepContext(next, second, supplement),
@@ -621,9 +623,12 @@ public class DependenciesResolutionTest {
                 .toCompletableFuture()
                 .join();
 
-        assertThat(result.next())
-                .as("an artifact this build produced needs no checksum, however it is reached")
-                .isTrue();
+        assertThat(result.next()).isTrue();
+        String entry = SequencedProperties.ofFiles(second.resolve(BuildStep.DEPENDENCIES))
+                .getProperty("main/compile/foo/bar");
+        assertThat(second.resolve(entry))
+                .as("what this build produces is taken from the build, never from what a previous run left behind")
+                .hasContent("second");
     }
 
     @Test


### PR DESCRIPTION
Stacked on #66, which had to land first: this change is only safe once nothing infers identity from a file name, and #66 removed the last two places that did.

## What changes

| artifact | file name |
|---|---|
| named module (`module-info.class`) | `<module>-<version>.jar` |
| automatic by manifest (`Automatic-Module-Name`) | `<module>-<version>.jar` |
| aliased (`@jenesis.alias`) | `<alias>-<version>.jar` |
| no module identity | `<encoded coordinate>.jar` |

The repository prefix is gone from both forms, so internal and external artifacts read alike and match the coordinate in `dependencies.properties`. Both halves are encoded, which is the identity function for a legal module name and an ordinary version.

Only a name the file name itself carries can break, so only an alias guards its version: appended when the runtime derives it back, left off when it cannot - `1-SNAPSHOT` truncates a name into a module that does not resolve, and it is Jenesis's own default version. A jar that states its own name takes any version, because the runtime reads the name from within.

Naming is per file, not per coordinate: the modular layout reaches one artifact under both its module and its Maven coordinate, and the first claim decides, with aliases claiming first. Two artifacts claiming one name is an error naming both.

The modularize rewrite carries the same names, and the descriptor it synthesises records the version, taken from the resolution graph rather than from a file name.

## What it buys

```
resolved/org.kohsuke.args4j-2.33.jar
java -p … --describe-module org.kohsuke.args4j   ->  org.kohsuke.args4j@2.33 … automatic
image --list-modules                             ->  org.kohsuke.args4j@2.33 open
```

A stack trace out of an aliased or automatic dependency now names the version that actually ran. Consumers stay free: javac records no version for a `requires` on an automatic module, since `ModuleSymbol.version` is only ever set from a read `module-info.class` or from `--module-version`.

## The one consequence to know about

A synthesized `module-info.class` is a real descriptor, so `ClassReader` reads its version back when a consumer compiles against the rewritten tree. Under `mode=declared` / `mode=synthetic`, a consumer's published `requires` will carry `(version)` for rewritten dependencies, and `ModularJarResolver` sees those as version hints. That is the price of a linked image reporting the same identity as a plain module path, and it was chosen deliberately.

## Verification

- `mvn test`: 144 classes, 0 failures.
- 24 of 25 demos rebuilt from a wiped `target` under `-Djenesis.dependency.pin=strict`, including jlink, both launcher demos, docker, jpx, alias, quality, coverage, pitest, sbom, publishing and build-cache. `demo-44-native-image` needs the GraalVM toolchain and has its own CI job.
- `PathPlacementTest` round-trips the namer against `ModuleFinder` over eleven realistic versions, so a change in the JDK's derivation fails a test rather than silently losing a module.
- Two tests that grepped file names for a dependency set now read coordinates out of the index, with every assertion string unchanged.

Pairs with raphw/jenesis-launcher#14, which keeps the version a module path derives for a bundled automatic module. Neither side waits for the other.
