### PR TITLE
Verify the sources behind the version before trusting it

### DIFF
--- a/sdk/jenesis/bin/jenesis
+++ b/sdk/jenesis/bin/jenesis
@@ -4,34 +4,47 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 JENESIS_HOME="$(dirname "$SCRIPT_DIR")"
 
 DIR="$PWD"
-STAMP=""
+VENDORED=""
 while :; do
-    if [ -f "$DIR/build/jenesis/jenesis.version" ]; then
-        STAMP="$(cat "$DIR/build/jenesis/jenesis.version")"
+    if [ -d "$DIR/build/jenesis" ]; then
+        VENDORED="$DIR/build/jenesis"
         break
     fi
     [ "$DIR" = "/" ] && break
     DIR="$(dirname "$DIR")"
 done
 
-if [ -z "$STAMP" ]; then
+if [ -z "$VENDORED" ]; then
     exec "$SCRIPT_DIR/jenesis-run" "$@"
 fi
 
-for candidate in "$JENESIS_HOME"/sources/*-sources.jar; do
-    if [ -f "$candidate" ]; then
-        JAR_NAME="$(basename "$candidate" .jar)"
-        VERSION="${JAR_NAME#build.jenesis-}"
-        VERSION="${VERSION%-sources}"
-        if [ "$STAMP" = "$VERSION" ]; then
-            exec "$SCRIPT_DIR/jenesis-run" "$@"
+version() {
+    local jar
+    for jar in "$1"/sources/*-sources.jar; do
+        if [ -f "$jar" ]; then
+            jar="$(basename "$jar" .jar)"
+            jar="${jar#build.jenesis-}"
+            printf '%s' "${jar%-sources}"
+            return 0
         fi
-        break
-    fi
-done
+    done
+    return 1
+}
+
+STAMP=""
+if [ -f "$VENDORED/jenesis.version" ]; then
+    STAMP="$(cat "$VENDORED/jenesis.version")"
+fi
+if [ -z "$STAMP" ]; then
+    STAMP="$(version "$JENESIS_HOME")" || STAMP=""
+fi
 
 locate() {
     local home
+    if [ "$(version "$JENESIS_HOME" 2>/dev/null || true)" = "$1" ]; then
+        printf '%s' "$JENESIS_HOME"
+        return 0
+    fi
     for home in \
             "${SDKMAN_DIR:-$HOME/.sdkman}/candidates/jenesis/$1" \
             "$(dirname "$JENESIS_HOME")/$1" \
@@ -55,36 +68,91 @@ locate() {
     return 1
 }
 
-TARGET_HOME="$(locate "$STAMP")" || TARGET_HOME=""
-
 sdkman() {
     command -v sdk >/dev/null 2>&1 && return 0
     [ -s "${SDKMAN_DIR:-$HOME/.sdkman}/bin/sdkman-init.sh" ]
 }
 
-if [ -z "$TARGET_HOME" ] && sdkman; then
-    echo "jenesis: build/jenesis is at ${STAMP}, installing that version via SDKMAN" >&2
-    (
-        set +e
-        if ! command -v sdk >/dev/null 2>&1; then
-            # shellcheck disable=SC1090
-            . "${SDKMAN_DIR:-$HOME/.sdkman}/bin/sdkman-init.sh" >/dev/null 2>&1
-        fi
-        command -v sdk >/dev/null 2>&1 || exit 1
-        printf 'n\n' | sdk install jenesis "$STAMP" >&2
-    ) || true
+fromSource() {
+    if [ ! -f "$VENDORED/Project.java" ]; then
+        echo "jenesis: ${VENDORED} carries no Project.java, so there is nothing to run from source" >&2
+        exit 1
+    fi
+    local java
+    if [ -n "${JAVA_HOME:-}" ] && [ -x "${JAVA_HOME}/bin/java" ]; then
+        java="${JAVA_HOME}/bin/java"
+    elif command -v java >/dev/null 2>&1; then
+        java="java"
+    else
+        echo "jenesis: no Java runtime found - set JAVA_HOME or add 'java' to PATH (Java 25 or newer required)" >&2
+        exit 1
+    fi
+    exec "$java" ${JAVA_OPTS:-} "$VENDORED/Project.java" "$@"
+}
+
+digestOf() {
+    (cd "$1" && find . -name '*.java' | LC_ALL=C sort | xargs "$HASH" | "$HASH" | cut -d' ' -f1)
+}
+
+if command -v sha256sum >/dev/null 2>&1; then
+    HASH=sha256sum
+elif command -v shasum >/dev/null 2>&1; then
+    HASH="shasum -a 256"
+else
+    fromSource "$@"
+fi
+
+TARGET_HOME=""
+if [ -n "$STAMP" ]; then
     TARGET_HOME="$(locate "$STAMP")" || TARGET_HOME=""
+    if [ -z "$TARGET_HOME" ] && sdkman; then
+        echo "jenesis: build/jenesis records ${STAMP}, installing that version via SDKMAN" >&2
+        (
+            set +e
+            if ! command -v sdk >/dev/null 2>&1; then
+                # shellcheck disable=SC1090
+                . "${SDKMAN_DIR:-$HOME/.sdkman}/bin/sdkman-init.sh" >/dev/null 2>&1
+            fi
+            command -v sdk >/dev/null 2>&1 || exit 1
+            printf 'n\n' | sdk install jenesis "$STAMP" >&2
+        ) || true
+        TARGET_HOME="$(locate "$STAMP")" || TARGET_HOME=""
+    fi
 fi
 
 if [ -z "$TARGET_HOME" ]; then
-    echo "jenesis: ${DIR}/build/jenesis is at version ${STAMP}, which is not installed" >&2
-    if sdkman; then
-        echo "jenesis: install it with 'sdk install jenesis ${STAMP}', or run the installed version with 'jenesis-run'" >&2
-    else
-        echo "jenesis: install that version with your package manager, or run the installed version with 'jenesis-run'" >&2
-    fi
-    exit 1
+    echo "jenesis: no installed Jenesis matches ${VENDORED}, building from its sources" >&2
+    fromSource "$@"
 fi
+
+REFERENCE=""
+for jar in "$TARGET_HOME"/sources/*-sources.jar; do
+    [ -f "$jar" ] && REFERENCE="$jar" && break
+done
+if [ -z "$REFERENCE" ]; then
+    echo "jenesis: ${TARGET_HOME} ships no sources to verify against, building from ${VENDORED}" >&2
+    fromSource "$@"
+fi
+
+EXTRACTED="$(mktemp -d)"
+trap 'rm -rf "$EXTRACTED"' EXIT
+if command -v unzip >/dev/null 2>&1; then
+    unzip -qq -o "$REFERENCE" 'build/jenesis/*' -d "$EXTRACTED" >/dev/null 2>&1 || true
+elif command -v jar >/dev/null 2>&1; then
+    (cd "$EXTRACTED" && jar xf "$REFERENCE" build/jenesis) >/dev/null 2>&1 || true
+fi
+if [ ! -d "$EXTRACTED/build/jenesis" ]; then
+    echo "jenesis: could not read the sources of ${TARGET_HOME}, building from ${VENDORED}" >&2
+    fromSource "$@"
+fi
+
+if [ "$(digestOf "$VENDORED")" != "$(digestOf "$EXTRACTED/build/jenesis")" ]; then
+    echo "jenesis: ${VENDORED} does not match the sources of Jenesis ${STAMP}, building from it instead" >&2
+    fromSource "$@"
+fi
+
+rm -rf "$EXTRACTED"
+trap - EXIT
 
 if [ -x "$TARGET_HOME/bin/jenesis-run" ]; then
     exec "$TARGET_HOME/bin/jenesis-run" "$@"

--- a/sdk/jenesis/bin/jenesis.bat
+++ b/sdk/jenesis/bin/jenesis.bat
@@ -34,6 +34,7 @@ set "STAMP="
 if exist "!VENDORED!\jenesis.version" (
     for /f "usebackq delims=" %%v in ("!VENDORED!\jenesis.version") do if not defined STAMP set "STAMP=%%v"
 )
+if defined STAMP set "STAMP=!STAMP:"=!"
 if not defined STAMP set "STAMP=!VERSION!"
 
 set "TARGET_HOME="

--- a/sdk/jenesis/bin/jenesis.bat
+++ b/sdk/jenesis/bin/jenesis.bat
@@ -3,22 +3,20 @@ setlocal EnableDelayedExpansion
 set "SCRIPT_DIR=%~dp0"
 for %%i in ("%~dp0..") do set "JENESIS_HOME=%%~fi"
 
-set "STAMP="
-set "FOUND_DIR="
+set "VENDORED="
 set "DIR=%CD%"
-:findstamp
-if exist "!DIR!\build\jenesis\jenesis.version" (
-    for /f "usebackq delims=" %%v in ("!DIR!\build\jenesis\jenesis.version") do if not defined STAMP set "STAMP=%%v"
-    set "FOUND_DIR=!DIR!"
-    goto :stampdone
+:findvendored
+if exist "!DIR!\build\jenesis\" (
+    set "VENDORED=!DIR!\build\jenesis"
+    goto :vendoreddone
 )
 for %%i in ("!DIR!\..") do set "PARENT=%%~fi"
-if "!PARENT!"=="!DIR!" goto :stampdone
+if "!PARENT!"=="!DIR!" goto :vendoreddone
 set "DIR=!PARENT!"
-goto :findstamp
-:stampdone
+goto :findvendored
+:vendoreddone
 
-if not defined STAMP (
+if not defined VENDORED (
     call "%SCRIPT_DIR%jenesis-run.bat" %*
     exit /b !errorlevel!
 )
@@ -31,25 +29,67 @@ for %%f in ("%JENESIS_HOME%\sources\*-sources.jar") do (
         if /i "!VERSION:~-8!"=="-sources" set "VERSION=!VERSION:~0,-8!"
     )
 )
-if "!STAMP!"=="!VERSION!" (
-    call "%SCRIPT_DIR%jenesis-run.bat" %*
-    exit /b !errorlevel!
+
+set "STAMP="
+if exist "!VENDORED!\jenesis.version" (
+    for /f "usebackq delims=" %%v in ("!VENDORED!\jenesis.version") do if not defined STAMP set "STAMP=%%v"
 )
+if not defined STAMP set "STAMP=!VERSION!"
 
 set "TARGET_HOME="
-for %%h in (
-    "%USERPROFILE%\scoop\apps\jenesis\!STAMP!"
-    "%JENESIS_HOME%\..\!STAMP!"
-) do (
-    if not defined TARGET_HOME (
-        if exist "%%~h\bin" set "TARGET_HOME=%%~fh"
+if "!STAMP!"=="!VERSION!" (
+    set "TARGET_HOME=%JENESIS_HOME%"
+) else (
+    for %%h in (
+        "%USERPROFILE%\scoop\apps\jenesis\!STAMP!"
+        "%JENESIS_HOME%\..\!STAMP!"
+    ) do (
+        if not defined TARGET_HOME (
+            if exist "%%~h\bin\" set "TARGET_HOME=%%~fh"
+        )
     )
 )
 
 if not defined TARGET_HOME (
-    echo jenesis: !FOUND_DIR!\build\jenesis is at version !STAMP!, which is not installed 1>&2
-    echo jenesis: install that version, or run the installed version with 'jenesis-run' 1>&2
-    exit /b 1
+    echo jenesis: no installed Jenesis matches !VENDORED!, building from its sources 1>&2
+    goto :fromsource
+)
+
+set "REFERENCE="
+for %%f in ("!TARGET_HOME!\sources\*-sources.jar") do if not defined REFERENCE set "REFERENCE=%%~ff"
+if not defined REFERENCE (
+    echo jenesis: !TARGET_HOME! ships no sources to verify against, building from !VENDORED! 1>&2
+    goto :fromsource
+)
+
+set "EXTRACTED=%TEMP%\jenesis-verify-%RANDOM%%RANDOM%"
+mkdir "!EXTRACTED!" 2>nul
+pushd "!EXTRACTED!"
+jar xf "!REFERENCE!" build/jenesis >nul 2>&1
+popd
+if not exist "!EXTRACTED!\build\jenesis\" (
+    rmdir /s /q "!EXTRACTED!" 2>nul
+    echo jenesis: could not read the sources of !TARGET_HOME!, building from !VENDORED! 1>&2
+    goto :fromsource
+)
+
+set "DIGEST_A="
+set "DIGEST_B="
+for /f "usebackq delims=" %%d in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; $r=(Resolve-Path -LiteralPath '!VENDORED!').Path; $t=(Get-ChildItem -LiteralPath $r -Recurse -Filter *.java | ForEach-Object { $rel=$_.FullName.Substring($r.Length).Replace('\','/'); $h=(Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash; \"$h $rel\" } | Sort-Object) -join \"`n\"; $s=[IO.MemoryStream]::new([Text.Encoding]::UTF8.GetBytes($t)); (Get-FileHash -InputStream $s -Algorithm SHA256).Hash" 2^>nul`) do set "DIGEST_A=%%d"
+for /f "usebackq delims=" %%d in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; $r=(Resolve-Path -LiteralPath '!EXTRACTED!\build\jenesis').Path; $t=(Get-ChildItem -LiteralPath $r -Recurse -Filter *.java | ForEach-Object { $rel=$_.FullName.Substring($r.Length).Replace('\','/'); $h=(Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash; \"$h $rel\" } | Sort-Object) -join \"`n\"; $s=[IO.MemoryStream]::new([Text.Encoding]::UTF8.GetBytes($t)); (Get-FileHash -InputStream $s -Algorithm SHA256).Hash" 2^>nul`) do set "DIGEST_B=%%d"
+rmdir /s /q "!EXTRACTED!" 2>nul
+
+if not defined DIGEST_A (
+    echo jenesis: could not digest !VENDORED!, building from it 1>&2
+    goto :fromsource
+)
+if not defined DIGEST_B (
+    echo jenesis: could not digest the sources of !TARGET_HOME!, building from !VENDORED! 1>&2
+    goto :fromsource
+)
+if not "!DIGEST_A!"=="!DIGEST_B!" (
+    echo jenesis: !VENDORED! does not match the sources of Jenesis !STAMP!, building from it instead 1>&2
+    goto :fromsource
 )
 
 if exist "!TARGET_HOME!\bin\jenesis-run.bat" (
@@ -57,4 +97,24 @@ if exist "!TARGET_HOME!\bin\jenesis-run.bat" (
     exit /b !errorlevel!
 )
 call "!TARGET_HOME!\bin\jenesis.bat" %*
+exit /b !errorlevel!
+
+:fromsource
+if not exist "!VENDORED!\Project.java" (
+    echo jenesis: !VENDORED! carries no Project.java, so there is nothing to run from source 1>&2
+    exit /b 1
+)
+set "JAVA="
+if defined JAVA_HOME (
+    if exist "%JAVA_HOME%\bin\java.exe" set "JAVA=%JAVA_HOME%\bin\java.exe"
+)
+if not defined JAVA (
+    where java >nul 2>&1
+    if errorlevel 1 (
+        echo jenesis: no Java runtime found - set JAVA_HOME or add 'java' to PATH ^(Java 25 or newer required^) 1>&2
+        exit /b 1
+    )
+    set "JAVA=java"
+)
+"!JAVA!" %JAVA_OPTS% "!VENDORED!\Project.java" %*
 exit /b !errorlevel!

--- a/sdk/jenesis/tests/test.bat
+++ b/sdk/jenesis/tests/test.bat
@@ -102,7 +102,7 @@ REM [8/8] jenesis: a stamp naming a version that is not installed builds from th
 echo [8/8] jenesis on an uninstalled stamp
 set "UNSTAMPED=%TMPDIR%\unstamped"
 xcopy /s /e /y /i /q "%PROJ%" "%UNSTAMPED%" >nul
-(echo^\|set /p="0.0.0-ABSENT")> "%UNSTAMPED%\build\jenesis\jenesis.version"
+<nul set /p ="0.0.0-ABSENT">"%UNSTAMPED%\build\jenesis\jenesis.version"
 pushd "%UNSTAMPED%"
 call "%SDK_HOME%\bin\jenesis.bat" help > "%OUTFILE%" 2>&1
 set "RC=!ERRORLEVEL!"

--- a/sdk/jenesis/tests/test.bat
+++ b/sdk/jenesis/tests/test.bat
@@ -29,8 +29,8 @@ set "PROJ=%TMPDIR%\proj"
 mkdir "%PROJ%"
 set "OUTFILE=%TMPDIR%\out.txt"
 
-REM [1/7] jenesis-version on fresh directory: exit 1, reports missing build/jenesis
-echo [1/7] jenesis-version on fresh directory
+REM [1/8] jenesis-version on fresh directory: exit 1, reports missing build/jenesis
+echo [1/8] jenesis-version on fresh directory
 call "%SDK_HOME%\bin\jenesis-version.bat" "%PROJ%" > "%OUTFILE%" 2>&1
 set "RC=!ERRORLEVEL!"
 if not "!RC!"=="1" goto :fail
@@ -38,8 +38,8 @@ findstr /c:"sdk is at version !VERSION!" "%OUTFILE%" >nul || goto :fail
 findstr /c:"no build/jenesis found" "%OUTFILE%" >nul || goto :fail
 echo   ok
 
-REM [2/7] jenesis-init: populates build\jenesis and writes jenesis.version
-echo [2/7] jenesis-init
+REM [2/8] jenesis-init: populates build\jenesis and writes jenesis.version
+echo [2/8] jenesis-init
 call "%SDK_HOME%\bin\jenesis-init.bat" "%PROJ%" > "%OUTFILE%" 2>&1
 if errorlevel 1 goto :fail
 if not exist "%PROJ%\build\jenesis\" goto :fail
@@ -49,22 +49,22 @@ for /f "usebackq delims=" %%v in ("%PROJ%\build\jenesis\jenesis.version") do if 
 if not "!RECORDED!"=="!VERSION!" goto :fail
 echo   ok
 
-REM [3/7] jenesis-version on initialised project: exit 0, reports matching version
-echo [3/7] jenesis-version on initialised project
+REM [3/8] jenesis-version on initialised project: exit 0, reports matching version
+echo [3/8] jenesis-version on initialised project
 call "%SDK_HOME%\bin\jenesis-version.bat" "%PROJ%" > "%OUTFILE%" 2>&1
 if errorlevel 1 goto :fail
 findstr /c:"build/jenesis is at version !VERSION!" "%OUTFILE%" >nul || goto :fail
 echo   ok
 
-REM [4/7] jenesis-validate: reports zero drift against the bundled sources
-echo [4/7] jenesis-validate
+REM [4/8] jenesis-validate: reports zero drift against the bundled sources
+echo [4/8] jenesis-validate
 call "%SDK_HOME%\bin\jenesis-validate.bat" "%PROJ%" > "%OUTFILE%" 2>&1
 findstr /c:"0 differs, 0 missing, 0 additional" "%OUTFILE%" >nul || goto :fail
 echo   ok
 
-REM [5/7] jenesis: the launcher resolves the engine from the SDK and dispatches to it;
+REM [5/8] jenesis: the launcher resolves the engine from the SDK and dispatches to it;
 REM `help` is a print-only goal, so it runs offline once a project descriptor exists.
-echo [5/7] jenesis help
+echo [5/8] jenesis help
 if not exist "%PROJ%\sources\" mkdir "%PROJ%\sources"
 (echo module sdktest {})> "%PROJ%\sources\module-info.java"
 pushd "%PROJ%"
@@ -75,8 +75,8 @@ if not "!RC!"=="0" goto :fail
 findstr /c:"a Java build tool" "%OUTFILE%" >nul || goto :fail
 echo   ok
 
-REM [6/7] jenesis-run: runs the installed version directly, without the version lookup
-echo [6/7] jenesis-run
+REM [6/8] jenesis-run: runs the installed version directly, without the version lookup
+echo [6/8] jenesis-run
 pushd "%PROJ%"
 call "%SDK_HOME%\bin\jenesis-run.bat" help > "%OUTFILE%" 2>&1
 set "RC=!ERRORLEVEL!"
@@ -85,18 +85,30 @@ if not "!RC!"=="0" goto :fail
 findstr /c:"a Java build tool" "%OUTFILE%" >nul || goto :fail
 echo   ok
 
-REM [7/7] jenesis: a stamp naming a version that is not installed fails, naming both fixes
-echo [7/7] jenesis on an uninstalled stamp
+REM [7/8] jenesis: a patched vendored tree is never run from the installed engine
+echo [7/8] jenesis refuses an engine the vendored sources do not match
+set "PATCHED=%TMPDIR%\patched"
+xcopy /s /e /y /i /q "%PROJ%" "%PATCHED%" >nul
+echo // local patch>> "%PATCHED%\build\jenesis\Platform.java"
+pushd "%PATCHED%"
+call "%SDK_HOME%\bin\jenesis.bat" help > "%OUTFILE%" 2>&1
+set "RC=!ERRORLEVEL!"
+popd
+if not "!RC!"=="0" goto :fail
+findstr /c:"does not match the sources" "%OUTFILE%" >nul || goto :fail
+echo   ok
+
+REM [8/8] jenesis: a stamp naming a version that is not installed builds from the vendored sources
+echo [8/8] jenesis on an uninstalled stamp
 set "UNSTAMPED=%TMPDIR%\unstamped"
-if not exist "%UNSTAMPED%\build\jenesis\" mkdir "%UNSTAMPED%\build\jenesis"
-(echo^|set /p="0.0.0-ABSENT")> "%UNSTAMPED%\build\jenesis\jenesis.version"
+xcopy /s /e /y /i /q "%PROJ%" "%UNSTAMPED%" >nul
+(echo^\|set /p="0.0.0-ABSENT")> "%UNSTAMPED%\build\jenesis\jenesis.version"
 pushd "%UNSTAMPED%"
 call "%SDK_HOME%\bin\jenesis.bat" help > "%OUTFILE%" 2>&1
 set "RC=!ERRORLEVEL!"
 popd
-if "!RC!"=="0" goto :fail
-findstr /c:"0.0.0-ABSENT" "%OUTFILE%" >nul || goto :fail
-findstr /c:"jenesis-run" "%OUTFILE%" >nul || goto :fail
+if not "!RC!"=="0" goto :fail
+findstr /c:"no installed Jenesis matches" "%OUTFILE%" >nul || goto :fail
 echo   ok
 
 rmdir /s /q "%TMPDIR%" >nul 2>&1

--- a/sdk/jenesis/tests/test.sh
+++ b/sdk/jenesis/tests/test.sh
@@ -42,8 +42,8 @@ dump_and_fail() {
     exit 1
 }
 
-# [1/8] jenesis-version on a fresh directory: exit 1, reports missing build/jenesis
-echo "[1/8] jenesis-version on fresh directory"
+# [1/9] jenesis-version on a fresh directory: exit 1, reports missing build/jenesis
+echo "[1/9] jenesis-version on fresh directory"
 set +e
 OUT="$("${SDK_HOME}/bin/jenesis-version" "$PROJ" 2>&1)"
 RC=$?
@@ -53,8 +53,8 @@ printf '%s' "$OUT" | grep -qF "sdk is at version ${VERSION}" || dump_and_fail "m
 printf '%s' "$OUT" | grep -qF "no build/jenesis found" || dump_and_fail "missing 'no build/jenesis found' line" "$OUT"
 echo "  ok"
 
-# [2/8] jenesis-init: populates build/jenesis and writes jenesis.version
-echo "[2/8] jenesis-init"
+# [2/9] jenesis-init: populates build/jenesis and writes jenesis.version
+echo "[2/9] jenesis-init"
 "${SDK_HOME}/bin/jenesis-init" "$PROJ" >/dev/null
 [ -d "$PROJ/build/jenesis" ] || dump_and_fail "build/jenesis not created"
 [ -f "$PROJ/build/jenesis/jenesis.version" ] || dump_and_fail "jenesis.version not written"
@@ -62,8 +62,8 @@ RECORDED="$(cat "$PROJ/build/jenesis/jenesis.version")"
 [ "$RECORDED" = "$VERSION" ] || dump_and_fail "jenesis.version was '$RECORDED', expected '$VERSION'"
 echo "  ok"
 
-# [3/8] jenesis-version on initialised project: exit 0, reports matching version
-echo "[3/8] jenesis-version on initialised project"
+# [3/9] jenesis-version on initialised project: exit 0, reports matching version
+echo "[3/9] jenesis-version on initialised project"
 set +e
 OUT="$("${SDK_HOME}/bin/jenesis-version" "$PROJ" 2>&1)"
 RC=$?
@@ -72,45 +72,57 @@ set -e
 printf '%s' "$OUT" | grep -qF "build/jenesis is at version ${VERSION}" || dump_and_fail "missing matching-version line" "$OUT"
 echo "  ok"
 
-# [4/8] jenesis-validate: reports zero drift against the bundled sources
-echo "[4/8] jenesis-validate"
+# [4/9] jenesis-validate: reports zero drift against the bundled sources
+echo "[4/9] jenesis-validate"
 OUT="$("${SDK_HOME}/bin/jenesis-validate" "$PROJ" 2>&1)"
 printf '%s' "$OUT" | grep -qF "0 differs, 0 missing, 0 additional" || dump_and_fail "drift reported against bundled sources" "$OUT"
 echo "  ok"
 
-# [5/8] jenesis: the launcher resolves the engine from the SDK and dispatches to it;
+# [5/9] jenesis: the launcher resolves the engine from the SDK and dispatches to it;
 # `help` is a print-only goal, so it runs offline once a project descriptor exists.
-echo "[5/8] jenesis help"
+echo "[5/9] jenesis help"
 mkdir -p "$PROJ/sources"
 printf 'module sdktest {}\n' > "$PROJ/sources/module-info.java"
 OUT="$(cd "$PROJ" && "${SDK_HOME}/bin/jenesis" help 2>&1)" || dump_and_fail "jenesis help exited non-zero" "$OUT"
 printf '%s' "$OUT" | grep -qF "a Java build tool" || dump_and_fail "jenesis help did not print the usage banner" "$OUT"
 echo "  ok"
 
-# [6/8] jenesis: a project stamped with the SDK's own version dispatches to jenesis-run
-echo "[6/8] jenesis on a matching stamp"
+# [6/9] jenesis: a project stamped with the SDK's own version dispatches to jenesis-run
+echo "[6/9] jenesis on a matching stamp"
 OUT="$(cd "$PROJ" && "${SDK_HOME}/bin/jenesis" help 2>&1)" || dump_and_fail "jenesis help exited non-zero" "$OUT"
 printf '%s' "$OUT" | grep -qF "a Java build tool" || dump_and_fail "matching stamp did not run the installed version" "$OUT"
 OUT="$(cd "$PROJ" && "${SDK_HOME}/bin/jenesis-run" help 2>&1)" || dump_and_fail "jenesis-run help exited non-zero" "$OUT"
 printf '%s' "$OUT" | grep -qF "a Java build tool" || dump_and_fail "jenesis-run did not print the usage banner" "$OUT"
 echo "  ok"
 
-# [7/8] jenesis: a stamp naming a version that is not installed fails, naming both fixes
-echo "[7/8] jenesis on an uninstalled stamp"
+# [7/9] jenesis: a stamp naming a version that is not installed fails, naming both fixes
+echo "[7/9] jenesis refuses an engine the vendored sources do not match"
+PATCHED="$TMPDIR/patched"
+cp -r "$PROJ" "$PATCHED"
+echo "// local patch" >> "$PATCHED/build/jenesis/Platform.java"
+set +e
+OUT="$(cd "$PATCHED" && "${SDK_HOME}/bin/jenesis" help 2>&1)"
+RC=$?
+set -e
+[ "$RC" = "0" ] || dump_and_fail "expected the fallback to still build, got $RC" "$OUT"
+printf '%s' "$OUT" | grep -qF "does not match the sources" || dump_and_fail "a patched tree still used the installed engine" "$OUT"
+echo "  ok"
+
+# [8/9] jenesis: a stamp naming a version that is not installed falls back to the vendored sources
+echo "[8/9] jenesis on an uninstalled stamp"
 UNSTAMPED="$TMPDIR/unstamped"
-mkdir -p "$UNSTAMPED/build/jenesis"
+cp -r "$PROJ" "$UNSTAMPED"
 printf '0.0.0-ABSENT' > "$UNSTAMPED/build/jenesis/jenesis.version"
 set +e
 OUT="$(cd "$UNSTAMPED" && SDKMAN_DIR="$TMPDIR/no-sdkman" PATH="/usr/bin:/bin" "${SDK_HOME}/bin/jenesis" help 2>&1)"
 RC=$?
 set -e
-[ "$RC" != "0" ] || dump_and_fail "expected a non-zero exit for an uninstalled version" "$OUT"
-printf '%s' "$OUT" | grep -qF "0.0.0-ABSENT" || dump_and_fail "error did not name the requested version" "$OUT"
-printf '%s' "$OUT" | grep -qF "jenesis-run" || dump_and_fail "error did not name the jenesis-run fallback" "$OUT"
+[ "$RC" = "0" ] || dump_and_fail "expected the fallback to build from the vendored sources, got $RC" "$OUT"
+printf '%s' "$OUT" | grep -qF "no installed Jenesis matches" || dump_and_fail "did not fall back to the vendored sources" "$OUT"
 echo "  ok"
 
-# [8/8] jenesis: a broken or absent SDKMAN degrades to the error, it never aborts the script
-echo "[8/8] jenesis with a broken SDKMAN"
+# [9/9] jenesis: a broken SDKMAN never aborts the launcher, it reaches the same fallback
+echo "[9/9] jenesis with a broken SDKMAN"
 BROKEN="$TMPDIR/broken-sdkman/bin"
 mkdir -p "$BROKEN"
 printf 'set -eu\nexit 1\n' > "$BROKEN/sdkman-init.sh"
@@ -118,8 +130,8 @@ set +e
 OUT="$(cd "$UNSTAMPED" && SDKMAN_DIR="$TMPDIR/broken-sdkman" PATH="/usr/bin:/bin" "${SDK_HOME}/bin/jenesis" help 2>&1)"
 RC=$?
 set -e
-[ "$RC" = "1" ] || dump_and_fail "expected exit 1 from a broken SDKMAN, got $RC" "$OUT"
-printf '%s' "$OUT" | grep -qF "which is not installed" || dump_and_fail "broken SDKMAN did not reach the error" "$OUT"
+[ "$RC" = "0" ] || dump_and_fail "a broken SDKMAN did not reach the fallback, got $RC" "$OUT"
+printf '%s' "$OUT" | grep -qF "no installed Jenesis matches" || dump_and_fail "broken SDKMAN did not reach the fallback" "$OUT"
 echo "  ok"
 
 echo "sdk-tests: all checks passed"


### PR DESCRIPTION
`jenesis` chose a compiled engine from `build/jenesis/jenesis.version` alone. That version is a claim: a stale
or hand-edited stamp pointed the launcher at an engine the vendored sources do not describe, and a locally
patched `build/jenesis` was ignored outright.

The launcher now digests the vendored `*.java` and the sources the target installation ships, and runs the
compiled engine only when the two agree. Every other outcome - a mismatch, a version it cannot locate, a
sources jar it cannot read, a digest it cannot compute - builds from the vendored sources, so what runs
always matches what the project carries.

Measured on the real tree (162 files, 1.9MB): hashing it is 6ms in one process, extracting and hashing the
reference jar 19ms, and the whole verified dispatch 40ms - against the ~9s the compiled engine saves over
source mode. Per-file hashing, the way `jenesis-validate` does it, would have been 109ms, so the digest is
computed in a single process.

`test.sh` covers it (9 checks, passing locally): a patched tree is refused, an uninstalled version falls back,
and a broken SDKMAN reaches the same fallback rather than aborting.

**This PR is opened for the Windows leg.** The POSIX launcher is verified locally; `jenesis.bat` and its two
new checks in `test.bat` have never been executed - there is no Windows shell on the machine they were written
on. The batch script is written to fail safe: any step of the verification that does not complete falls
through to source mode, so a bug there can cost speed but cannot run an unverified engine.